### PR TITLE
fix(lwc): distinguish Jest failures from crashes

### DIFF
--- a/packages/salesforcedx-vscode-lwc/src/testSupport/testExplorer/lwcTestController.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/testExplorer/lwcTestController.ts
@@ -540,9 +540,9 @@ class LwcTestController {
 
       const { command, args, workspaceFolder, testResultFsPath } = shellInfo;
 
-      // Track task failure independently of whether this run has a selected source item.
-      // This also prevents partial results from overwriting a crash-extracted error.
-      let taskCrashed = false;
+      // A non-zero exit code is also used for ordinary assertion failures, so defer deciding
+      // whether Jest crashed until after inspecting any JSON results it produced.
+      let taskFailure: { errorMessage: string; errorDetail: string } | undefined;
       let exitCode: number | undefined;
 
       if (isDebug) {
@@ -577,12 +577,9 @@ class LwcTestController {
         const taskEnd = await taskEndPromise;
         exitCode = taskEnd.exitCode;
 
-        // Capture error details if Jest crashed, but don't return early.
-        // Jest may write partial results even with exitCode > 0 (e.g., syntax error in one file
-        // of a multi-file run). We'll attempt to read results and show both captured error and
-        // any partial test results Jest produced.
+        // Capture potential crash details, but don't report them until the Jest JSON confirms
+        // this was a runtime failure rather than an ordinary failed assertion.
         if (exitCode === undefined || exitCode > 0) {
-          taskCrashed = true;
           let errorMessage = `Jest test suite failed to run (exit code ${exitCode})`;
           let errorDetail = 'The test suite crashed before producing results.';
 
@@ -595,40 +592,7 @@ class LwcTestController {
               errorDetail = capturedError.replaceAll(/\x1b\[[0-9;]*m/g, '');
             }
           }
-
-          const createCrashMessage = (): vscode.TestMessage => {
-            const message = new vscode.TestMessage(errorDetail);
-            message.actualOutput = errorMessage;
-
-            // Extract error location from stack trace for editor highlighting
-            const location = matchJestStackTraceLocation(errorDetail);
-            if (location) {
-              const errorUri = URI.file(normalizeJestFsPath(location.file));
-              const position = new vscode.Position(Math.max(0, location.line - 1), Math.max(0, location.column - 1));
-              message.location = new vscode.Location(errorUri, position);
-            }
-
-            return message;
-          };
-
-          // If this execution targets a specific test item, attach the error to it. For an implicit run-all,
-          // give every item that was marked running a terminal state; partial Jest results can still replace
-          // these provisional crash states below.
-          if (sourceItem) {
-            run.errored(sourceItem, createCrashMessage());
-            this.markDescendantsSkipped(run, sourceItem);
-          } else {
-            runAllItems.forEach(item => {
-              run.errored(item, createCrashMessage());
-              this.markDescendantsSkipped(run, item);
-            });
-          }
-
-          appendLine(run, errorMessage);
-          appendLine(run, '');
-          // Split multi-line error detail into individual lines for proper formatting
-          const errorLines = errorDetail.split('\n');
-          errorLines.forEach(line => appendLine(run, line));
+          taskFailure = { errorMessage, errorDetail };
         }
       }
 
@@ -638,15 +602,54 @@ class LwcTestController {
 
       // Jest may not have flushed the output file to disk immediately when the task completes.
       // Poll for the file's existence with a short timeout before attempting to read.
-      // If we captured a crash error and the exit code suggests no results file will exist,
+      // If the exit code suggests no results file may exist,
       // use a shorter timeout to avoid hanging for 5 minutes.
-      await waitForResultFile(testResultFsPath, token, taskCrashed);
+      await waitForResultFile(testResultFsPath, token, taskFailure !== undefined);
 
       if (token.isCancellationRequested) {
         return;
       }
 
       const results = await readJestResults(testResultFsPath);
+      const taskCrashed =
+        taskFailure !== undefined &&
+        (!results ||
+          results.numRuntimeErrorTestSuites > 0 ||
+          results.testResults.length === 0 ||
+          results.testResults.some(result => result.assertionResults.length === 0 && Boolean(result.message)));
+
+      if (taskCrashed && taskFailure) {
+        const { errorMessage, errorDetail } = taskFailure;
+        const createCrashMessage = (): vscode.TestMessage => {
+          const message = new vscode.TestMessage(errorDetail);
+          message.actualOutput = errorMessage;
+
+          const location = matchJestStackTraceLocation(errorDetail);
+          if (location) {
+            const errorUri = URI.file(normalizeJestFsPath(location.file));
+            const position = new vscode.Position(Math.max(0, location.line - 1), Math.max(0, location.column - 1));
+            message.location = new vscode.Location(errorUri, position);
+          }
+
+          return message;
+        };
+
+        // For run-all, partial Jest results can replace these provisional crash states below.
+        if (sourceItem) {
+          run.errored(sourceItem, createCrashMessage());
+          this.markDescendantsSkipped(run, sourceItem);
+        } else {
+          runAllItems.forEach(item => {
+            run.errored(item, createCrashMessage());
+            this.markDescendantsSkipped(run, item);
+          });
+        }
+
+        appendLine(run, errorMessage);
+        appendLine(run, '');
+        errorDetail.split('\n').forEach(line => appendLine(run, line));
+      }
+
       if (results) {
         // Don't let applyResults overwrite crash-extracted errors.
         // Pass the crash state so it can skip items already marked as errored.

--- a/packages/salesforcedx-vscode-lwc/test/jest/testSupport/testExplorer/lwcTestController.test.ts
+++ b/packages/salesforcedx-vscode-lwc/test/jest/testSupport/testExplorer/lwcTestController.test.ts
@@ -1135,9 +1135,9 @@ describe('LwcTestController public run API', () => {
     expect(mockRun.passed).not.toHaveBeenCalledWith(item);
   });
 
-  it('preserves a case-level crash error when the fallback resolves without an exit code and partial results exist', async () => {
+  it('reports failed assertions instead of a crash when Jest exits with code 1 and writes valid results', async () => {
     const testUri = URI.file('/project/force-app/lwc/foo/__tests__/foo.test.js');
-    const testName = 'does not overwrite the crash error';
+    const testName = 'fails an assertion';
 
     const mockRun = {
       started: jest.fn(),
@@ -1242,11 +1242,12 @@ describe('LwcTestController public run API', () => {
       index: 0
     });
 
-    // Jest wrote a partial results file that would overwrite the case-level crash without the ancestor guard.
+    // Jest writes valid assertion results for ordinary test failures even though it exits with code 1.
     const EffectLib = jest.requireActual('effect/Effect');
     mockFsReadFile.mockImplementation(() =>
       EffectLib.succeed(
         JSON.stringify({
+          numRuntimeErrorTestSuites: 0,
           testResults: [
             {
               name: '/project/force-app/lwc/foo/__tests__/foo.test.js',
@@ -1256,7 +1257,7 @@ describe('LwcTestController public run API', () => {
                   title: testName,
                   ancestorTitles: ['outer', 'inner'],
                   status: 'failed',
-                  failureMessages: ['Generic Jest error that should NOT overwrite crash error']
+                  failureMessages: ['Expected true to be false']
                 }
               ]
             }
@@ -1265,7 +1266,11 @@ describe('LwcTestController public run API', () => {
       )
     );
 
-    vscodeMock.tasks.onDidEndTaskProcess = jest.fn(() => ({ dispose: jest.fn() }));
+    let taskEndProcessCallback: ((e: vscode.TaskProcessEndEvent) => void) | undefined;
+    vscodeMock.tasks.onDidEndTaskProcess = jest.fn((cb: (e: vscode.TaskProcessEndEvent) => void) => {
+      taskEndProcessCallback = cb;
+      return { dispose: jest.fn() };
+    });
 
     const capturedStackTrace =
       'ReferenceError: foo is not defined\n    at Object.<anonymous> (/project/force-app/lwc/foo/__tests__/foo.test.js:20:5)';
@@ -1284,7 +1289,10 @@ describe('LwcTestController public run API', () => {
         },
         execute: jest.fn().mockImplementation(function (this: any) {
           this.taskExecution = mockTaskExecution;
-          setImmediate(() => endCb?.());
+          setImmediate(() => {
+            taskEndProcessCallback?.({ execution: mockTaskExecution, exitCode: 1 });
+            endCb?.();
+          });
           return Promise.resolve();
         }),
         terminate: jest.fn(),
@@ -1296,36 +1304,25 @@ describe('LwcTestController public run API', () => {
       };
     });
 
-    const timeoutSpy = jest.spyOn(globalThis, 'setTimeout').mockImplementation((callback: TimerHandler) => {
-      if (typeof callback === 'function') {
-        callback();
-      }
-      return undefined as unknown as ReturnType<typeof setTimeout>;
-    });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const { getLwcTestController } = require('../../../../src/testSupport/testExplorer/lwcTestController');
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const ctrl = getLwcTestController();
+    await ctrl.refresh();
 
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const { getLwcTestController } = require('../../../../src/testSupport/testExplorer/lwcTestController');
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const ctrl = getLwcTestController();
-      await ctrl.refresh();
+    await ctrl.runByExecutionInfo(
+      { kind: 'testCase' as const, testUri, testName, ancestorTitles: ['outer', 'inner'] },
+      false
+    );
 
-      await ctrl.runByExecutionInfo(
-        { kind: 'testCase' as const, testUri, testName, ancestorTitles: ['outer', 'inner'] },
-        false
-      );
-
-      expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 250);
-      const caseItem = expect.objectContaining({ id: expect.stringContaining(`::outer > inner > ${testName}`) });
-      expect(mockRun.errored).toHaveBeenCalledWith(
-        caseItem,
-        expect.objectContaining({ message: expect.stringContaining('ReferenceError: foo is not defined') })
-      );
-      expect(mockRun.failed).not.toHaveBeenCalledWith(caseItem, expect.anything());
-      expect(mockRun.passed).not.toHaveBeenCalledWith(caseItem);
-    } finally {
-      timeoutSpy.mockRestore();
-    }
+    const caseItem = expect.objectContaining({ id: expect.stringContaining(`::outer > inner > ${testName}`) });
+    expect(mockRun.failed).toHaveBeenCalledWith(
+      caseItem,
+      expect.objectContaining({ message: 'Expected true to be false' })
+    );
+    expect(mockRun.errored).not.toHaveBeenCalled();
+    const output = mockRun.appendOutput.mock.calls.flat().join('');
+    expect(output).not.toContain(capturedStackTrace);
   });
 
   it('runByExecutionInfo reveals Test Results panel when starting a run', async () => {


### PR DESCRIPTION
## Summary

Suggestion follow-up for #7940.

- defer crash reporting until the Jest JSON result is available
- treat exit code 1 with valid assertion results as an ordinary failed test
- continue reporting missing results, runtime-error suites, and file-level runtime errors as crashes
- cover the exit-code-1 assertion-failure path while retaining the existing crash regressions

## Why

Jest uses a non-zero exit code for both assertion failures and runtime failures. Treating every non-zero code as a crash marks the selected item errored and prevents `applyResults` from applying otherwise valid failed assertions.

## Validation

- `npm run test -w packages/salesforcedx-vscode-lwc` (14 suites, 84 tests)
- `npm run lint -w packages/salesforcedx-vscode-lwc`
- `npx prettier --check packages/salesforcedx-vscode-lwc/src/testSupport/testExplorer/lwcTestController.ts packages/salesforcedx-vscode-lwc/test/jest/testSupport/testExplorer/lwcTestController.test.ts`
- `git diff --check`
