### PR TITLE
test(soql): establish UI migration baselines - W-23928676

### DIFF
--- a/docs/superpowers/plans/2026-08-19-soql-builder-lit-migration.md
+++ b/docs/superpowers/plans/2026-08-19-soql-builder-lit-migration.md
@@ -1,0 +1,579 @@
+# SOQL Builder and Query Results Lit Migration Plan
+
+> **Status:** Proposed. A working vertical-slice spike exists on `feature/soql-builder-lit-spike` and remains opt-in behind `salesforcedx-vscode-soql.experimental.useLitSpike`.
+
+**Goal:** Replace the LWC-based SOQL Builder and the vanilla JavaScript query-results shell with Lit applications using `@vscode-elements/elements` and a browser-safe Effect state/action layer, while retaining the Tabulator results grid and preserving extension-host protocols, SOQL model behavior, saved webview state, exports, telemetry, accessibility, and desktop/web-extension support.
+
+**Recommendation:** Proceed with Lit for both webviews. Keep the builder application in the private `@salesforce/soql-builder-ui` workspace package introduced by the spike, and implement query results as a separately bundled, extension-owned Lit entry because its lifecycle and save actions are specific to the VS Code webview. Both applications should use VSCode Elements and the same VS Code theme-token strategy.
+
+## Scope
+
+In scope:
+
+- The visual SOQL Builder under `packages/salesforcedx-vscode-soql/src/soql-builder-ui`.
+- The framework-driven application package under `packages/soql-builder-ui`.
+- All current builder features: From, Fields, Where, Order By, Limit, All Rows, query preview, notifications, Run Query, and Get Query Plan.
+- The query-results webview under `packages/salesforcedx-vscode-soql/src/soql-data-view` and its extension host under `src/queryDataView`.
+- All current results features: document title, returned/total record count, max-row guidance, flattened relationship columns, grouped headers, local pagination, column sizing, scrolling, saved webview state, and CSV/JSON exports.
+- LWC build, dependency, test, lint, and template removal after feature parity.
+- Plain JavaScript results-controller removal and Tabulator restyling around VS Code theme tokens after results parity.
+- A production-quality Lit test strategy and accessible VS Code-native styling.
+
+Out of scope:
+
+- Changes to SOQL execution, query-plan execution, metadata retrieval, query-result flattening, CSV/JSON file formats, or extension-host/webview message contracts unless a proven incompatibility requires one.
+- A second metadata discovery, caching, or invalidation implementation in either webview. The extension-side catalog-backed `MetadataDescribeService` merged in PR #7918 remains the metadata authority.
+- A bundler migration. Keep Rollup until the Lit cutover is complete.
+- Publishing the new package to the npm registry. `@salesforce/soql-builder-ui` must remain a private workspace package and be excluded from publication jobs.
+
+## Spike Results
+
+The spike validates the critical framework boundary:
+
+- A Lit root component runs in the real VS Code webview.
+- The Lit root and its public host contract compile as the independent `@salesforce/soql-builder-ui` workspace package. The production plan changes the spike manifest to private before cutover.
+- The UI package contains no VS Code API, extension-owned service, or extension-message imports. The production migration deliberately adds browser-safe Effect state, action, error, stream, and lifecycle primitives to the package.
+- The extension consumes the package through a VS Code/Effect host adapter.
+- `vscode-single-select` and `vscode-multi-select` receive real org metadata and follow VS Code theme variables.
+- `ToolingSDK`, `ToolingModelService`, `VscodeMessageServiceLive`, saved state, and document synchronization work unchanged.
+- A Chromium smoke test selects Account, Id, and Name and verifies the production model emits `SELECT Id, Name FROM Account`.
+- Consuming the independent package produces an 826,612-byte minified spike bundle (209,675 bytes gzip), compared with the current 880,931-byte LWC bundle (230,171 bytes gzip). This is directional only because the spike implements fewer features.
+
+Important findings:
+
+- Reactive TypeScript fields must use Lit's `declare` plus constructor initialization pattern; emitted class fields shadow Lit accessors.
+- Babel must enable `allowDeclareFields` for the Lit entry.
+- VSCode Elements uses nested shadow roots, so browser tests should favor roles and public control APIs; targeted shadow-root traversal is acceptable in low-level component verification.
+- The query-results webview is not LWC. It is static HTML/CSS plus an untyped JavaScript controller using Tabulator 4.8.1 and direct `acquireVsCodeApi()` calls.
+- Retain Tabulator for its local pagination, sorting, grouped headers, column sizing, and scrolling. `vscode-table` is not a drop-in replacement because it does not provide all of those behaviors.
+- VSCode Elements styles are encapsulated in component shadow roots and cannot be applied directly to Tabulator. The Lit results shell should use VSCode Elements controls, while Tabulator is themed separately with the same public `--vscode-*` tokens, spacing, borders, focus treatment, and typography.
+- The independent UI package and host contract are type-checked. The legacy builder service graph and thin VS Code adapter are still bundled through Babel type erasure and excluded from the extension package TypeScript compile. A full migration should make the remaining adapter boundary type-checkable rather than carrying this debt forward indefinitely.
+- PR #7918 changed the extension host to obtain object metadata through the shared, catalog-backed `MetadataDescribeService`, normalize raw describes through `TransmogrifierService.toMinimalSObject`, and send the resulting minimal `SObject` across the existing webview message boundary.
+- The current builder-side `SObjectMetadata` type is a JSforce-derived structural subset. Although the normalized `SObject` is compatible with current consumers, the production UI package should own and decode a browser-safe metadata DTO/Effect Schema rather than importing JSforce or `salesforcedx-vscode-services` types.
+- The persistent extension `getSoqlRuntime()` and the managed browser runtime serve different execution contexts. The extension runtime owns catalog-backed metadata acquisition; the webview runtime owns UI state and actions. They communicate only through the existing messages and are not combined or duplicated.
+- The existing LWC Jest suite has baseline failures and an engine/compiler version warning. Establishing a trustworthy parity baseline is an early migration task.
+
+## Target Architecture
+
+```text
+SOQLEditorInstance (extension host)
+  ├─ persistent getSoqlRuntime()
+  └─ MetadataDescribeService → TransmogrifierService
+              ↓ normalized browser-safe metadata DTO
+              ↕ existing messages
+VscodeMessageService / ToolingSDK / ToolingModelService
+              ↓
+VscodeSoqlBuilderDriver (extension-owned Effect layer)
+              ↓ public Effect driver contract
+@salesforce/soql-builder-ui (browser-safe private workspace package)
+  ├─ one managed Effect runtime and scoped application controller
+  ├─ Effect-native state stream, typed actions, and typed UI errors
+  ├─ Lit root application
+  │   ├─ application shell and notifications
+  │   ├─ From and Fields controls
+  │   ├─ Where editor
+  │   ├─ Order By editor
+  │   ├─ Limit and All Rows controls
+  │   └─ query preview and actions
+  └─ @vscode-elements/elements + semantic HTML
+
+QueryDataViewService (extension host)
+              ↕ existing activate/update/save_records messages
+VscodeQueryResultsDriver (extension-owned Effect layer)
+              ↓ typed state and actions
+QueryResultsApp (extension-owned Lit entry)
+  ├─ one managed Effect runtime and scoped QueryResultsDriver
+  ├─ results header, record count, and max-row guidance
+  ├─ Lit-managed Tabulator results-grid wrapper
+  ├─ CSV and JSON actions
+  └─ @vscode-elements/elements + semantic HTML
+```
+
+Keep business and protocol behavior in framework-neutral Effect services and driver layers. Lit components should render immutable state and dispatch typed actions through one composition-root-owned Effect runtime per webview; they should not create component-local runtimes or duplicate SOQL conversion, result flattening, export behavior, or extension messaging logic. Both applications must be bundled into the VSIX rather than loading application code remotely.
+
+## Proposed File Structure
+
+```text
+packages/soql-builder-ui/
+  src/
+    index.ts                    # public npm entry and custom-element registration
+    contracts.ts                # browser-safe Effect driver/state/action/error contracts
+    metadata.ts                 # browser-safe metadata DTO and Effect Schema
+    controller.ts               # Effect state transitions and action orchestration
+    runtime.ts                  # one scoped browser runtime per mounted application
+    soqlBuilderApp.ts           # Lit root
+    components/
+      appHeader.ts
+      fromFields.ts
+      whereEditor.ts
+      whereCondition.ts
+      orderByEditor.ts
+      queryOptions.ts
+      queryPreview.ts
+      notificationPanel.ts
+    styles/
+      layout.ts
+      shared.ts
+
+packages/salesforcedx-vscode-soql/src/soql-builder-ui/
+  lit/
+    index.ts                     # webview composition root
+    vscodeSoqlBuilderDriver.ts   # VS Code Effect layer using existing services/messages
+  modules/querybuilder/services/ # retained initially
+  index.html                     # points to Lit after cutover
+
+packages/salesforcedx-vscode-soql/src/soql-data-view/
+  index.html                     # minimal query-results Lit mount point
+  lit/
+    index.ts                     # results webview composition root
+    queryResultsApp.ts           # Lit root
+    queryResultsContracts.ts     # Effect-native state/action/error boundary
+    vscodeQueryResultsDriver.ts  # acquireVsCodeApi/message/state Effect layer
+    components/
+      resultsHeader.ts
+      resultsGrid.ts
+      resultsPagination.ts
+    styles.ts
+```
+
+Do not preserve the current LWC component boundaries mechanically. Group controls by cohesive user workflow and keep each root component focused on orchestration. The query-results UI remains extension-owned rather than expanding the public builder package.
+
+## Epic
+
+### Migrate the SOQL Builder and query-results webviews to Lit and VSCode Elements
+
+**Epic story:** As a Salesforce developer using SOQL Builder, I want the builder and query results to use a consistent, VS Code-native Lit interface so that I can compose, run, inspect, and export queries with the same behavior, accessibility, and reliability in desktop and web VS Code.
+
+**Business outcome:** Remove the SOQL Builder's LWC-specific runtime and the results view's untyped JavaScript shell while delivering a consistent Lit and VSCode Elements experience without changing Tabulator grid, query, results, or export behavior.
+
+**Starting point:** `feature/soql-builder-lit-spike` after merge commit `181aea40e`, which reconciles spike commits `8cacbe1fb` and `5e7f2ac5d` with `develop` commit `2326d1eff` from PR #7918. The spike and the shared org metadata catalog are accepted technical inputs to this epic, not work that must be repeated. They already provide:
+
+- the `@salesforce/soql-builder-ui` workspace package and browser-safe host contract;
+- a Lit root using `vscode-single-select` and `vscode-multi-select` for From, Fields, and query preview;
+- an extension-owned `VscodeSoqlBuilderHost` that reuses the current Effect services and message transport;
+- catalog-backed object discovery and describe caching in the extension host, plus normalized minimal `SObject` payloads across the existing metadata messages;
+- opt-in VS Code wiring behind `salesforcedx-vscode-soql.experimental.useLitSpike`;
+- compile, lint, package-contract, and Chromium smoke-test coverage for the vertical slice.
+
+### Success measures
+
+- Every supported builder and query-results workflow has an automated Lit parity check and passes on desktop and web extension targets.
+- Existing extension-host message types, saved-state shapes, document round-trip behavior, result payloads, exports, and telemetry fields remain compatible.
+- Builder metadata is acquired only through the extension-side `MetadataDescribeService` and `TransmogrifierService`; the UI accepts a validated browser DTO and introduces no competing org connection, cache, or invalidation path.
+- The Lit UI meets the accessibility, theme, performance, and bundle budgets established by Story 1.
+- No `@lwc/*` runtime, compiler, Jest preset, lint dependency, template, custom-select implementation, or LWC-only Rollup workaround remains after cutover.
+- No untyped query-results controller or results-specific hard-coded color palette remains after cutover; Tabulator is isolated behind a typed Lit wrapper and themed with VS Code tokens.
+- `@salesforce/soql-builder-ui` remains browser-safe and independently type-checked, with `"private": true` preventing repository publication jobs from publishing it.
+
+### Delivery constraints
+
+- Keep the legacy builder and results entries available while their Lit replacements are under parity testing; make Lit the default only in the cutover story.
+- Keep Rollup for the migration; a bundler change is a separate effort.
+- Keep `@salesforce/soql-builder-ui` private. Its `package.json` must contain `"private": true`, must not advertise public publication, and must be skipped by repository release/publish automation.
+- Reuse `ToolingModelService`, `ToolingSDK`, SOQL model converters, `extendQueryData`, `QueryDataFileService`, and current extension messages unless a story identifies and documents an incompatibility.
+- Treat the extension-side `MetadataDescribeService` and its catalog integration as the sole builder metadata authority. Normalize raw describes with `TransmogrifierService`, then validate/map the message payload to a browser-safe UI contract; do not import JSforce or `salesforcedx-vscode-services` into `@salesforce/soql-builder-ui`.
+- Keep the persistent extension `getSoqlRuntime()` separate from the browser runtime. Metadata API calls, catalog caching, invalidation, and org identity remain in the extension context; UI state/action fibers remain in the webview context.
+- Keep VS Code-specific APIs, extension-owned Effect services, and transport types outside `@salesforce/soql-builder-ui`. Browser-safe Effect services, streams, typed errors, scopes, and action types belong in the UI package.
+- Create exactly one managed Effect runtime per mounted webview application. The composition root owns it, Lit connection starts scoped subscriptions, and disconnection interrupts fibers and disposes the runtime and all acquired resources.
+- Model UI intent as typed actions returning `Effect` values and expose immutable state as an Effect stream. Do not scatter `Effect.runPromise`/`Effect.runFork` calls across presentation components or use unowned daemon fibers.
+- Use VSCode Elements where it provides the control (`vscode-button`, `vscode-button-group`, `vscode-checkbox`, `vscode-icon`, `vscode-label`, `vscode-multi-select`, `vscode-option`, `vscode-progress-ring` or `vscode-progress-bar`, `vscode-single-select`, and `vscode-textfield`) and semantic HTML where it does not. Retain Tabulator as the query-results grid and theme it with public VS Code CSS variables.
+
+## User Story Backlog
+
+Stories are ordered by dependency. Relative sizes are planning guidance and should be re-estimated by the delivery team after Story 1.
+
+### Story 1 — Establish builder and query-results parity baselines and migration gates
+
+**Type / size:** Enabler / M
+
+**Story:** As a maintainer, I want a repeatable record of current builder and query-results behavior and quality thresholds so that framework migration regressions are distinguishable from existing failures.
+
+**Acceptance criteria:**
+
+- The builder baseline covers initial load, saved-state restoration, external text changes, From, Fields, `COUNT()`, select all, clear all, Where, Order By, Limit, All Rows, query preview, missing default org, recoverable errors, unsupported queries, syntax errors, notification dismissal, Run Query, Get Query Plan, and builder/text-editor toggling.
+- The results baseline covers activation/update messages, restored state after tab changes, document title, returned/total counts, max-row guidance, empty results, flattened and relationship fields, grouped headers, header sorting, local pagination at the current 50-row page size, column resizing, horizontal/vertical scrolling, narrow layouts, CSV/JSON actions, and desktop/web save flows.
+- Existing LWC Jest failures and engine/compiler warnings are either fixed or recorded with test names, reproduction commands, and an explicit quarantine owner; quality gates are not disabled.
+- Light, dark, high-contrast, and high-contrast-light reference screenshots are captured for representative builder and results states.
+- Raw and gzip bundle sizes, first-render time, and interaction behavior are measured for a large object with thousands of fields and for small, 50-row, 51-row, wide, deeply related, and maximum-configured result sets using documented, repeatable commands.
+- The baseline records the Effect contribution to each browser bundle, verifies that each mounted webview creates only one managed Effect runtime, and defines acceptable fiber/resource counts across repeated hide, restore, and dispose cycles.
+- Metadata baselines cover the normalized minimal `SObject` payload, catalog cache reuse, default-org changes, invalidation after relevant metadata changes, stale-response rejection, missing-org behavior, and the number of extension-side list/describe requests for repeated UI actions.
+- A role/label-based Playwright selector contract is documented; framework-internal selectors are limited to low-level control tests.
+- Desktop and web release-gate commands and the agreed accessibility, performance, and bundle thresholds are recorded before feature migration begins.
+
+### Story 2 — Promote the Lit spike to a production foundation
+
+**Type / size:** Enabler / M
+
+**Story:** As a maintainer, I want the spike's Lit application, Effect runtime, and driver to become supported production code so that feature stories build on stable lifecycle, packaging, and type-checking boundaries.
+
+**Acceptance criteria:**
+
+- `litSpike` and spike-only names, copy, banner content, and file paths are replaced with the intended production `lit` composition root without changing the LWC default.
+- The browser-safe UI package depends directly on `effect` and defines the shared typed state, action, error, stream, and scoped-lifecycle primitives used by the Lit application and its drivers.
+- The webview composition root creates exactly one `ManagedRuntime` for the mounted application; Lit connection starts scoped subscriptions and disconnection interrupts fibers, runs finalizers, and disposes the runtime without leaking listeners across reloads.
+- The extension-owned adapter and retained framework-neutral services are included in a repository TypeScript project and pass compile and lint without blanket diagnostics suppression.
+- `@salesforce/soql-builder-ui` has no imports from VS Code, extension-owned services, or extension message modules. Its Effect imports use browser-compatible entry points and remain independently bundleable for VS Code webviews and test/browser drivers.
+- The UI package owns a browser-safe object/field DTO and Effect Schema for inbound metadata. It has no JSforce or `salesforcedx-vscode-services` dependency, and invalid metadata becomes a typed driver error rather than unvalidated component state.
+- Presentation components do not create runtimes, call global `Effect.runPromise`/`Effect.runFork`, or start unowned daemon fibers; the composition root and controller own Effect execution.
+- `packages/soql-builder-ui/package.json` contains `"private": true`; public `publishConfig` and unnecessary independent-publication metadata from the spike are removed, and the repository's package-selection/release tooling verifies that publication jobs skip the package.
+- The CSP and Rollup outputs bundle all application code into the VSIX; no runtime code is loaded remotely.
+- A deterministic fake Effect driver layer used by UI tests is updated when the public contract changes.
+
+**Depends on:** Story 1.
+
+### Story 3 — Expand the Effect driver contract to cover the complete builder state and actions
+
+**Type / size:** Enabler / L
+
+**Story:** As a UI developer, I want a typed, browser-safe Effect driver contract for the full builder so that Lit components can render immutable state and dispatch actions without knowing about VS Code messages or extension-owned services.
+
+**Acceptance criteria:**
+
+- The public state represents the complete `ToolingModelJson` behavior needed by the UI: object metadata, selected fields, Where conditions and AND/OR, Order By entries, Limit, All Rows, original SOQL, parse errors, unsupported syntax, loading flags, missing-default-org state, and query/query-plan progress.
+- The driver exposes immutable builder state as an Effect `Stream` and accepts a discriminated union of typed UI actions whose execution returns `Effect<void, SoqlBuilderError>` or an equivalently typed Effect result.
+- The public actions cover object and field selection, select all, clear all, Where upsert/remove/AND-OR changes, Order By add/update/remove, Limit, All Rows, notification dismissal, setting a default org, running a query, and requesting a query plan.
+- `VscodeSoqlBuilderDriver` is an extension-owned Effect `Layer` that maps those actions to the existing services and preserves `ui_soql_changed`, `ui_telemetry`, metadata, connection, run-query, query-plan, and default-org message behavior.
+- Object discovery and describes remain extension-host operations executed through the persistent `getSoqlRuntime()`, catalog-backed `MetadataDescribeService`, and `TransmogrifierService.toMinimalSObject`; the browser driver does not open an org connection or implement another metadata cache.
+- The existing `sobjects_request`/`sobjects_response` and `sobject_metadata_request`/`sobject_metadata_response` message names remain compatible. The driver decodes normalized payloads at the boundary into the UI-owned browser DTO before publishing state.
+- The metadata contract covers every field attribute required by Fields, Where, and Order By—including name, type, nillability, picklist values, filtering/sorting capabilities, and relationship information—without exposing the services-owned `SObject` type to the UI package.
+- Request correlation or an equivalent selected-object guard prevents a late describe response from a prior object or org from replacing current metadata; connection changes clear incompatible state and reload through the extension authority.
+- A browser/test driver implements the same Effect service contract without VS Code APIs, message types, or extension-owned Effect services.
+- Saved state and an external `text_soql_changed` event repopulate every supported Lit control without emitting a duplicate document update.
+- Changing the selected object preserves header comments and resets dependent model state exactly as the current `ToolingModelService` does.
+- Contract tests exercise immutable state publication, typed error propagation, initialization, cancellation, disposal/finalization, and each action mapping using deterministic Effect layers.
+
+**Depends on:** Story 2.
+
+### Story 4 — Add a production Lit browser test harness
+
+**Type / size:** Enabler / M
+
+**Story:** As a maintainer, I want browser-based component and integration tests for Lit and VSCode Elements so that behavior relying on shadow DOM, popovers, and `ElementInternals` is tested in a real browser.
+
+**Acceptance criteria:**
+
+- A repository-owned test command runs Lit component tests in Chromium and is part of the relevant package test workflow.
+- Tests mount components with deterministic fake `SoqlBuilderDriver` and `QueryResultsDriver` layers and can drive state changes and assert actions without `acquireVsCodeApi()` emulation.
+- Fake builder and results drivers are provided as Effect layers with deterministic state streams, typed failures, controllable latency, and test-clock support where timing affects behavior.
+- User-flow tests prefer accessible roles, names, labels, and public component APIs; any shadow-root traversal is isolated in documented helpers.
+- The harness includes keyboard navigation, focus movement, form association, disabled/loading state, alert/status announcement, and component cleanup coverage.
+- Lifecycle tests prove that reconnect/disconnect, action cancellation, and driver failure do not leave running fibers, duplicate subscriptions, or acquired resources.
+- The existing vertical-slice smoke test remains green or is replaced by equivalent coverage in the production harness.
+
+**Depends on:** Story 2. Can proceed in parallel with Story 3.
+
+### Story 5 — Migrate From selection
+
+**Type / size:** Feature / M
+
+**Story:** As a Salesforce developer, I want to search for and select an object in the Lit builder so that I can establish the query's `FROM` clause.
+
+**Acceptance criteria:**
+
+- From uses a labeled `vscode-single-select` with searchable object options and a loading state.
+- Empty, no-results, missing-default-org, invalid/recoverable From error, restored selection, and external-document update states match the accepted baseline.
+- Selecting an object resets the same dependent query state as LWC, requests that object's metadata once, and updates the document and preview through the existing model service.
+- Object options come from the extension-side catalog-backed metadata service through the existing messages; reopening or repeating the same request follows the established cache policy rather than creating a webview-local metadata source.
+- A default-org change clears object options and in-flight selection state before repopulating them for the new org, and a late response from the previous org is ignored.
+- Keyboard-only selection, visible focus, accessible labeling, large-list behavior, and theme rendering meet Story 1 gates.
+- Component, host-contract, and desktop/web parity tests cover the workflow.
+
+**Depends on:** Stories 3 and 4.
+
+### Story 6 — Migrate Fields selection
+
+**Type / size:** Feature / L
+
+**Story:** As a Salesforce developer, I want to search, select, and remove fields in the Lit builder so that I can define the query's `SELECT` clause efficiently.
+
+**Acceptance criteria:**
+
+- Fields uses a labeled `vscode-multi-select`, is disabled until an object is selected, and exposes loading, empty, no-results, and recoverable field-error states.
+- Individual add/remove, Select All, Clear All, restored selection, and external-document updates match LWC behavior.
+- `COUNT()` remains mutually exclusive with ordinary fields and round-trips through the model and text document.
+- Selections remain valid while metadata is refreshed for the same object, and stale metadata from a previous object is not displayed.
+- Field metadata is decoded from the normalized browser DTO, including type, nillability, picklists, filter/sort capabilities, and relationships needed by downstream editors; invalid payloads enter the typed recoverable-error state.
+- Repeated field loads reuse the extension catalog/describe cache, while relevant metadata invalidation and org changes refresh through the extension authority without a second UI cache.
+- Thousands of fields remain searchable and responsive within the Story 1 budget.
+- Component, host-contract, and desktop/web parity tests cover the workflow.
+
+**Depends on:** Stories 3–5.
+
+### Story 7 — Migrate Limit and All Rows
+
+**Type / size:** Feature / S
+
+**Story:** As a Salesforce developer, I want to set a row limit and include deleted or archived records so that I can control the query result scope.
+
+**Acceptance criteria:**
+
+- Limit uses a labeled `vscode-textfield` with numeric input behavior and preserves empty, valid, invalid, recoverable-error, restored, blur/change, and external-update semantics.
+- All Rows uses `vscode-checkbox`, restores its checked state, and adds or removes `ALL ROWS` without altering other clauses.
+- Both controls update the query preview, document, saved state, and telemetry through the existing model path.
+- Keyboard, focus, accessible error association, and theme tests pass.
+
+**Depends on:** Stories 3 and 4.
+
+### Story 8 — Migrate query actions and progress states
+
+**Type / size:** Feature / M
+
+**Story:** As a Salesforce developer, I want to run the current query or request its query plan from the Lit builder so that I can act on the query without switching views.
+
+**Acceptance criteria:**
+
+- Run Query and Get Query Plan use `vscode-button` and are disabled when the query lacks an object or fields, when no default org is available, or when the same action is already running.
+- Starting an action sends the existing `run_query` or `get_query_plan` message exactly once and exposes accessible progress text plus a VSCode Elements progress indicator where appropriate.
+- `run_query_done` and `get_query_plan_done` independently clear the correct progress state and restore button labels and availability.
+- The results webview and query-plan output behavior remain extension-host concerns and match current end-to-end behavior.
+- Existing telemetry payload names and values are unchanged.
+- Component, adapter, desktop, and web tests cover valid, invalid, running, completed, and repeated-click states.
+
+**Depends on:** Stories 3 and 4.
+
+### Story 9 — Migrate notifications and query preview
+
+**Type / size:** Feature / M
+
+**Story:** As a Salesforce developer, I want clear feedback about org and query problems plus a live query preview so that I understand what the builder will run or rewrite.
+
+**Acceptance criteria:**
+
+- The preview renders the model's original SOQL, preserves whitespace/wrapping behavior, updates live, and is announced without excessive screen-reader chatter.
+- Missing-default-org guidance blocks the form and offers the existing Set a Default Org action.
+- Recoverable From, Fields, and Limit errors remain associated with their controls without unnecessarily blocking the full builder.
+- Unsupported syntax and unrecoverable syntax errors display the accepted title, guidance, and ordered messages and block editing until Edit Query Anyway is chosen.
+- Edit Query Anyway dismisses the blocking notification and clearly communicates that unsupported or invalid syntax can be rewritten.
+- Notifications use semantic alert/status behavior, support keyboard interaction and visible focus, and render correctly in all supported themes.
+- Telemetry for errors and unsupported reasons is preserved without duplicate emission.
+
+**Depends on:** Stories 3 and 4.
+
+### Story 10 — Migrate the Where editor
+
+**Type / size:** Feature / L
+
+**Story:** As a Salesforce developer, I want to add and edit typed filter conditions in the Lit builder so that I can create valid `WHERE` clauses without writing SOQL manually.
+
+**Acceptance criteria:**
+
+- A Lit `whereEditor` manages repeatable `whereCondition` rows with labeled `vscode-single-select` field/operator controls, a `vscode-textfield` value control, VSCode Elements buttons, and accessible remove actions.
+- An empty query shows one incomplete row; Add is enabled only when the last row is complete and valid; remove and reindex behavior matches the model service.
+- AND/OR selection is restored and only updates a complete multi-condition expression.
+- Operators `=`, `!=`, `<`, `<=`, `>`, `>=`, `IN`, `NOT IN`, `INCLUDES`, `EXCLUDES`, `LIKE`, starts with, ends with, and contains preserve their current model mappings.
+- Validation, normalization, display conversion, string escaping, wildcard handling, multiple values, `null`, nillability, and picklist values reuse the existing SOQL model/utilities rather than being reimplemented in presentation components.
+- Boolean, integer, long, double, currency, percent, date, date-time, time, string, picklist, multi-picklist, and fallback field behavior have focused tests, including invalid values and operators.
+- Restored and externally edited queries repopulate every row; debounced input cannot publish stale state after a field/operator change or component removal.
+- Keyboard-only creation, removal, error discovery, and predictable focus placement pass accessibility tests.
+
+**Depends on:** Stories 3, 4, and 6.
+
+### Story 11 — Migrate Order By
+
+**Type / size:** Feature / M
+
+**Story:** As a Salesforce developer, I want to add, update, and remove sort fields in the Lit builder so that I can control record ordering.
+
+**Acceptance criteria:**
+
+- Field, direction, and null ordering use labeled VSCode Elements controls and expose loading and no-results states.
+- Adding a new field, updating an existing field, selecting ascending/descending and nulls first/last, and removing an entry preserve existing model semantics.
+- Multiple entries restore from saved state and external text, maintain their order, and round-trip through the document without duplication.
+- Add is disabled until the row is valid, and remove controls have accessible names, keyboard behavior, visible focus, and deterministic post-remove focus.
+- Component, adapter, and desktop/web parity tests cover add, update, remove, restore, and multi-entry scenarios.
+
+**Depends on:** Stories 3, 4, and 6.
+
+### Story 12 — Migrate the query-results shell and Effect driver boundary to Lit
+
+**Type / size:** Feature / L
+
+**Story:** As a Salesforce developer, I want query results presented in a VS Code-native Lit shell backed by an Effect driver so that inspecting and exporting records feels consistent with the Lit builder and remains reliable across webview lifecycle changes.
+
+**Acceptance criteria:**
+
+- An extension-owned, type-checked `QueryResultsApp` replaces the Lit path's static DOM manipulation and is emitted as a separate bundled webview entry under the existing CSP.
+- A typed `QueryResultsDriver` exposes immutable result state as an Effect `Stream` and CSV/JSON save actions as typed Effect operations; `acquireVsCodeApi()`, window message listeners, `getState`, `setState`, and `postMessage` are isolated in the extension-owned `VscodeQueryResultsDriver` layer rather than presentation components.
+- The results composition root owns exactly one managed Effect runtime. Mount starts scoped message/state subscriptions, and unmount interrupts them and runs finalizers without component-local runners or unowned fibers.
+- The driver preserves the existing `activate`, `update`, and `save_records` messages, including `csv`/`json` format values and extension-host OpenTelemetry spans.
+- State represents the document title, returned count, total count, max-row guidance, flattened fields/rows, and any empty/error state required by the UI without duplicating `extendQueryData` or export logic.
+- The title, returned/total summary, and max-row guidance match current behavior; guidance is keyboard and screen-reader accessible rather than hover-only.
+- Save as CSV and Save as JSON use `vscode-button` or `vscode-button-group` with accessible names and optional `vscode-icon`, and continue to invoke `QueryDataFileService` through the host.
+- Saved webview state restores immediately after context recreation, the activation response can refresh it, and initialization, cancellation, failure, and disposal do not duplicate message or resize listeners or leave running fibers.
+- The legacy results entry remains available during parity testing, while the Lit entry has component and driver tests with a deterministic fake Effect layer.
+- Component and driver tests use a deterministic fake Effect layer to cover initial state, updates, export success/failure, cancellation, reconnection, and disposal.
+- A repository-owned `test:query-results-ui` command or clearly named equivalent runs the results component and driver tests in the package quality workflow.
+
+**Depends on:** Stories 1 and 4. Can proceed in parallel with builder Stories 5–11.
+
+### Story 13 — Wrap and theme the Tabulator results grid in Lit
+
+**Type / size:** Feature / XL
+
+**Story:** As a Salesforce developer, I want the existing results grid presented through a Lit component and styled consistently with VS Code so that pagination, sorting, grouped headers, and performance remain familiar while the surrounding webview is modernized.
+
+**Acceptance criteria:**
+
+- A Lit `resultsGrid` component owns a narrow, typed Tabulator adapter; the rest of the application does not reference the Tabulator global, DOM classes, or imperative API.
+- Tabulator acquisition is modeled as a scoped Effect resource: construction and listener/resize registration are paired with guaranteed destruction and cleanup through `Effect.acquireRelease` or an equivalent scoped finalizer.
+- The grid wrapper deliberately renders its Tabulator mount in a scoped light-DOM container so the retained base stylesheet and VS Code-token overrides apply; it does not assume document CSS can cross a Lit shadow root.
+- The component creates one grid instance after its mount element is available, updates data without unnecessary destruction/recreation, rebuilds only when the column schema requires it, and releases the Effect scope so the instance plus resize resources are destroyed when disconnected.
+- The adapter consumes `flattenedGrid.fields` and `flattenedGrid.rowData`; result flattening stays in the extension host.
+- Tabulator preserves the current 50-row local pagination, header sorting, grouped relationship headers, resizable/fit columns, and horizontal/vertical scrolling behavior.
+- Current pagination and sorting are keyboard operable and expose meaningful roles, labels, state, and sort direction. Accessibility gaps discovered in the baseline are fixed in the wrapper where feasible and documented if constrained by Tabulator.
+- Dotted relationship fields retain their grouped hierarchy, full accessible labels, and safe value rendering.
+- Empty, single-row, 50-row, 51-row, wide, deeply related, null-valued, and maximum-configured result sets render correctly, with no unsafe HTML interpolation of record values.
+- Small results avoid unnecessary empty gray space; large results remain within the Story 1 render, interaction, and memory budgets without relying on `retainContextWhenHidden` to hide a costly rebuild.
+- A dedicated Tabulator theme layer uses public `--vscode-*` variables for background, foreground, borders, hover/selection, focus, buttons, and typography so the grid visually aligns with adjacent VSCode Elements controls in light, dark, high-contrast, and high-contrast-light themes.
+- Tabulator overrides are scoped to the results component, minimize coupling to internal selectors, and are documented separately from reusable Lit/VSCode Elements styles.
+- Focused browser tests cover initialization, data/schema updates, pagination, sorting, resizing, scrolling, grouped relationship fields, theme tokens, restoration, and cleanup.
+
+**Depends on:** Story 12.
+
+### Story 14 — Migrate SOQL webview end-to-end tests to the Lit UI contracts
+
+**Type / size:** Quality / L
+
+**Story:** As a maintainer, I want builder and query-results end-to-end tests to interact with Lit through stable user-facing contracts so that the suite validates the new frameworks and styling without depending on legacy implementation details.
+
+**Acceptance criteria:**
+
+- The existing `soql-builder.spec.ts` flow can run against the opt-in Lit builder before cutover and covers object and field selection, Limit, Where, Order By, All Rows, live preview, save, Run Query, Get Query Plan, and builder/text-editor round-trip.
+- `soql-save-query-results.spec.ts` runs against Lit results and covers the record summary, grid headers/rows, saved-state restoration after tab switching, pagination for more than 50 rows, CSV export, JSON export, and desktop/web save flows.
+- Feature-level E2E selectors no longer depend on LWC custom-element names, `.query-preview-container`, `p.option[data-option-value]`, `[data-el-*]`, Tabulator classes, or results element IDs; they prefer roles, accessible names, labels, and public VSCode Elements APIs.
+- Any traversal required for VSCode Elements shadow roots or popovers is isolated in shared helpers with user-facing method names, rather than repeated in test scenarios.
+- Tests wait on observable UI or extension state instead of framework render timing, fixed delays, internal reactive fields, Lit lifecycle methods, or Tabulator callbacks.
+- Test setup can explicitly choose legacy or Lit entries for builder and results while both exist; Lit variants are required migration checks, and legacy variants are removed in Story 16.
+- Desktop and web suites exercise the same workflows, with runtime-specific setup isolated in fixtures.
+- E2E styling coverage captures representative builder and results states—including empty, populated, paginated, wide, loading/progress, error, blocking-notification, max-row guidance, and narrow layouts—in light, dark, high-contrast, and high-contrast-light themes.
+- Styling assertions focus on usable layout, visibility, scrolling, focus indication, control state, and resolved VS Code theme tokens; any pixel-diff snapshots have documented tolerances for platform and browser rendering.
+- Failure screenshots, console/network monitoring, and accessibility-oriented assertions remain enabled and produce enough state-specific artifacts to diagnose component, grid, or styling regressions.
+
+**Depends on:** Stories 4–13. Selector helpers and Lit opt-in plumbing may be introduced incrementally with the feature stories.
+
+### Story 15 — Harden both Lit webviews across supported environments
+
+**Type / size:** Quality / L
+
+**Story:** As a Salesforce developer, I want the Lit builder and results view to remain usable across themes, input methods, data sizes, and VS Code runtimes so that the migration does not reduce product quality.
+
+**Acceptance criteria:**
+
+- An accessibility audit covers landmarks, heading order, form and grid labels, descriptions and errors, alert/status behavior, table/header/cell relationships, pagination, tab order, visible focus, keyboard-only use, contrast, zoom, and accessible names for all icon-only actions.
+- Light, dark, high-contrast, and high-contrast-light screenshots are reviewed against the Story 1 baselines, using VS Code theme variables instead of Salesforce-specific hard-coded colors where a VS Code token exists.
+- Both layouts remain usable at narrow webview widths and supported zoom levels without hiding actions or causing avoidable two-dimensional scrolling; horizontal grid scrolling remains available when the result shape requires it.
+- Desktop and web Playwright suites cover the complete builder flow, restoration, external text updates, connection changes, query execution, results inspection/restoration, CSV/JSON export, and query-plan execution using Lit entries.
+- Large object/field lists, large and wide result sets, first render, tab restoration, memory behavior, and minified/gzip bundle sizes meet the Story 1 budgets or have an approved exception with measurements.
+- Repeated mount, hide/restore, driver failure, and disposal scenarios demonstrate one Effect runtime per webview, bounded fiber counts, interruption of obsolete work, and execution of all scoped finalizers.
+- Multi-org tests prove that catalog-backed object/field metadata is isolated by org, relevant invalidation reaches the builder, stale prior-org responses cannot update the Lit state, and the webview performs no direct metadata network request.
+- The UI package, builder adapter, and results entry/adapter pass compile, lint, unit/component tests, package checks, and CSP verification.
+
+**Depends on:** Stories 5–14.
+
+### Story 16 — Cut over both webviews and remove legacy UI assets
+
+**Type / size:** Release / L
+
+**Story:** As a maintainer, I want Lit to be the only SOQL Builder and query-results shell so that the extension no longer carries duplicate UI frameworks or an untyped legacy results controller.
+
+**Acceptance criteria:**
+
+- Lit becomes the default builder and query-results entry after Stories 1–15 pass their gates; experimental switches and spike-only HTML/bundle entries are removed.
+- LWC components and templates, `lwcUtils`, the custom select, LWC Jest setup/configuration, and migrated LWC tests are deleted.
+- `@lwc/*`, LWC lint packages, and LWC-only Rollup/Babel aliases, plugins, and compatibility workarounds are removed when no longer used by the SOQL package.
+- `queryDataViewController.js`, the save SVG if no longer needed, and obsolete results CSS/HTML scaffolding are removed. Tabulator runtime and base style assets remain packaged for the Lit wrapper.
+- Remaining framework-neutral services and tests are placed in production-owned locations with no stale `querybuilder` LWC module aliases; Tabulator-specific access is confined to the typed results-grid adapter and asset wiring.
+- JSforce-derived webview metadata aliases and duplicate metadata acquisition/cache code are removed. The final builder retains one browser DTO/Schema at the message boundary and the extension retains the catalog-backed metadata authority.
+- Transitional callback host facades, component-local Effect runners, and duplicate runtime wiring are removed; each production webview has one composition-root-owned managed runtime and Effect driver layer.
+- `retainContextWhenHidden` is retained only if measurements show it remains necessary for the Lit grid, with the reason documented; otherwise it is removed.
+- Contributor documentation, architecture notes, verification commands, screenshots, package metadata, and release notes describe both Lit webviews as the supported implementations.
+- The VSIX includes only production Lit assets plus the required Tabulator runtime/styles, desktop and web release gates pass, and a clean dependency/install/build verifies that no generated LWC artifact is masking a missing source.
+- The last legacy-default commit and rollback procedure for both webviews are recorded before merge.
+
+**Depends on:** Stories 1–15.
+
+## Recommended Delivery Slices
+
+1. Stories 1–4: parity gates, production builder/Effect foundation, full Effect driver contract, and browser test harness.
+2. Stories 5–7: From, Fields, Limit, and All Rows.
+3. Stories 8–9: actions, progress, notifications, and query preview.
+4. Story 10: Where editor as a dedicated high-risk pull request or short sequence of stacked pull requests.
+5. Story 11: Order By plus full query restoration coverage.
+6. Story 12: typed Lit query-results shell, Effect driver, state restoration, and export actions.
+7. Story 13: typed Lit Tabulator wrapper, VS Code-token styling, lifecycle, performance, and grid parity.
+8. Story 14: migrate desktop/web E2E workflows and styling coverage away from LWC and Tabulator DOM contracts.
+9. Story 15: cross-cutting accessibility, theme, performance, desktop, and web hardening.
+10. Story 16: cutover, legacy asset removal, documentation, and release rollback record.
+
+Builder and query-results work may proceed in parallel after Stories 1 and 4. Each slice keeps the corresponding legacy entry available until Story 16 and includes its own production tests. A slice is not accepted based only on the final end-to-end suite.
+
+## GitHub Stacked PR Delivery Strategy
+
+Use the repository's installed `github/gh-stack` extension with `develop` as the explicit trunk. Do not create one 16-story stack. Complete and land a short stack at each architectural or demonstrable-product boundary, then start the next stack from the updated `develop` branch. This limits cascading rebases, keeps each PR independently understandable, and allows builder and query-results work to proceed as separate stacks after their shared foundation lands.
+
+A user story is a planning outcome, not necessarily one PR. Large stories may span multiple stack layers, while a layer may combine only tightly coupled acceptance criteria that cannot be reviewed or verified meaningfully in isolation. Every layer must compile, preserve the legacy-default behavior until Story 16, and pass the quality gates relevant to its diff.
+
+| Stack | PR layers, bottom to top | Stories | Boundary or demo |
+| --- | --- | --- | --- |
+| 1. Baseline and production foundation | Baselines and migration gates; lift the private UI package and production/migration packaging without the example Node server; production naming plus scoped Effect runtime/lifecycle | 1–2 | Mergeable foundation with no default UI change |
+| 2. Effect driver and browser harness | Browser-safe state/action/error and metadata DTO/Schema contracts; VS Code driver plus catalog-backed metadata authority; deterministic browser harness and fake Effect layers | 3–4 | Stable contract and test boundary for all feature work |
+| 3. Builder core-controls demo | From; Fields; Limit and All Rows | 5–7 | First management-ready Lit builder demo |
+| 4. Builder actions and feedback | Run Query and Query Plan actions/progress; notifications and query preview | 8–9 | First end-to-end Lit builder demo using the legacy results view |
+| 5. Builder clauses | Where typed-value/operator foundation; repeatable Where rows, AND/OR, restoration, and cancellation; Order By | 10–11 | Complete builder feature parity before hardening |
+| 6. Lit query results | Results Effect shell, state restoration, and exports; Tabulator typed adapter and scoped lifecycle; VS Code-token theme, accessibility, and grid performance | 12–13 | Lit builder/results product demo; may run in parallel with Stacks 3–5 after Stack 2 lands |
+| 7. Release convergence | Lit-targeted E2E migration; cross-runtime hardening; default-entry and VSIX cutover; legacy UI removal, documentation, and rollback record | 14–16 | Release-ready Lit-only implementation |
+
+Operational rules:
+
+- Initialize each new stack non-interactively with an explicit trunk and bottom branch, for example `gh stack init --base develop <bottom-branch>`.
+- Add a named branch for each PR layer with `gh stack add <branch>`. Branch names should describe the review unit rather than only repeat the epic name.
+- Submit new PRs as drafts with `gh stack submit --auto`; mark a layer ready only after its own verification is green and its lower layers are reviewable.
+- Use `gh stack rebase` for cascading local rebases after lower-layer changes and `gh stack sync` to fetch, rebase, push, and synchronize PR bases/state. Never bypass repository hooks or quality gates during a stack rebase.
+- Keep each active stack to two through four PRs where practical. Split a large story such as Where, Tabulator, or cutover across cohesive layers rather than allowing a single review to absorb the entire story.
+- After a stack lands, run `gh stack sync --prune`, update local `develop`, and initialize the next stack from that new trunk. Do not extend a completed stack with the next delivery slice.
+- Builder and query-results stacks are independent siblings after Stack 2. Do not place results work above unfinished builder clauses merely to keep everything in one linear chain.
+- Story 14 starts only after the builder and results stacks it validates have landed. Story 16's cutover and cleanup layers remain adjacent in the same final stack so reviewers can evaluate the complete release transition.
+- Each PR body identifies its GUS story or story subset, the lower stack dependency, legacy/Lit artifact behavior, verification commands, and the demo increment it enables.
+
+## Verification Commands
+
+From the repository root:
+
+```bash
+npm run compile --workspace salesforcedx-vscode-services
+npm test --workspace salesforcedx-vscode-services
+npm run compile --workspace salesforcedx-vscode-soql
+npm run compile --workspace @salesforce/soql-builder-ui
+npm run lint --workspace @salesforce/soql-builder-ui
+npm test --workspace @salesforce/soql-builder-ui
+npm run lint --workspace salesforcedx-vscode-soql
+npm test --workspace salesforcedx-vscode-soql
+npm run test:soql-builder-ui --workspace salesforcedx-vscode-soql
+npm run test:query-results-ui --workspace salesforcedx-vscode-soql
+npm run test:ui-bundle-budgets --workspace salesforcedx-vscode-soql
+npm run test:lit-spike --workspace salesforcedx-vscode-soql
+npm run test:web --workspace salesforcedx-vscode-soql
+npm run test:desktop --workspace salesforcedx-vscode-soql
+```
+
+`test:soql-builder-ui` is the LWC parity command until Story 16. `test:query-results-ui` locks down the legacy results protocol until the Lit test variants are added. `test:ui-bundle-budgets` measures the builder, first-party results shell, and retained Tabulator assets independently. Story 2 or Story 4 should rename `test:lit-spike` to a production Lit component/integration test command, and Story 12 should extend the results command with the Lit entry. The last two E2E commands are release-gate checks; Story 14 makes the Lit-targeted builder and results variants mandatory, and they may require the repository's normal browser/desktop test environment. Detailed thresholds and capture procedures live in `packages/salesforcedx-vscode-soql/docs/soql-ui-migration-baseline.md`.
+
+## Definition of Done
+
+- Feature parity for all current SOQL Builder and query-results workflows.
+- Correct light, dark, high-contrast, and high-contrast-light rendering across both webviews.
+- Keyboard navigation, visible focus, form labels, alerts, grid semantics, pagination, and export actions meet VS Code accessibility expectations.
+- Desktop and web-extension builds pass.
+- Builder and query-results E2E tests target Lit through roles, labels, and shared helpers, with no remaining reliance on LWC or Tabulator DOM/styling selectors in feature scenarios.
+- No regression in document round-tripping, saved state, telemetry, query execution, query-plan execution, result counts/flattening, pagination, sorting, grouped headers, scrolling, or CSV/JSON exports.
+- Object and field metadata use the extension-side catalog-backed services as their sole authority, normalized payloads are validated at the browser boundary, org isolation/invalidation is tested, and neither webview contains a competing metadata connection or cache.
+- Large object/field lists and large/wide result sets remain responsive and do not materially regress memory, first-render time, or tab restoration.
+- Builder and results production bundle sizes have agreed budgets and are measured using the same minified/gzip method as their baselines.
+- `@salesforce/soql-builder-ui` is consumed as a private workspace dependency without importing VS Code APIs, and its `package.json` contains `"private": true` so CI publication jobs skip it.
+- LWC dependencies, templates, tests, build plugins, and compatibility workarounds are removed.
+- The plain JavaScript query-results controller and obsolete styling are removed; Tabulator is retained only behind the typed Lit wrapper and a VS Code-token theme layer.
+- Both Lit webviews, their Effect drivers, scoped runtimes, and framework-neutral controllers are type-checked by repository quality gates.
+
+## Rollback Strategy
+
+Until final cutover, disable `salesforcedx-vscode-soql.experimental.useLitSpike` to return to the LWC builder and keep the legacy query-results entry selectable through the migration toggle introduced by Story 12. During cutover, record the last legacy-default commit for both webviews so a release can revert either entry-point change without reverting unrelated model, query, export, or extension-host work.

--- a/packages/salesforcedx-vscode-soql/.vscodeignore
+++ b/packages/salesforcedx-vscode-soql/.vscodeignore
@@ -15,7 +15,9 @@ playwright-report/**
 test-results/**
 **/*.ts
 coverage
+docs/**
 junit*
+scripts/**
 *.vsix
 .circular-deps.json
 .eslintcache

--- a/packages/salesforcedx-vscode-soql/docs/soql-ui-migration-baseline.md
+++ b/packages/salesforcedx-vscode-soql/docs/soql-ui-migration-baseline.md
@@ -1,0 +1,157 @@
+# SOQL UI Migration Baseline and Gates
+
+This document is the parity contract for migrating the SOQL Builder and query-results webviews to Lit. It records the legacy behavior at `develop` commit `2326d1eff` on 2026-08-19. A Lit slice is mergeable while the legacy entry remains the default only when the checks relevant to that slice pass.
+
+## Repeatable commands
+
+Run package commands from the repository root:
+
+```bash
+npm run compile --workspace salesforcedx-vscode-soql
+npm test --workspace salesforcedx-vscode-soql
+npm run test:soql-builder-ui --workspace salesforcedx-vscode-soql -- --runInBand
+npm run test:query-results-ui --workspace salesforcedx-vscode-soql
+npm run test:ui-bundle-budgets --workspace salesforcedx-vscode-soql
+npm run test:web --workspace salesforcedx-vscode-soql
+npm run test:desktop --workspace salesforcedx-vscode-soql
+```
+
+The last two commands require the repository's normal authenticated E2E environment. Both targets are release gates. A feature PR may run the focused spec that owns its behavior, but it must not disable the full desktop or web gate.
+
+## Behavior evidence
+
+| Area | Legacy behavior that must remain | Automated evidence | Remaining environment evidence |
+| --- | --- | --- | --- |
+| Builder lifecycle | Initial activation, saved-state restoration, external document updates, and builder/text round trips | `vscodeMessageService.test.ts`, `toolingModelService.test.ts`, `soql-builder.spec.ts` | Desktop and web runs |
+| From and Fields | Object search, field search, selection/removal, `COUNT()`, Select All, and Clear All | `from.test.ts`, `fields.test.ts`, `customSelect.test.ts`, `soql-builder.spec.ts` | Large metadata fixture timing |
+| Clauses | Where values/operators/AND/OR, Order By, Limit, and All Rows | `where*.test.ts`, `orderBy.test.ts`, `limit.test.ts`, `soqlUtils.test.ts`, `soql-builder.spec.ts`, `soql-run-query.spec.ts` | Keyboard-only E2E pass |
+| Feedback and actions | Preview, missing org, recoverable/unsupported/syntax errors, dismissal, Run Query, and Query Plan | `app.test.ts`, `queryPreview.test.ts`, `soqlEditorProvider.test.ts`, `soql-builder.spec.ts`, `soql-query-plan.spec.ts` | Accessibility scan and theme captures |
+| Results lifecycle | `activate`, `update`, state restore, title, returned/total count, max-row hint, empty data, and resize | `queryDataViewController.test.ts` | Restore after a real tab teardown on desktop and web |
+| Results grid | Flattened keys, relationship groups, legacy rows, 50-row pagination, sorting, resize, scrolling, and narrow layouts | `queryDataViewController.test.ts`, `dataQuery.test.ts` | Tabulator interaction matrix below |
+| Exports | CSV/JSON actions, data conversion, desktop save dialog, and web workspace save | `queryDataViewController.test.ts`, `csvDataProvider.test.ts`, `queryDataFileService.test.ts`, `soql-save-query-results.spec.ts` | Desktop and web runs |
+
+The focused controller test is intentionally a contract test around the plain JavaScript query-results entry. It does not expose controller internals and can be run against every compatibility edit until the Lit entry replaces it.
+
+### Result data matrix
+
+Use deterministic fixtures with the following shapes when collecting browser measurements. `salesforcedx-vscode-soql.maxQueryLimit` supplies the maximum-result case.
+
+| Fixture | Required assertion |
+| --- | --- |
+| Empty | Title and `Returned 0 of 0 total records`; no crash or stale rows |
+| Small | 10 flat records; no unused gray table area |
+| Page boundary | 50 records stays on one page; 51 records exposes a second local page |
+| Wide | 40 scalar fields; horizontal scroll preserves header/body alignment |
+| Related | At least three relationship depths and a null relationship; grouped headers and literal dotted-key values remain correct |
+| Maximum | Maximum configured returned records with a greater server total; max-row guidance is visible |
+
+For each non-empty fixture, exercise ascending/descending header sort, column resize, horizontal and vertical scrolling, and a 480 px-wide editor group.
+
+## Existing legacy defects
+
+The baseline run originally reported 3 failed suites (2 failed tests, 139 passed) plus an LWC version warning. This story repairs the stale assertions and mock shape without changing runtime behavior:
+
+- `header/header.test.ts` now makes the query valid before clicking the intentionally disabled Run Query button.
+- `whereModifierGroup/whereModifierGroup.test.ts` now mocks the package's default export, matching the production import.
+- `services/soqlUtils.test.ts` now includes the `@salesforce/soql-model` condition discriminators and uses structural equality.
+
+The resulting legacy baseline is 18 suites passed, 167 tests passed, and 1 test skipped. The suite still logs: `current engine is v8.26.2, but template was compiled with v9.3.4`. `@lwc/jest-preset@19.6.1` owns engine 8.26.2 while its compiler and this package's Rollup plugin use 9.3.4. The quarantine owner is the SOQL Lit migration assignee (Peter Hale), with removal due in the final LWC-removal story. The warning is not suppressed and any test failure remains fatal.
+
+Reproduce with:
+
+```bash
+npm ls @lwc/engine-dom @lwc/compiler @lwc/jest-preset --workspace salesforcedx-vscode-soql
+npm run test:soql-builder-ui --workspace salesforcedx-vscode-soql -- --runInBand
+```
+
+## Bundle baseline and budgets
+
+`test:ui-bundle-budgets` builds the legacy builder, concatenates each configured artifact in a stable order, and applies Node zlib gzip level 9. The source of truth is `test/baselines/soql-ui-bundles.json`.
+
+| Artifact | Baseline raw | Baseline gzip | Maximum raw | Maximum gzip |
+| --- | ---: | ---: | ---: | ---: |
+| Legacy builder application | 880,931 B | 231,443 B | 925,000 B | 242,000 B |
+| Query-results first-party shell | 14,293 B | 4,856 B | 16,000 B | 5,500 B |
+| Retained Tabulator vendor assets | 377,590 B | 80,815 B | 378,000 B | 81,000 B |
+
+Tabulator is measured separately because it is retained. A Lit results PR must not present the vendor bytes as framework growth. Migration builds report legacy and Lit entry sizes independently; production VSIX builds must continue excluding inactive migration entries until final cutover.
+
+## Performance and lifecycle gates
+
+Collect five warm runs after one discarded warm-up run on the same machine and VS Code build. Report the median and p95 plus the fixture, target, commit, CPU, and available memory. A regression is a gate failure when either the absolute budget or the 20% relative budget against this baseline is exceeded.
+
+| Measurement | Absolute p95 budget |
+| --- | ---: |
+| Builder activation to stable controls, cached metadata | 750 ms |
+| Builder activation to stable controls, uncached 3,000-field object | 1,500 ms |
+| Search/filter or clause interaction to updated preview | 100 ms |
+| Results `update` message to stable 50-row grid | 500 ms |
+| Results `update` message to stable maximum-result grid | 1,500 ms |
+| Sort, page, or restored-tab interaction | 200 ms |
+
+Neither legacy browser UI imports Effect, so its browser-bundle Effect contribution, managed-runtime count, and UI fiber count are all zero. The persistent extension host already owns one lazily created `getSoqlRuntime()` shared across SOQL instances. During migration:
+
+- each mounted Lit builder or results webview owns exactly one browser `ManagedRuntime`;
+- presentation components own no runtimes and start no unscoped fibers;
+- after ten hide/restore cycles, active UI fiber/listener/resource counts return to the post-mount value after every restore;
+- after disposal, the webview runtime and its fibers/listeners are zero;
+- retained heap after disposal must be within 10% of the pre-mount value after forced collection in the diagnostic run.
+
+Every new browser bundle reports raw/gzip totals and the raw/gzip contribution attributable to `effect`, `@salesforce/effect-ext-utils`, Lit, and VSCode Elements. The package gate fails on total budgets; the PR report explains dependency-level movement.
+
+## Metadata authority baseline
+
+The extension host is the only metadata authority. `SOQLEditorInstance` routes object lists to `MetadataDescribeService.listSObjects()` and object descriptions to `MetadataDescribeService.describeCustomObject()`, then `TransmogrifierService.toMinimalSObject()` normalizes the payload. The browser does not open an org connection.
+
+Required migration assertions:
+
+- Two identical list requests in one org cause at most one remote list request after cache warm-up.
+- Two identical object describes in one org cause at most one remote describe after cache warm-up.
+- The browser receives only the minimal `SObject` DTO required for builder behavior.
+- A default-org change never returns data tagged for the previous org.
+- Deploy, retrieve, source-tracking, and relevant metadata-document changes invalidate affected entries.
+- A late response for an old org or selection is rejected rather than replacing newer UI state.
+- Missing default org produces the established recoverable state and no browser-side connection attempt.
+
+Run the SOQL completion integration checks together with the catalog/cache suites owned by `salesforcedx-vscode-services`; they are part of this UI's release evidence because the builder consumes that authority rather than duplicating it.
+
+## Accessibility selector contract
+
+Feature-level Playwright tests locate controls by user-visible semantics. Allowed contracts are, in priority order:
+
+1. `getByRole(role, { name })` for buttons, checkboxes, options, alerts, tabs, grids, column headers, rows, and pagination.
+2. `getByLabel(label)` for form controls with stable product labels.
+3. `getByPlaceholder()` only while the placeholder is an intentional product string and no label is available.
+4. A documented public host element or `data-testid` only when the control cannot expose a suitable accessible contract.
+
+LWC element names, shadow-root layout, `.query-preview-container`, `p.option[data-option-value]`, `[data-el-*]`, results element IDs, and `.tabulator-*` classes are legacy-only selectors. They may appear in low-level adapter/component tests, but Lit feature scenarios must not depend on them. Tabulator-specific DOM selectors stay inside the results-grid adapter tests.
+
+Required accessible names include `Run Query`, `Get Query Plan`, `From`, `Fields`, `Select all fields`, `Clear all fields`, `Where`, `Order By`, `Limit`, `All Rows`, `Query preview`, `Save as CSV`, and `Save as JSON`. Notifications use an alert or status role appropriate to urgency. Sorted result headers expose sort direction.
+
+## Theme and screenshot evidence
+
+Capture representative complete-builder and results states in these four VS Code themes:
+
+| Theme kind | Builder artifact | Results artifact |
+| --- | --- | --- |
+| Light | `builder-light.png` | `results-light.png` |
+| Dark | `builder-dark.png` | `results-dark.png` |
+| High contrast | `builder-high-contrast.png` | `results-high-contrast.png` |
+| High contrast light | `builder-high-contrast-light.png` | `results-high-contrast-light.png` |
+
+The builder state contains From, multiple Fields, Where, Order By, Limit, All Rows, and preview. The results state uses the wide, related, 51-row fixture with the second page and max-row hint visible. Capture at 1440x900 and at a 480 px editor width. Store screenshots as CI artifacts named `soql-ui-baseline-<target>-<commit>`; do not silently update an accepted reference. Review foreground/background, borders, focus, disabled controls, validation, selection, hover, scrollbars, grouped headers, pagination, and icon visibility against VS Code tokens.
+
+Screenshot collection remains an environment gate: a PR without desktop and web artifacts has not completed Story 1 even if unit tests pass.
+
+## Local E2E evidence — 2026-08-19
+
+The focused builder scenario was run locally against a one-day `minimalTestOrg` created through the globally authenticated `vscodeOrg` Dev Hub. The scratch org was deleted successfully after the run. No credentials were copied into the repository or test artifacts.
+
+```bash
+npm run test:web --workspace salesforcedx-vscode-soql -- --grep "SOQL Builder"
+npm run test:desktop --workspace salesforcedx-vscode-soql -- --grep "SOQL Builder"
+```
+
+On web and macOS desktop, the complete builder scenario reached its final validation step after exercising query construction, Run Query, Get Query Plan, and builder/text-editor round trips. Both targets then failed the existing global console-error gate under VS Code 1.134.0 because the VS Code workbench reported that `chat.contextContributions` depends on the unavailable `chatSessionRoutingProviderService`. The desktop run also reported that the local O11y span exporter could not reach its divert endpoint.
+
+These errors originate outside the SOQL webviews, but they remain unsuppressed. The SOQL Lit migration assignee owns reconciliation with the shared Playwright/VS Code test infrastructure before Story 1 closes. The captured default-dark screenshot confirms the completed builder state but does not replace the required four-theme builder/results matrix.

--- a/packages/salesforcedx-vscode-soql/jest.config.js
+++ b/packages/salesforcedx-vscode-soql/jest.config.js
@@ -2,7 +2,11 @@
 const baseConfig = require('../../config/jest.base.config');
 
 module.exports = Object.assign({}, baseConfig, {
-  testPathIgnorePatterns: [...(baseConfig.testPathIgnorePatterns || []), '/test/jest/soql-builder-ui/'],
+  testPathIgnorePatterns: [
+    ...(baseConfig.testPathIgnorePatterns || []),
+    '/test/jest/soql-builder-ui/',
+    '/test/jest/queryDataView/queryDataViewController.test.ts'
+  ],
   transform: {
     '^.+\\.tsx?$': ['ts-jest', { isolatedModules: true }]
   }

--- a/packages/salesforcedx-vscode-soql/jest.query-results.config.js
+++ b/packages/salesforcedx-vscode-soql/jest.query-results.config.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+// eslint:disable-next-line:no-var-requires
+const baseConfig = require('../../config/jest.base.config');
+
+module.exports = Object.assign({}, baseConfig, {
+  testEnvironment: 'jsdom',
+  testMatch: ['<rootDir>/test/jest/queryDataView/queryDataViewController.test.ts'],
+  modulePathIgnorePatterns: [...(baseConfig.modulePathIgnorePatterns || []), '<rootDir>/.wireit/'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { isolatedModules: true }]
+  }
+});

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -84,6 +84,8 @@
     "build:soql-builder-ui": "wireit",
     "test": "wireit",
     "test:soql-builder-ui": "wireit",
+    "test:query-results-ui": "wireit",
+    "test:ui-bundle-budgets": "wireit",
     "run:web": "wireit",
     "test:web": "wireit",
     "test:web:ui": "DEBUG_MODE=1 npm run test:web -- --headed",
@@ -152,6 +154,35 @@
         "src/soql-builder-ui/jest.config.js",
         "src/soql-builder-ui/jestSetup/**",
         "test/jest/soql-builder-ui/**"
+      ],
+      "output": []
+    },
+    "test:query-results-ui": {
+      "command": "jest --config jest.query-results.config.js --runInBand",
+      "files": [
+        "src/soql-data-view/index.html",
+        "src/soql-data-view/queryDataViewController.js",
+        "test/jest/queryDataView/queryDataViewController.test.ts",
+        "jest.query-results.config.js",
+        "../../config/jest.base.config.js",
+        "../../scripts/setup-jest.ts"
+      ],
+      "output": []
+    },
+    "test:ui-bundle-budgets": {
+      "command": "node scripts/check-ui-bundle-budgets.mjs",
+      "dependencies": [
+        "build:soql-builder-ui"
+      ],
+      "files": [
+        "scripts/check-ui-bundle-budgets.mjs",
+        "test/baselines/soql-ui-bundles.json",
+        "src/soql-builder-ui/dist/app.js",
+        "src/soql-data-view/index.html",
+        "src/soql-data-view/queryDataViewController.js",
+        "src/soql-data-view/queryDataView.css",
+        "src/soql-data-view/tabulator.min.js",
+        "src/soql-data-view/tabulator.min.css"
       ],
       "output": []
     },

--- a/packages/salesforcedx-vscode-soql/scripts/check-ui-bundle-budgets.mjs
+++ b/packages/salesforcedx-vscode-soql/scripts/check-ui-bundle-budgets.mjs
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { gzipSync } from 'node:zlib';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const configPath = resolve(packageRoot, 'test/baselines/soql-ui-bundles.json');
+const config = JSON.parse(readFileSync(configPath, 'utf8'));
+
+const formatBytes = value => `${new Intl.NumberFormat('en-US').format(value)} B`;
+const failures = [];
+
+console.log('SOQL UI bundle baseline (gzip level 9)');
+
+for (const artifact of config.artifacts) {
+  const missingFiles = artifact.files.filter(file => !existsSync(resolve(packageRoot, file)));
+  if (missingFiles.length > 0) {
+    failures.push(`${artifact.name}: missing ${missingFiles.join(', ')}`);
+    continue;
+  }
+
+  const content = Buffer.concat(artifact.files.map(file => readFileSync(resolve(packageRoot, file))));
+  const actual = {
+    rawBytes: content.byteLength,
+    gzipBytes: gzipSync(content, { level: 9 }).byteLength
+  };
+
+  console.log(`\n${artifact.name}`);
+  for (const metric of ['rawBytes', 'gzipBytes']) {
+    const delta = actual[metric] - artifact.baseline[metric];
+    const deltaLabel = `${delta >= 0 ? '+' : ''}${formatBytes(delta)}`;
+    console.log(
+      `  ${metric === 'rawBytes' ? 'raw ' : 'gzip'} ${formatBytes(actual[metric])} ` +
+        `(baseline ${formatBytes(artifact.baseline[metric])}, ${deltaLabel}; budget ${formatBytes(artifact.budget[metric])})`
+    );
+    if (actual[metric] > artifact.budget[metric]) {
+      failures.push(
+        `${artifact.name} ${metric}: ${formatBytes(actual[metric])} exceeds ${formatBytes(artifact.budget[metric])}`
+      );
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error('\nSOQL UI bundle gate failed:');
+  failures.forEach(failure => console.error(`- ${failure}`));
+  process.exitCode = 1;
+} else {
+  console.log('\nSOQL UI bundle gate passed.');
+}

--- a/packages/salesforcedx-vscode-soql/test/baselines/soql-ui-bundles.json
+++ b/packages/salesforcedx-vscode-soql/test/baselines/soql-ui-bundles.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": 1,
+  "measurement": "Concatenate files in listed order and gzip the result at level 9.",
+  "artifacts": [
+    {
+      "name": "legacy builder application",
+      "files": ["src/soql-builder-ui/dist/app.js"],
+      "baseline": {
+        "rawBytes": 880931,
+        "gzipBytes": 231443
+      },
+      "budget": {
+        "rawBytes": 925000,
+        "gzipBytes": 242000
+      }
+    },
+    {
+      "name": "query-results first-party shell",
+      "files": [
+        "src/soql-data-view/index.html",
+        "src/soql-data-view/queryDataViewController.js",
+        "src/soql-data-view/queryDataView.css"
+      ],
+      "baseline": {
+        "rawBytes": 14293,
+        "gzipBytes": 4856
+      },
+      "budget": {
+        "rawBytes": 16000,
+        "gzipBytes": 5500
+      }
+    },
+    {
+      "name": "retained Tabulator vendor assets",
+      "files": ["src/soql-data-view/tabulator.min.js", "src/soql-data-view/tabulator.min.css"],
+      "baseline": {
+        "rawBytes": 377590,
+        "gzipBytes": 80815
+      },
+      "budget": {
+        "rawBytes": 378000,
+        "gzipBytes": 81000
+      }
+    }
+  ]
+}

--- a/packages/salesforcedx-vscode-soql/test/jest/queryDataView/queryDataViewController.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/queryDataView/queryDataViewController.test.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+type TableOptions = {
+  data: unknown[];
+  pagination: string;
+  paginationSize: number;
+  layout: string;
+  height: string;
+  virtualDom: boolean;
+  columns: Array<{
+    title: string;
+    field?: string;
+    columns?: TableOptions['columns'];
+    formatter?: (cell: { getRow: () => { getData: () => Record<string, unknown> } }) => string;
+  }>;
+};
+
+class FakeTabulator {
+  public static readonly instances: FakeTabulator[] = [];
+
+  public readonly destroy = jest.fn();
+  public readonly redraw = jest.fn();
+  public readonly setHeight = jest.fn();
+
+  constructor(
+    public readonly target: string | HTMLElement,
+    public readonly options: TableOptions
+  ) {
+    FakeTabulator.instances.push(this);
+  }
+}
+
+describe('Query Data View controller baseline', () => {
+  const getState = jest.fn();
+  const setState = jest.fn();
+  const postMessage = jest.fn();
+
+  beforeEach(() => {
+    FakeTabulator.instances.length = 0;
+    document.body.innerHTML = `
+      <div>
+        <header>
+          <h3 id="webview-title"></h3>
+          <span id="total-records-size"></span>
+          <span id="max-rows-hint" hidden><span class="info-tooltip__text"></span></span>
+          <button id="save-csv-button">.csv</button>
+          <button id="save-json-button">.json</button>
+        </header>
+        <div id="data-table"></div>
+      </div>`;
+
+    getState.mockReturnValue({
+      documentName: 'restored.soql',
+      data: {
+        done: true,
+        totalSize: 52,
+        records: Array.from({ length: 51 }, (_, index) => ({ Id: String(index + 1).padStart(3, '0') })),
+        flattenedGrid: {
+          fields: ['Id', 'Owner', 'Owner.Name', 'Owner.Email'],
+          rowData: Array.from({ length: 51 }, (_, index) => ({
+            Id: String(index + 1).padStart(3, '0'),
+            'Owner.Name': index === 0 ? 'Ada' : 'Grace',
+            'Owner.Email': index === 0 ? null : 'owner@example.com'
+          }))
+        },
+        columnData: { columns: [], subTables: [] }
+      }
+    });
+
+    Object.defineProperty(globalThis, 'acquireVsCodeApi', {
+      configurable: true,
+      value: () => ({ getState, setState, postMessage })
+    });
+    Object.defineProperty(globalThis, 'Tabulator', {
+      configurable: true,
+      value: FakeTabulator
+    });
+
+    jest.requireActual('../../../src/soql-data-view/queryDataViewController.js');
+  });
+
+  it('restores, renders, updates, exports, and resizes through the existing protocol', () => {
+    expect(getState).toHaveBeenCalledTimes(1);
+    expect(document.getElementById('webview-title')?.innerText).toBe('restored.soql');
+    expect(document.getElementById('total-records-size')?.innerText).toBe('Returned 51 of 52 total records');
+    expect(document.getElementById('max-rows-hint')?.hasAttribute('hidden')).toBe(false);
+    expect((document.querySelector('.info-tooltip__text') as HTMLElement | null)?.innerText).toContain(
+      'Max Query Limit'
+    );
+    expect(postMessage).toHaveBeenCalledWith({ type: 'activate' });
+
+    const restoredTable = FakeTabulator.instances[0];
+    expect(restoredTable.target).toBe('#data-table');
+    expect(restoredTable.options).toMatchObject({
+      pagination: 'local',
+      paginationSize: 50,
+      layout: 'fitColumns',
+      height: '100%',
+      virtualDom: false
+    });
+    expect(restoredTable.options.columns).toHaveLength(2);
+    expect(restoredTable.options.columns[0]).toMatchObject({ title: 'Id', field: 'Id' });
+    expect(restoredTable.options.columns[1]).toMatchObject({
+      title: 'Owner',
+      columns: [
+        { title: 'Name', field: 'Owner.Name' },
+        { title: 'Email', field: 'Owner.Email' }
+      ]
+    });
+    expect(
+      restoredTable.options.columns[1].columns?.[1].formatter?.({
+        getRow: () => ({ getData: () => ({ 'Owner.Email': null }) })
+      })
+    ).toBe('');
+
+    const updatedData = {
+      done: true,
+      totalSize: 1,
+      records: [{ ID: '003', NAME: 'Katherine' }],
+      columnData: {
+        columns: [
+          { title: 'Id', fieldHelper: ['id'] },
+          { title: 'Name', fieldHelper: ['name'] }
+        ],
+        subTables: []
+      }
+    };
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: 'update', data: updatedData, documentName: 'updated.soql' }
+      })
+    );
+
+    expect(restoredTable.destroy).toHaveBeenCalledTimes(1);
+    expect(document.getElementById('webview-title')?.innerText).toBe('updated.soql');
+    expect(document.getElementById('total-records-size')?.innerText).toBe('Returned 1 of 1 total records');
+    expect(document.getElementById('max-rows-hint')?.hasAttribute('hidden')).toBe(true);
+    expect(setState).toHaveBeenCalledWith({ data: updatedData, documentName: 'updated.soql' });
+    expect(FakeTabulator.instances[1].options.columns).toEqual([
+      { title: 'Id', field: 'ID' },
+      { title: 'Name', field: 'NAME' }
+    ]);
+
+    const emptyData = {
+      done: true,
+      totalSize: 0,
+      records: [],
+      columnData: { columns: [{ title: 'Id', fieldHelper: ['Id'] }], subTables: [] }
+    };
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: 'update', data: emptyData, documentName: 'empty.soql' }
+      })
+    );
+    expect(FakeTabulator.instances[1].destroy).toHaveBeenCalledTimes(1);
+    expect(FakeTabulator.instances[2].options.columns).toEqual([]);
+
+    document.getElementById('save-csv-button')?.click();
+    document.getElementById('save-json-button')?.click();
+    expect(postMessage).toHaveBeenCalledWith({ type: 'save_records', format: 'csv' });
+    expect(postMessage).toHaveBeenCalledWith({ type: 'save_records', format: 'json' });
+
+    window.dispatchEvent(new Event('resize'));
+    expect(FakeTabulator.instances[2].setHeight).toHaveBeenCalled();
+    expect(FakeTabulator.instances[2].redraw).toHaveBeenCalledWith(true);
+  });
+});

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-builder-ui/modules/querybuilder/header/header.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-builder-ui/modules/querybuilder/header/header.test.ts
@@ -24,6 +24,7 @@ describe('Header', () => {
   });
 
   it('emits a run event', () => {
+    header.isQueryValid = true;
     document.body.appendChild(header);
 
     const handler = jest.fn();

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-builder-ui/modules/querybuilder/services/soqlUtils.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-builder-ui/modules/querybuilder/services/soqlUtils.test.ts
@@ -34,23 +34,27 @@ describe('SoqlUtils', () => {
       conditions: [
         {
           condition: {
-            field: { fieldName: 'Name' },
+            field: { kind: 'fieldRef', fieldName: 'Name' },
             operator: '=',
             compareValue: {
               type: 'STRING',
-              value: "'pwt'"
-            }
+              value: "'pwt'",
+              kind: 'literal'
+            },
+            kind: 'fieldCompare'
           },
           index: 0
         },
         {
           condition: {
-            field: { fieldName: 'Id' },
+            field: { kind: 'fieldRef', fieldName: 'Id' },
             operator: '=',
             compareValue: {
               type: 'NUMBER',
-              value: '123456'
-            }
+              value: '123456',
+              kind: 'literal'
+            },
+            kind: 'fieldCompare'
           },
           index: 1
         }
@@ -152,7 +156,7 @@ describe('SoqlUtils', () => {
     const transformedUiModel = convertSoqlToUiModel(soqlOne);
     const expectedUiModel = { ...uiModelOne } as any;
     delete expectedUiModel.originalSoqlStatement;
-    expect(JSON.stringify(transformedUiModel)).toEqual(JSON.stringify(expectedUiModel));
+    expect(transformedUiModel).toEqual(expectedUiModel);
   });
 
   it('transforms SOQL to UI Model with SELECT COUNT() clause', () => {

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-builder-ui/modules/querybuilder/whereModifierGroup/whereModifierGroup.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-builder-ui/modules/querybuilder/whereModifierGroup/whereModifierGroup.test.ts
@@ -17,7 +17,7 @@
 
 import { createElement } from 'lwc';
 import WhereModifierGroup from 'querybuilder/whereModifierGroup';
-import { debounce } from 'debounce';
+import debounce from 'debounce';
 
 jest.mock('debounce');
 // @ts-ignore


### PR DESCRIPTION
<!--- PR title: <type>(optional scope): <description> - W-XXXXXXXX — append GUS work item at the end (space, hyphen, space, W-). Conventional commits: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?

Establishes the first Stack Group 1 delivery layer for the SOQL Builder and query-results Lit migration.

- Adds the approved epic/user-story migration plan and the Story 1 parity/gate contract.
- Adds a JSDOM contract suite for query-results restoration, messaging, flattened relationship columns, the 51-row pagination boundary, empty results, exports, and resize behavior.
- Adds repeatable raw/gzip budgets for the legacy builder, first-party results shell, and retained Tabulator vendor assets.
- Repairs three stale LWC tests without changing runtime behavior.
- Records accessibility selectors, metadata authority, Effect lifecycle, performance, theme, and desktop/web evidence requirements.
- Excludes baseline documentation and measurement scripts from the production VSIX.
- Synchronizes the generated `@salesforce/vscode-services` package version with the root lockfile as required by the repository pre-commit gate.

This is Stack Group 1's bottom layer with no lower PR dependency. The legacy LWC builder and plain JavaScript query-results entry remain the production defaults. This layer does not add or bundle the Lit implementation and does not include the spike's example Node server.

### What issues does this PR fix or reference?
@W-23928676@ ([GUS User Story](https://gus.lightning.force.com/a07EE00002iATrlYAG)), GUS Epic: `a3QEE000002e0RZ2AY`

### Functionality Before

- Query results had no UI-level controller baseline.
- Bundle size, Effect lifecycle, metadata authority, theme, performance, and selector gates were not recorded together.
- The LWC suite contained three stale failures.

### Functionality After

- Legacy runtime behavior remains unchanged.
- The LWC baseline is 18 suites passed, 167 tests passed, and 1 pre-existing skip.
- Query-results activation/update/state, grouped fields, pagination configuration, empty results, exports, and resize behavior have a focused contract gate.
- First-party and retained vendor bundle costs are measured independently.
- Story 1 closure requirements and existing environment blockers are explicit and reproducible.

Verification:

- Repository pre-commit workflow: 93 scripts passed, 1 skipped.
- `npm test --workspace salesforcedx-vscode-soql -- --runInBand`: 128 passed.
- `npm run test:soql-builder-ui --workspace salesforcedx-vscode-soql -- --runInBand`: 18 suites passed, 167 passed, 1 skipped.
- `npm run test:query-results-ui --workspace salesforcedx-vscode-soql`: passed.
- `npm run test:ui-bundle-budgets --workspace salesforcedx-vscode-soql`: passed.
- `npm run test:compile --workspace salesforcedx-vscode-soql`: passed.
- `npm run lint --workspace salesforcedx-vscode-soql`: passed with pre-existing warnings.
- Focused metadata describe/catalog suites: 27 passed.
- Focused web and macOS desktop builder scenarios completed the SOQL workflow but remain red at the final global console guard because VS Code 1.134.0 emits an unrelated missing `chatSessionRoutingProviderService` error; desktop also reports an unavailable local O11y divert endpoint. No suppression was added.

Demo increment: this is a mergeable, no-default-behavior-change foundation. The first management-facing Lit UI demo remains Stack Group 3 after the production foundation and Effect driver/browser harness layers land.
