### PR TITLE
feat(soql): expand Lit Effect service contract - W-23928675

### DIFF
--- a/.claude/skills/effect-best-practices/SKILL.md
+++ b/.claude/skills/effect-best-practices/SKILL.md
@@ -95,6 +95,7 @@ const MainLive = Layer.mergeAll(UserService.Default, OtherService.Default);
 
 - Infrastructure with runtime injection (Cloudflare KV, worker bindings)
 - Factory patterns where resources are provided externally
+- Interfaces with caller-provided implementations — no single canonical one to bundle as `.Default` (e.g. `SoqlBuilderService`, implemented once by the VS Code host and once by a test fake); see `references/service-patterns.md`
 
 ### Params vs Dependencies
 

--- a/.claude/skills/effect-best-practices/references/service-patterns.md
+++ b/.claude/skills/effect-best-practices/references/service-patterns.md
@@ -141,7 +141,11 @@ yield* Effect.annotateCurrentSpan("step", "completing")
 
 ## When Context.Tag is Acceptable
 
-`Context.Tag` is appropriate **only** for infrastructure that's injected at runtime:
+`Context.Tag` is appropriate for infrastructure that's injected at runtime, or for an interface
+with more than one legitimate implementation swapped in by the caller (a real host implementation
+plus a test fake, or one implementation per embedding environment). `Effect.Service` bundles a tag
+with *one* canonical implementation, so it doesn't fit when the whole point of the type is that
+callers provide their own:
 
 ### Cloudflare Worker Bindings
 
@@ -188,6 +192,20 @@ const DatabaseLive = PgClient.layer({
     // ...
 })
 ```
+
+### Interfaces With Caller-Provided Implementations
+
+A type is a pure interface — the package that declares it never picks a default implementation —
+when every consumer must supply its own. `SoqlBuilderService` (`packages/soql-builder-ui/src/effect/soqlBuilderService.ts`)
+is the shape a host embeds the browser-safe SOQL Builder UI against: the VS Code extension
+provides `VscodeSoqlBuilderServiceLive`, tests provide `FakeSoqlBuilderService`, and neither is
+more "canonical" than the other, so there's no single implementation to bundle into `.Default`.
+`Context.GenericTag` (or `Context.Tag`) stays correct here.
+
+Contrast this with `SoqlBuilderController` (`packages/soql-builder-ui/src/effect/soqlBuilderController.ts`):
+it has exactly one implementation regardless of host, so it's an `Effect.Service` — the fact that
+it depends on the caller-provided `SoqlBuilderService` doesn't change that; that dependency is just
+yielded from context like any other, not baked into `dependencies`.
 
 ## Single Responsibility
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # TypeScript generated files
 dist/
 dist-lit/
+dist-migration/
 out/
 
 # Logs
@@ -160,4 +161,4 @@ graphify-out/
 .claude/scheduled_tasks.lock
 .claude/auto-build-wi.lock
 .claude/backlog-grooming-*.md
-/.fastcontext
+.fastcontext/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -57,6 +57,7 @@ export default [
       '**/out/**',
       '**/dist/**',
       '**/dist-lit/**',
+      '**/dist-migration/**',
       '**/packages/**/coverage',
       '**/test-workspaces/**',
       '**/*.d.ts',

--- a/package-lock.json
+++ b/package-lock.json
@@ -47121,6 +47121,7 @@
         "@salesforce/soql-language-server": "^1.1.0",
         "@salesforce/soql-model": "*",
         "@salesforce/vscode-i18n": "*",
+        "@salesforce/vscode-services": "*",
         "antlr4ts": "^0.5.0-alpha.3",
         "debounce": "^2.2.0",
         "effect": "^3.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47325,6 +47325,7 @@
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@salesforce/vscode-services": "*",
         "@vscode-elements/elements": "^2.5.1",
         "effect": "^3.21.2",
         "lit": "3.3.3"

--- a/packages/salesforcedx-vscode-services-types/scripts/generateEntry.ts
+++ b/packages/salesforcedx-vscode-services-types/scripts/generateEntry.ts
@@ -26,6 +26,15 @@ const generateEntry = (): void => {
 // This file is auto-generated. Do not edit manually.
 export type { SalesforceVSCodeServicesApi } from '../../salesforcedx-vscode-services/out/src/index';
 export { DefaultOrgInfoSchema } from '../../salesforcedx-vscode-services/out/src/core/schemas/defaultOrgInfo';
+export {
+  ChildRelationshipSchema,
+  PicklistValueSchema,
+  SObjectFieldSchema,
+  SObjectSchema,
+  type ChildRelationship,
+  type SObject,
+  type SObjectField
+} from '../../salesforcedx-vscode-services/out/src/core/schemas/sObject';
 export { ICONS, type IconId } from './icons';
 `;
 

--- a/packages/salesforcedx-vscode-services/src/core/schemas/sObject.ts
+++ b/packages/salesforcedx-vscode-services/src/core/schemas/sObject.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as S from 'effect/Schema';
+
+export const PicklistValueSchema = S.Struct({
+  active: S.Boolean,
+  label: S.NullOr(S.String),
+  value: S.String
+});
+
+export const SObjectFieldSchema = S.Struct({
+  aggregatable: S.Boolean,
+  custom: S.Boolean,
+  defaultValue: S.NullOr(S.Unknown),
+  extraTypeInfo: S.NullOr(S.String),
+  filterable: S.Boolean,
+  groupable: S.Boolean,
+  inlineHelpText: S.NullOr(S.String),
+  label: S.String,
+  length: S.optional(S.Number),
+  name: S.String,
+  nillable: S.Boolean,
+  picklistValues: S.Array(PicklistValueSchema),
+  precision: S.optional(S.Number),
+  referenceTo: S.Array(S.String),
+  relationshipName: S.NullOr(S.String),
+  scale: S.optional(S.Number),
+  sortable: S.Boolean,
+  type: S.String
+});
+
+export const ChildRelationshipSchema = S.Struct({
+  childSObject: S.String,
+  field: S.String,
+  relationshipName: S.NullOr(S.String)
+});
+
+export const SObjectSchema = S.Struct({
+  name: S.String,
+  label: S.String,
+  custom: S.Boolean,
+  queryable: S.Boolean,
+  fields: S.Array(SObjectFieldSchema),
+  childRelationships: S.Array(ChildRelationshipSchema)
+});
+
+export type SObject = S.Schema.Type<typeof SObjectSchema>;
+export type SObjectField = S.Schema.Type<typeof SObjectFieldSchema>;
+export type ChildRelationship = S.Schema.Type<typeof ChildRelationshipSchema>;

--- a/packages/salesforcedx-vscode-services/src/core/transmogrifierService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/transmogrifierService.ts
@@ -8,57 +8,12 @@
 import type { Connection } from '@salesforce/core';
 import * as Effect from 'effect/Effect';
 import * as S from 'effect/Schema';
+import { SObjectSchema, type SObject } from './schemas/sObject';
 
 type RawDescribeSObjectResult = Awaited<ReturnType<Connection['describe']>>;
 
 /** Re-exported raw jsforce describe result for consumer type safety */
 export type DescribeSObjectResult = RawDescribeSObjectResult;
-
-export const PicklistValueSchema = S.Struct({
-  active: S.Boolean,
-  label: S.NullOr(S.String),
-  value: S.String
-});
-
-export const SObjectFieldSchema = S.Struct({
-  aggregatable: S.Boolean,
-  custom: S.Boolean,
-  defaultValue: S.NullOr(S.Unknown),
-  extraTypeInfo: S.NullOr(S.String),
-  filterable: S.Boolean,
-  groupable: S.Boolean,
-  inlineHelpText: S.NullOr(S.String),
-  label: S.String,
-  length: S.optional(S.Number),
-  name: S.String,
-  nillable: S.Boolean,
-  picklistValues: S.Array(PicklistValueSchema),
-  precision: S.optional(S.Number),
-  referenceTo: S.Array(S.String),
-  relationshipName: S.NullOr(S.String),
-  scale: S.optional(S.Number),
-  sortable: S.Boolean,
-  type: S.String
-});
-
-export const ChildRelationshipSchema = S.Struct({
-  childSObject: S.String,
-  field: S.String,
-  relationshipName: S.NullOr(S.String)
-});
-
-export const SObjectSchema = S.Struct({
-  name: S.String,
-  label: S.String,
-  custom: S.Boolean,
-  queryable: S.Boolean,
-  fields: S.Array(SObjectFieldSchema),
-  childRelationships: S.Array(ChildRelationshipSchema)
-});
-
-export type SObject = S.Schema.Type<typeof SObjectSchema>;
-export type SObjectField = S.Schema.Type<typeof SObjectFieldSchema>;
-export type ChildRelationship = S.Schema.Type<typeof ChildRelationshipSchema>;
 
 const mapToSObject = (raw: RawDescribeSObjectResult): SObject => ({
   name: raw.name,

--- a/packages/salesforcedx-vscode-services/src/index.ts
+++ b/packages/salesforcedx-vscode-services/src/index.ts
@@ -251,19 +251,14 @@ export type {
   ListMetadataError,
   SObjectGlobalDescribeItem
 } from './core/metadataDescribeService';
-export type {
-  DescribeSObjectResult,
-  SObject,
-  SObjectField,
-  ChildRelationship,
-  TransmogrifierService
-} from './core/transmogrifierService';
+export type { DescribeSObjectResult, TransmogrifierService } from './core/transmogrifierService';
+export type { SObject, SObjectField, ChildRelationship } from './core/schemas/sObject';
 export {
   SObjectSchema,
   SObjectFieldSchema,
   ChildRelationshipSchema,
   PicklistValueSchema
-} from './core/transmogrifierService';
+} from './core/schemas/sObject';
 export type { ExecuteAnonymousResult } from './core/executeAnonymousService';
 export type { ExecuteAnonymousError } from './errors/executeAnonymousErrors';
 export type { ApexLogBodyFetchError, ApexLogQueryError } from './errors/apexLogErrors';

--- a/packages/salesforcedx-vscode-services/src/orgCatalog/orgMetadataCatalogStore.ts
+++ b/packages/salesforcedx-vscode-services/src/orgCatalog/orgMetadataCatalogStore.ts
@@ -8,7 +8,7 @@
 import * as Effect from 'effect/Effect';
 import * as Schema from 'effect/Schema';
 import { URI, Utils } from 'vscode-uri';
-import { SObjectSchema } from '../core/transmogrifierService';
+import { SObjectSchema } from '../core/schemas/sObject';
 import { FsService } from '../vscode/fsService';
 import { isUriEqualOrWithin, uriPathIncludesSegments } from '../vscode/uriContainment';
 import { WorkspaceService } from '../vscode/workspaceService';

--- a/packages/salesforcedx-vscode-services/src/orgCatalog/orgMetadataCatalogTypes.ts
+++ b/packages/salesforcedx-vscode-services/src/orgCatalog/orgMetadataCatalogTypes.ts
@@ -8,7 +8,7 @@
 import type { OrgMetadataReference } from './orgMetadataReference';
 import * as Schema from 'effect/Schema';
 import { URI } from 'vscode-uri';
-import { SObjectSchema } from '../core/transmogrifierService';
+import { SObjectSchema } from '../core/schemas/sObject';
 
 const UriSchema = Schema.declare((value): value is URI => value instanceof URI, {
   identifier: 'URI',

--- a/packages/salesforcedx-vscode-services/test/jest/orgCatalog/orgMetadataCatalog.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/orgCatalog/orgMetadataCatalog.test.ts
@@ -27,7 +27,8 @@ import { FOLDERED_METADATA_TYPES, MetadataDescribeService } from '../../../src/c
 import { MetadataRegistryService } from '../../../src/core/metadataRegistryService';
 import { MetadataRetrieveService } from '../../../src/core/metadataRetrieveService';
 import { ProjectService } from '../../../src/core/projectService';
-import { TransmogrifierService, type SObject } from '../../../src/core/transmogrifierService';
+import { TransmogrifierService } from '../../../src/core/transmogrifierService';
+import type { SObject } from '../../../src/core/schemas/sObject';
 import { OrgMetadataCatalog } from '../../../src/orgCatalog/orgMetadataCatalog';
 import { OrgCatalogDocuments } from '../../../src/orgCatalog/orgCatalogDocuments';
 import { OrgCatalogInventory } from '../../../src/orgCatalog/orgCatalogInventory';

--- a/packages/salesforcedx-vscode-soql/.vscodeignore
+++ b/packages/salesforcedx-vscode-soql/.vscodeignore
@@ -3,6 +3,7 @@
 .vscode-test-web/**
 .vscode-web/**
 .wireit/**
+.fastcontext/**
 node_modules
 out/**
 src/**

--- a/packages/salesforcedx-vscode-soql/docs/soql-ui-migration-baseline.md
+++ b/packages/salesforcedx-vscode-soql/docs/soql-ui-migration-baseline.md
@@ -70,11 +70,16 @@ npm run test:soql-builder-ui --workspace salesforcedx-vscode-soql -- --runInBand
 
 | Artifact | Baseline raw | Baseline gzip | Maximum raw | Maximum gzip |
 | --- | ---: | ---: | ---: | ---: |
-| Legacy builder application | 880,931 B | 231,443 B | 925,000 B | 242,000 B |
+| Legacy builder application | 933,725 B | 246,879 B | 981,000 B | 260,000 B |
 | Query-results first-party shell | 14,293 B | 4,856 B | 16,000 B | 5,500 B |
 | Retained Tabulator vendor assets | 377,590 B | 80,815 B | 378,000 B | 81,000 B |
 
 Tabulator is measured separately because it is retained. A Lit results PR must not present the vendor bytes as framework growth. Migration builds report legacy and Lit entry sizes independently; production VSIX builds must continue excluding inactive migration entries until final cutover.
+
+PR #8026 advances the legacy-builder baseline from 880,931 raw / 231,443 gzip bytes to 933,725 raw /
+246,879 gzip bytes because message-boundary validation now consumes the complete shared Salesforce object schema. The
+new maximums retain approximately five percent headroom rather than treating that intentional schema coverage as an
+unbounded allowance for future growth.
 
 ## Performance and lifecycle gates
 

--- a/packages/salesforcedx-vscode-soql/esbuild.config.mjs
+++ b/packages/salesforcedx-vscode-soql/esbuild.config.mjs
@@ -13,6 +13,9 @@ import { commonConfigBrowser } from '../../scripts/bundling/web.mjs';
 const require = createRequire(import.meta.url);
 const isLitMigration = process.argv.includes('--lit-migration');
 const soqlBuilderUiSource = isLitMigration ? './src/soql-builder-ui/dist-lit/**' : './src/soql-builder-ui/dist/**';
+// dist-migration keeps the lit-migration bundle from colliding with vscode:bundle's dist/ output
+// so the two wireit tasks never fight over the same declared output path.
+const distDir = isLitMigration ? './dist-migration' : './dist';
 
 const commonConfig = {
   external: ['vscode']
@@ -23,7 +26,7 @@ await build({
   ...nodeConfig,
   ...commonConfig,
   entryPoints: ['./out/src/index.js'],
-  outfile: './dist/index.js',
+  outfile: `${distDir}/index.js`,
   plugins: [
     copy({
       assets: {
@@ -45,7 +48,7 @@ await build({
   ...nodeConfig,
   ...commonConfig,
   entryPoints: [require.resolve('@salesforce/soql-language-server/lib/server.js')],
-  outfile: './dist/server.js'
+  outfile: `${distDir}/server.js`
 });
 
 // Web extension bundle
@@ -57,7 +60,7 @@ await build({
     'vscode-languageclient/node': 'vscode-languageclient/browser'
   },
   entryPoints: ['./out/src/index.js'],
-  outfile: './dist/web/index.js'
+  outfile: `${distDir}/web/index.js`
 });
 
 // Web language server worker bundle
@@ -65,5 +68,5 @@ await build({
   ...commonConfigBrowser,
   format: 'iife', // Workers run as plain browser scripts — no module system, no `exports`
   entryPoints: [require.resolve('@salesforce/soql-language-server/lib/serverWorker.js')],
-  outfile: './dist/serverWorker.js'
+  outfile: `${distDir}/serverWorker.js`
 });

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -267,7 +267,6 @@
       "dependencies": [
         "compile",
         "copy:grammars",
-        "build:soql-builder-lit",
         "test:lit-foundation"
       ],
       "files": [

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -191,9 +191,11 @@
     "test:soql-builder-ui": {
       "command": "jest --config src/soql-builder-ui/jest.config.js",
       "dependencies": [
+        "../soql-builder-ui:compile",
         "../soql-model:compile"
       ],
       "files": [
+        "src/soql-builder-ui/lit/**/*.ts",
         "src/soql-builder-ui/modules/**",
         "src/soql-builder-ui/jest.config.js",
         "src/soql-builder-ui/jestSetup/**",

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -42,6 +42,7 @@
     "@salesforce/soql-model": "*",
     "@salesforce/soql-language-server": "^1.1.0",
     "@salesforce/vscode-i18n": "*",
+    "@salesforce/vscode-services": "*",
     "antlr4ts": "^0.5.0-alpha.3",
     "debounce": "^2.2.0",
     "papaparse": "^5.3.0",
@@ -160,6 +161,7 @@
         "../soql-model:compile"
       ],
       "files": [
+        "../salesforcedx-vscode-services/src/core/schemas/sObject.ts",
         "src/soql-builder-ui/*.{ts,html}",
         "src/soql-builder-ui/modules/**",
         "src/soql-builder-ui/rollup.config.mjs"

--- a/packages/salesforcedx-vscode-soql/package.json
+++ b/packages/salesforcedx-vscode-soql/package.json
@@ -81,7 +81,7 @@
     "compile": "wireit",
     "compile:lit-ui": "wireit",
     "lint": "wireit",
-    "clean": "shx rm -rf node_modules out dist coverage .nyc_output .wireit .eslintcache *.vsix src/soql-builder-ui/dist src/soql-builder-ui/dist-lit src/soql-builder-ui/node_modules .circular-deps.json",
+    "clean": "shx rm -rf node_modules out dist dist-migration coverage .nyc_output .wireit .eslintcache *.vsix src/soql-builder-ui/dist src/soql-builder-ui/dist-lit src/soql-builder-ui/node_modules .circular-deps.json",
     "copy:grammars": "wireit",
     "build:soql-builder-ui": "wireit",
     "build:soql-builder-lit": "wireit",
@@ -278,7 +278,7 @@
         "src/soql-data-view/**"
       ],
       "output": [
-        "dist"
+        "dist-migration"
       ]
     },
     "vscode:bundle:local": {
@@ -427,11 +427,12 @@
       ]
     },
     "vscode:package:migration": {
-      "command": "vsce package --allow-package-all-secrets --out salesforcedx-vscode-soql-lit-migration.vsix",
+      "command": "node scripts/package-lit-migration.mjs",
       "dependencies": [
         "vscode:bundle:migration"
       ],
       "files": [
+        "scripts/package-lit-migration.mjs",
         ".vscodeignore",
         "package.json",
         "package.nls*.json",

--- a/packages/salesforcedx-vscode-soql/scripts/package-lit-migration.mjs
+++ b/packages/salesforcedx-vscode-soql/scripts/package-lit-migration.mjs
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// vscode:bundle:migration writes to dist-migration/ (not dist/) so its wireit output never collides
+// with vscode:bundle's dist/ output. package.json's main/browser fields are static and shared by every
+// `vsce package` invocation, so they're swapped to dist-migration/ paths here for just this packaging
+// run, then restored, rather than baked in permanently.
+const packageJsonPath = fileURLToPath(new URL('../package.json', import.meta.url));
+const original = readFileSync(packageJsonPath, 'utf8');
+const manifest = JSON.parse(original);
+manifest.main = 'dist-migration/index.js';
+manifest.browser = 'dist-migration/web/index.js';
+writeFileSync(packageJsonPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+try {
+  execFileSync(
+    'vsce',
+    ['package', '--allow-package-all-secrets', '--out', 'salesforcedx-vscode-soql-lit-migration.vsix'],
+    { stdio: 'inherit' }
+  );
+} finally {
+  writeFileSync(packageJsonPath, original);
+}

--- a/packages/salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts
+++ b/packages/salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts
@@ -59,6 +59,7 @@ type SoqlEditorEvent =
   | {
       type: 'sobject_metadata_request';
       payload: string;
+      requestId?: string;
     }
   | {
       type: 'sobject_metadata_response';
@@ -67,6 +68,7 @@ type SoqlEditorEvent =
   | {
       type: 'sobjects_request';
       payload: never;
+      requestId?: string;
     }
   | {
       type: 'run_query';
@@ -136,8 +138,8 @@ export class SOQLEditorInstance {
     webviewPanel.onDidDispose(this.dispose, this, this.subscriptions);
   }
 
-  protected sendMessageToUi(type: MessageType, payload?: string | string[] | SObject) {
-    return Effect.promise<boolean>(() => this.webviewPanel.webview.postMessage({ type, payload })).pipe(
+  protected sendMessageToUi(type: MessageType, payload?: string | string[] | SObject, requestId?: string) {
+    return Effect.promise<boolean>(() => this.webviewPanel.webview.postMessage({ type, payload, requestId })).pipe(
       Effect.asVoid,
       Effect.catchAllCause(cause =>
         appendToChannel(nls.localize('error_unknown_error', 'web_view_post_message')).pipe(
@@ -157,12 +159,12 @@ export class SOQLEditorInstance {
     });
   }
 
-  protected updateSObjects(sobjectNames: string[]) {
-    return this.sendMessageToUi('sobjects_response', sobjectNames);
+  protected updateSObjects(sobjectNames: string[], requestId?: string) {
+    return this.sendMessageToUi('sobjects_response', sobjectNames, requestId);
   }
 
-  protected updateSObjectMetadata(sobject: SObject) {
-    return this.sendMessageToUi('sobject_metadata_response', sobject);
+  protected updateSObjectMetadata(sobject: SObject, requestId?: string) {
+    return this.sendMessageToUi('sobject_metadata_response', sobject, requestId);
   }
 
   protected onDocumentChangeHandler(e: vscode.TextDocumentChangeEvent): void {
@@ -202,14 +204,14 @@ export class SOQLEditorInstance {
 
       case 'sobject_metadata_request':
         return retrieveSObject(event.payload).pipe(
-          Effect.flatMap(sobject => (sobject ? this.updateSObjectMetadata(sobject) : Effect.void)),
+          Effect.flatMap(sobject => (sobject ? this.updateSObjectMetadata(sobject, event.requestId) : Effect.void)),
           Effect.catchAll(() => appendToChannel(nls.localize('error_sobject_metadata_request', event.payload))),
           Effect.withSpan('SOQLEditor.sobject_metadata_request', { attributes: { sobjectName: event.payload } })
         );
 
       case 'sobjects_request':
         return listSObjectNamesEffect.pipe(
-          Effect.flatMap(names => (names ? this.updateSObjects(names) : Effect.void)),
+          Effect.flatMap(names => (names ? this.updateSObjects(names, event.requestId) : Effect.void)),
           Effect.catchAll(() => appendToChannel(nls.localize('error_sobjects_request'))),
           Effect.withSpan('SOQLEditor.sobjects_request')
         );

--- a/packages/salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts
+++ b/packages/salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import type { MessageType } from '../soql-builder-ui/modules/querybuilder/services/message/soqlEditorEvent';
+import type { MessageType, RequestId } from '../soql-builder-ui/modules/querybuilder/services/message/soqlEditorEvent';
 import type { QueryResult } from '../types';
 import { ExtensionProviderService, getServicesApi } from '@salesforce/effect-ext-utils';
 import type { JsonMap } from '@salesforce/ts-types';
@@ -59,7 +59,7 @@ type SoqlEditorEvent =
   | {
       type: 'sobject_metadata_request';
       payload: string;
-      requestId?: string;
+      requestId?: RequestId;
     }
   | {
       type: 'sobject_metadata_response';
@@ -68,7 +68,7 @@ type SoqlEditorEvent =
   | {
       type: 'sobjects_request';
       payload: never;
-      requestId?: string;
+      requestId?: RequestId;
     }
   | {
       type: 'run_query';
@@ -138,7 +138,7 @@ export class SOQLEditorInstance {
     webviewPanel.onDidDispose(this.dispose, this, this.subscriptions);
   }
 
-  protected sendMessageToUi(type: MessageType, payload?: string | string[] | SObject, requestId?: string) {
+  protected sendMessageToUi(type: MessageType, payload?: string | string[] | SObject, requestId?: RequestId) {
     return Effect.promise<boolean>(() => this.webviewPanel.webview.postMessage({ type, payload, requestId })).pipe(
       Effect.asVoid,
       Effect.catchAllCause(cause =>
@@ -159,11 +159,11 @@ export class SOQLEditorInstance {
     });
   }
 
-  protected updateSObjects(sobjectNames: string[], requestId?: string) {
+  protected updateSObjects(sobjectNames: string[], requestId?: RequestId) {
     return this.sendMessageToUi('sobjects_response', sobjectNames, requestId);
   }
 
-  protected updateSObjectMetadata(sobject: SObject, requestId?: string) {
+  protected updateSObjectMetadata(sobject: SObject, requestId?: RequestId) {
     return this.sendMessageToUi('sobject_metadata_response', sobject, requestId);
   }
 

--- a/packages/salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts
+++ b/packages/salesforcedx-vscode-soql/src/editor/soqlEditorInstance.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import type { MessageType, RequestId } from '../soql-builder-ui/modules/querybuilder/services/message/soqlEditorEvent';
+import type { MessageType } from '../soql-builder-ui/modules/querybuilder/services/message/soqlEditorEvent';
 import type { QueryResult } from '../types';
 import { ExtensionProviderService, getServicesApi } from '@salesforce/effect-ext-utils';
 import type { JsonMap } from '@salesforce/ts-types';
@@ -59,7 +59,6 @@ type SoqlEditorEvent =
   | {
       type: 'sobject_metadata_request';
       payload: string;
-      requestId?: RequestId;
     }
   | {
       type: 'sobject_metadata_response';
@@ -68,7 +67,6 @@ type SoqlEditorEvent =
   | {
       type: 'sobjects_request';
       payload: never;
-      requestId?: RequestId;
     }
   | {
       type: 'run_query';
@@ -138,8 +136,8 @@ export class SOQLEditorInstance {
     webviewPanel.onDidDispose(this.dispose, this, this.subscriptions);
   }
 
-  protected sendMessageToUi(type: MessageType, payload?: string | string[] | SObject, requestId?: RequestId) {
-    return Effect.promise<boolean>(() => this.webviewPanel.webview.postMessage({ type, payload, requestId })).pipe(
+  protected sendMessageToUi(type: MessageType, payload?: string | string[] | SObject) {
+    return Effect.promise<boolean>(() => this.webviewPanel.webview.postMessage({ type, payload })).pipe(
       Effect.asVoid,
       Effect.catchAllCause(cause =>
         appendToChannel(nls.localize('error_unknown_error', 'web_view_post_message')).pipe(
@@ -159,12 +157,12 @@ export class SOQLEditorInstance {
     });
   }
 
-  protected updateSObjects(sobjectNames: string[], requestId?: RequestId) {
-    return this.sendMessageToUi('sobjects_response', sobjectNames, requestId);
+  protected updateSObjects(sobjectNames: string[]) {
+    return this.sendMessageToUi('sobjects_response', sobjectNames);
   }
 
-  protected updateSObjectMetadata(sobject: SObject, requestId?: RequestId) {
-    return this.sendMessageToUi('sobject_metadata_response', sobject, requestId);
+  protected updateSObjectMetadata(sobject: SObject) {
+    return this.sendMessageToUi('sobject_metadata_response', sobject);
   }
 
   protected onDocumentChangeHandler(e: vscode.TextDocumentChangeEvent): void {
@@ -204,14 +202,14 @@ export class SOQLEditorInstance {
 
       case 'sobject_metadata_request':
         return retrieveSObject(event.payload).pipe(
-          Effect.flatMap(sobject => (sobject ? this.updateSObjectMetadata(sobject, event.requestId) : Effect.void)),
+          Effect.flatMap(sobject => (sobject ? this.updateSObjectMetadata(sobject) : Effect.void)),
           Effect.catchAll(() => appendToChannel(nls.localize('error_sobject_metadata_request', event.payload))),
           Effect.withSpan('SOQLEditor.sobject_metadata_request', { attributes: { sobjectName: event.payload } })
         );
 
       case 'sobjects_request':
         return listSObjectNamesEffect.pipe(
-          Effect.flatMap(names => (names ? this.updateSObjects(names, event.requestId) : Effect.void)),
+          Effect.flatMap(names => (names ? this.updateSObjects(names) : Effect.void)),
           Effect.catchAll(() => appendToChannel(nls.localize('error_sobjects_request'))),
           Effect.withSpan('SOQLEditor.sobjects_request')
         );

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/lit/soqlBuilderModelAdapter.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/lit/soqlBuilderModelAdapter.ts
@@ -124,7 +124,7 @@ export const parseSoqlBuilderQuery = (statement: string): SoqlBuilderQuery => {
     ...(model.headerComments ? { headerComments: model.headerComments.text } : {}),
     allRows: model.allRows ?? false,
     fields,
-    limit: model.limit ? String(model.limit.limit) : '',
+    ...(model.limit ? { limit: String(model.limit.limit) } : {}),
     orderBy: (model.orderBy?.orderByExpressions ?? []).flatMap(expression =>
       expression.field instanceof FieldRefImpl && !SoqlModelUtils.containsUnmodeledSyntax(expression)
         ? [
@@ -138,7 +138,7 @@ export const parseSoqlBuilderQuery = (statement: string): SoqlBuilderQuery => {
     ),
     originalSoqlStatement: statement,
     parseErrors: (model.errors ?? []).map(error => ({ ...error })),
-    sObject: model.from?.sobjectName ?? '',
+    ...(model.from?.sobjectName ? { sObject: model.from.sobjectName } : {}),
     unsupportedSyntax,
     where: {
       ...(whereGroup?.andOr ? { andOr: whereGroup.andOr } : {}),
@@ -198,12 +198,12 @@ const buildQueryModel = (query: SoqlBuilderQuery): Query => {
   );
   const model = new QueryImpl(
     select,
-    new FromImpl(query.sObject),
+    new FromImpl(query.sObject ?? ''),
     where,
     undefined,
     undefined,
     orderByExpressions.length > 0 ? new OrderByImpl(orderByExpressions) : undefined,
-    query.limit.length > 0 ? new LimitImpl(Number(query.limit)) : undefined
+    query.limit !== undefined ? new LimitImpl(Number(query.limit)) : undefined
   );
   if (query.headerComments) model.headerComments = new HeaderCommentsImpl(query.headerComments);
   model.allRows = query.allRows;
@@ -218,11 +218,6 @@ export const createSoqlBuilderTelemetry = (query: SoqlBuilderQuery) => ({
   fields: query.fields.length,
   limit: query.limit,
   orderBy: query.orderBy.length,
-  sObject: query.sObject.includes('__c') ? 'custom' : 'standard',
-  unsupported: query.unsupportedSyntax.map(unsupported => {
-    const reason = unsupported.reason;
-    return typeof reason === 'object' && reason !== null && 'reasonCode' in reason
-      ? String(reason.reasonCode)
-      : 'unknown';
-  })
+  sObject: query.sObject?.includes('__c') ? 'custom' : 'standard',
+  unsupported: query.unsupportedSyntax.map(unsupported => unsupported.reason.reasonCode)
 });

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/lit/soqlBuilderModelAdapter.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/lit/soqlBuilderModelAdapter.ts
@@ -124,7 +124,7 @@ export const parseSoqlBuilderQuery = (statement: string): SoqlBuilderQuery => {
     ...(model.headerComments ? { headerComments: model.headerComments.text } : {}),
     allRows: model.allRows ?? false,
     fields,
-    ...(model.limit ? { limit: String(model.limit.limit) } : {}),
+    limit: model.limit ? { _tag: 'Valid', value: model.limit.limit } : { _tag: 'Empty' },
     orderBy: (model.orderBy?.orderByExpressions ?? []).flatMap(expression =>
       expression.field instanceof FieldRefImpl && !SoqlModelUtils.containsUnmodeledSyntax(expression)
         ? [
@@ -203,7 +203,7 @@ const buildQueryModel = (query: SoqlBuilderQuery): Query => {
     undefined,
     undefined,
     orderByExpressions.length > 0 ? new OrderByImpl(orderByExpressions) : undefined,
-    query.limit !== undefined ? new LimitImpl(Number(query.limit)) : undefined
+    query.limit._tag === 'Valid' ? new LimitImpl(query.limit.value) : undefined
   );
   if (query.headerComments) model.headerComments = new HeaderCommentsImpl(query.headerComments);
   model.allRows = query.allRows;
@@ -216,7 +216,7 @@ export const serializeSoqlBuilderQuery = (query: SoqlBuilderQuery): string =>
 export const createSoqlBuilderTelemetry = (query: SoqlBuilderQuery) => ({
   errors: query.parseErrors.map(error => `${String(error.type)}:${String(error.grammarRule)}`),
   fields: query.fields.length,
-  limit: query.limit,
+  limit: query.limit._tag === 'Valid' ? query.limit.value : undefined,
   orderBy: query.orderBy.length,
   sObject: query.sObject?.includes('__c') ? 'custom' : 'standard',
   unsupported: query.unsupportedSyntax.map(unsupported => unsupported.reason.reasonCode)

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/lit/soqlBuilderModelAdapter.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/lit/soqlBuilderModelAdapter.ts
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import type {
+  SoqlBuilderQuery,
+  SoqlLiteral,
+  SoqlWhereCondition
+} from '@salesforce/soql-builder-ui/domain';
+import {
+  AndOr,
+  ConditionOperator,
+  deserialize,
+  FieldCompareConditionImpl,
+  FieldRefImpl,
+  FieldSelectionImpl,
+  FromImpl,
+  HeaderCommentsImpl,
+  IncludesConditionImpl,
+  InListConditionImpl,
+  LimitImpl,
+  LiteralImpl,
+  ModelSerializer,
+  NullsOrder,
+  Order,
+  OrderByExpressionImpl,
+  OrderByImpl,
+  QueryImpl,
+  SelectCountImpl,
+  SelectExprsImpl,
+  SoqlModelUtils,
+  WhereImpl,
+  type Condition,
+  type Query
+} from '@salesforce/soql-model';
+
+const literalFromModel = (literal: unknown): SoqlLiteral | undefined =>
+  literal instanceof LiteralImpl
+    ? { kind: 'literal', type: literal.type, value: literal.value }
+    : undefined;
+
+const conditionFromModel = (condition: Condition, index: number): SoqlWhereCondition | undefined => {
+  if (condition instanceof FieldCompareConditionImpl) {
+    if (!(condition.field instanceof FieldRefImpl)) return undefined;
+    const compareValue = literalFromModel(condition.compareValue);
+    return compareValue
+      ? {
+          condition: {
+            compareValue,
+            field: { fieldName: condition.field.fieldName, kind: 'fieldRef' },
+            kind: 'fieldCompare',
+            operator: condition.operator
+          },
+          index
+        }
+      : undefined;
+  }
+
+  if (condition instanceof InListConditionImpl || condition instanceof IncludesConditionImpl) {
+    if (!(condition.field instanceof FieldRefImpl)) return undefined;
+    const values = condition.values.map(literalFromModel);
+    if (values.includes(undefined)) return undefined;
+    return {
+      condition: {
+        field: { fieldName: condition.field.fieldName, kind: 'fieldRef' },
+        kind: condition.kind,
+        operator: condition.operator,
+        values: values.filter((value): value is SoqlLiteral => value !== undefined)
+      },
+      index
+    };
+  }
+
+  return undefined;
+};
+
+const conditionOperators: Readonly<Record<SoqlWhereCondition['condition']['operator'], ConditionOperator>> = {
+  '=': ConditionOperator.Equals,
+  '!=': ConditionOperator.NotEquals,
+  '<>': ConditionOperator.AlternateNotEquals,
+  '<=': ConditionOperator.LessThanOrEqual,
+  '>=': ConditionOperator.GreaterThanOrEqual,
+  '<': ConditionOperator.LessThan,
+  '>': ConditionOperator.GreaterThan,
+  LIKE: ConditionOperator.Like,
+  IN: ConditionOperator.In,
+  'NOT IN': ConditionOperator.NotIn,
+  INCLUDES: ConditionOperator.Includes,
+  EXCLUDES: ConditionOperator.Excludes
+};
+
+export const parseSoqlBuilderQuery = (statement: string): SoqlBuilderQuery => {
+  const model = deserialize(statement);
+  const fields =
+    model.select instanceof SelectExprsImpl
+      ? model.select.selectExpressions.flatMap(expression =>
+          expression instanceof FieldSelectionImpl && expression.field instanceof FieldRefImpl
+            ? [expression.field.fieldName]
+            : []
+        )
+      : model.select?.kind === 'selectCount'
+        ? ['COUNT()']
+        : [];
+  const whereGroup =
+    model.where?.condition && !SoqlModelUtils.containsUnmodeledSyntax(model.where.condition)
+      ? SoqlModelUtils.simpleGroupToArray(model.where.condition)
+      : undefined;
+  const conditions = (whereGroup?.conditions ?? []).flatMap((condition, index) => {
+    const mapped = conditionFromModel(condition, index);
+    return mapped ? [mapped] : [];
+  });
+  const unsupportedSyntax = SoqlModelUtils.getUnmodeledSyntax(model).map(unsupported => ({
+    reason: {
+      message: unsupported.reason.message,
+      reasonCode: unsupported.reason.reasonCode
+    },
+    unmodeledSyntax: unsupported.unmodeledSyntax
+  }));
+
+  return {
+    ...(model.headerComments ? { headerComments: model.headerComments.text } : {}),
+    allRows: model.allRows ?? false,
+    fields,
+    limit: model.limit ? String(model.limit.limit) : '',
+    orderBy: (model.orderBy?.orderByExpressions ?? []).flatMap(expression =>
+      expression.field instanceof FieldRefImpl && !SoqlModelUtils.containsUnmodeledSyntax(expression)
+        ? [
+            {
+              field: expression.field.fieldName,
+              ...(expression.order ? { order: expression.order } : {}),
+              ...(expression.nullsOrder ? { nulls: expression.nullsOrder } : {})
+            }
+          ]
+        : []
+    ),
+    originalSoqlStatement: statement,
+    parseErrors: (model.errors ?? []).map(error => ({ ...error })),
+    sObject: model.from?.sobjectName ?? '',
+    unsupportedSyntax,
+    where: {
+      ...(whereGroup?.andOr ? { andOr: whereGroup.andOr } : {}),
+      conditions
+    }
+  };
+};
+
+const conditionToModel = (whereCondition: SoqlWhereCondition): Condition | undefined => {
+  const field = new FieldRefImpl(whereCondition.condition.field.fieldName);
+  if (whereCondition.condition.compareValue) {
+    const value = whereCondition.condition.compareValue;
+    return new FieldCompareConditionImpl(
+      field,
+      conditionOperators[whereCondition.condition.operator],
+      new LiteralImpl(value.type, value.value)
+    );
+  }
+  if (whereCondition.condition.values) {
+    const values = whereCondition.condition.values.map(value => new LiteralImpl(value.type, value.value));
+    return whereCondition.condition.kind === 'includes'
+      ? new IncludesConditionImpl(field, conditionOperators[whereCondition.condition.operator], values)
+      : new InListConditionImpl(field, conditionOperators[whereCondition.condition.operator], values);
+  }
+  return undefined;
+};
+
+const buildQueryModel = (query: SoqlBuilderQuery): Query => {
+  const isCount = query.fields.length === 1 && query.fields[0].toUpperCase() === 'COUNT()';
+  const select = isCount
+    ? new SelectCountImpl()
+    : new SelectExprsImpl(query.fields.map(field => new FieldSelectionImpl(new FieldRefImpl(field))));
+  const conditions = query.where.conditions.flatMap(condition => {
+    const mapped = conditionToModel(condition);
+    return mapped ? [mapped] : [];
+  });
+  const where =
+    conditions.length > 0
+      ? new WhereImpl(
+          SoqlModelUtils.arrayToSimpleGroup(
+            conditions,
+            query.where.andOr === 'AND' ? AndOr.And : query.where.andOr === 'OR' ? AndOr.Or : undefined
+          )
+        )
+      : undefined;
+  const orderByExpressions = query.orderBy.map(
+    item =>
+      new OrderByExpressionImpl(
+        new FieldRefImpl(item.field),
+        item.order === 'ASC' ? Order.Ascending : item.order === 'DESC' ? Order.Descending : undefined,
+        item.nulls === 'NULLS FIRST'
+          ? NullsOrder.First
+          : item.nulls === 'NULLS LAST'
+            ? NullsOrder.Last
+            : undefined
+      )
+  );
+  const model = new QueryImpl(
+    select,
+    new FromImpl(query.sObject),
+    where,
+    undefined,
+    undefined,
+    orderByExpressions.length > 0 ? new OrderByImpl(orderByExpressions) : undefined,
+    query.limit.length > 0 ? new LimitImpl(Number(query.limit)) : undefined
+  );
+  if (query.headerComments) model.headerComments = new HeaderCommentsImpl(query.headerComments);
+  model.allRows = query.allRows;
+  return model;
+};
+
+export const serializeSoqlBuilderQuery = (query: SoqlBuilderQuery): string =>
+  new ModelSerializer(buildQueryModel(query)).serialize();
+
+export const createSoqlBuilderTelemetry = (query: SoqlBuilderQuery) => ({
+  errors: query.parseErrors.map(error => `${String(error.type)}:${String(error.grammarRule)}`),
+  fields: query.fields.length,
+  limit: query.limit,
+  orderBy: query.orderBy.length,
+  sObject: query.sObject.includes('__c') ? 'custom' : 'standard',
+  unsupported: query.unsupportedSyntax.map(unsupported => {
+    const reason = unsupported.reason;
+    return typeof reason === 'object' && reason !== null && 'reasonCode' in reason
+      ? String(reason.reasonCode)
+      : 'unknown';
+  })
+});

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/lit/vscodeSoqlBuilderService.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/lit/vscodeSoqlBuilderService.ts
@@ -6,7 +6,8 @@
  */
 
 import {
-  SoqlBuilderServiceError,
+  SoqlBuilderMessageChannelError,
+  SoqlBuilderQueryError,
   SoqlBuilderStateSchema,
   createInitialSoqlBuilderQuery,
   createInitialSoqlBuilderState,
@@ -36,7 +37,9 @@ import {
 } from '../modules/querybuilder/services/message/iMessageService';
 import {
   MessageType,
-  type HostToUiSoqlEditorEvent
+  RequestIdSchema,
+  type HostToUiSoqlEditorEvent,
+  type RequestId
 } from '../modules/querybuilder/services/message/soqlEditorEvent';
 import {
   createSoqlBuilderTelemetry,
@@ -44,31 +47,26 @@ import {
   serializeSoqlBuilderQuery
 } from './soqlBuilderModelAdapter';
 
-type ServiceOperation = ServiceError['operation'];
-
-const toServiceError = (operation: ServiceOperation, error: unknown): ServiceError =>
-  new SoqlBuilderServiceError({
-    details: String(error),
-    operation
-  });
-
-const tryServiceOperation = <A>(operation: ServiceOperation, evaluate: () => A) =>
+const trySendMessage = <A>(evaluate: () => A) =>
   Effect.try({
     try: evaluate,
-    catch: error => toServiceError(operation, error)
+    catch: error => new SoqlBuilderMessageChannelError({ details: String(error) })
+  });
+
+const tryQueryOperation = <A>(evaluate: () => A) =>
+  Effect.try({
+    try: evaluate,
+    catch: error => new SoqlBuilderQueryError({ details: String(error) })
   });
 
 const toObjectMetadata = (names: readonly string[]) =>
   names.map(name => ({ label: name, name, queryable: true }));
 
-const validateMetadata = (metadata: unknown) =>
-  decodeSoqlBuilderMetadata(metadata).pipe(Effect.mapError(error => toServiceError('subscribe', error)));
+const validateMetadata = (metadata: unknown) => decodeSoqlBuilderMetadata(metadata);
 
-const parseExternalQuery = (statement: string) =>
-  tryServiceOperation('subscribe', () => parseSoqlBuilderQuery(statement));
+const parseExternalQuery = (statement: string) => tryQueryOperation(() => parseSoqlBuilderQuery(statement));
 
-const serializeQuery = (query: SoqlBuilderQuery) =>
-  tryServiceOperation('dispatch', () => serializeSoqlBuilderQuery(query));
+const serializeQuery = (query: SoqlBuilderQuery) => tryQueryOperation(() => serializeSoqlBuilderQuery(query));
 
 const decodeSavedState = (input: unknown) =>
   Schema.decodeUnknown(SoqlBuilderStateSchema)(input).pipe(
@@ -91,11 +89,11 @@ const decodeSavedState = (input: unknown) =>
         Effect.map(query => ({ ...createInitialSoqlBuilderState(), query }))
       )
     ),
-    Effect.mapError(error => toServiceError('initialize', error))
+    Effect.mapError(error => new SoqlBuilderQueryError({ details: String(error) }))
   );
 
 const saveViewState = (messageService: IMessageService, state: SoqlBuilderState) =>
-  tryServiceOperation('dispatch', () => messageService.setState(state));
+  trySendMessage(() => messageService.setState(state));
 
 const makeVscodeSoqlBuilderService = Effect.gen(function* () {
   const messageService = yield* MessageService;
@@ -107,8 +105,8 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
   const errors = yield* PubSub.unbounded<ServiceError>();
 
   const requestSequence = yield* Ref.make(0);
-  const activeMetadataRequestId = yield* Ref.make<Option.Option<string>>(Option.none());
-  const activeObjectsRequestId = yield* Ref.make<Option.Option<string>>(Option.none());
+  const activeMetadataRequestId = yield* Ref.make<Option.Option<RequestId>>(Option.none());
+  const activeObjectsRequestId = yield* Ref.make<Option.Option<RequestId>>(Option.none());
 
   const removeMessageListener = messageService.onMessage(event => {
     messages.unsafeOffer(event);
@@ -121,29 +119,20 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
   );
 
   const reportMessageError = <A>(handler: Effect.Effect<A, ServiceError>) =>
-    handler.pipe(
-      Effect.catchTag('SoqlBuilderServiceError', error => PubSub.publish(errors, error).pipe(Effect.asVoid))
-    );
+    handler.pipe(Effect.catchAll(error => PubSub.publish(errors, error).pipe(Effect.asVoid)));
 
-  const requestObjects = Effect.fn('VscodeSoqlBuilderService.requestObjects')(function* (
-    operation: ServiceOperation
-  ) {
+  const requestObjects = Effect.fn('VscodeSoqlBuilderService.requestObjects')(function* () {
     const sequence = yield* Ref.updateAndGet(requestSequence, current => current + 1);
-    const requestId = `objects-${sequence}`;
+    const requestId = yield* Schema.decode(RequestIdSchema)(`objects-${sequence}`).pipe(Effect.orDie);
     yield* Ref.set(activeObjectsRequestId, Option.some(requestId));
-    yield* tryServiceOperation(operation, () =>
-      messageService.sendMessage({ type: MessageType.SOBJECTS_REQUEST, requestId })
-    );
+    yield* trySendMessage(() => messageService.sendMessage({ type: MessageType.SOBJECTS_REQUEST, requestId }));
   });
 
-  const requestMetadata = Effect.fn('VscodeSoqlBuilderService.requestMetadata')(function* (
-    objectName: string,
-    operation: ServiceOperation
-  ) {
+  const requestMetadata = Effect.fn('VscodeSoqlBuilderService.requestMetadata')(function* (objectName: string) {
     const sequence = yield* Ref.updateAndGet(requestSequence, current => current + 1);
-    const requestId = `metadata-${sequence}`;
+    const requestId = yield* Schema.decode(RequestIdSchema)(`metadata-${sequence}`).pipe(Effect.orDie);
     yield* Ref.set(activeMetadataRequestId, Option.some(requestId));
-    yield* tryServiceOperation(operation, () =>
+    yield* trySendMessage(() =>
       messageService.sendMessage({
         payload: objectName,
         requestId,
@@ -169,7 +158,7 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
         }
       };
       yield* SubscriptionRef.set(state, nextState);
-      yield* tryServiceOperation('dispatch', () =>
+      yield* trySendMessage(() =>
         messageService.sendMessage({
           payload: originalSoqlStatement,
           type: MessageType.UI_SOQL_CHANGED
@@ -184,8 +173,8 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
 
   const handleMessage = Match.type<HostToUiSoqlEditorEvent>().pipe(
     Match.discriminatorsExhaustive('type')({
-      [MessageType.SOBJECTS_RESPONSE]: event =>
-        Effect.gen(function* () {
+      [MessageType.SOBJECTS_RESPONSE]: Effect.fn('VscodeSoqlBuilderService.handleSObjectsResponse')(
+        function* (event) {
           const activeRequestId = yield* Ref.get(activeObjectsRequestId);
           if (Option.getOrUndefined(activeRequestId) !== event.requestId) return;
           const current = yield* SubscriptionRef.get(state);
@@ -194,23 +183,25 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
             objects: toObjectMetadata(event.payload)
           });
           yield* SubscriptionRef.set(state, { ...current, isObjectsLoading: false, metadata });
-        }),
-      [MessageType.SOBJECT_METADATA_RESPONSE]: event =>
-        Effect.gen(function* () {
-          const activeRequestId = yield* Ref.get(activeMetadataRequestId);
-          if (Option.getOrUndefined(activeRequestId) !== event.requestId) return;
-          const current = yield* SubscriptionRef.get(state);
-          if (event.payload.name !== current.query.sObject) return;
-          const metadata = yield* validateMetadata({
-            childRelationships: event.payload.childRelationships,
-            fields: event.payload.fields,
-            objects: current.metadata.objects,
-            selectedObjectName: event.payload.name
-          });
-          yield* SubscriptionRef.set(state, { ...current, isFieldsLoading: false, metadata });
-        }),
-      [MessageType.TEXT_SOQL_CHANGED]: event =>
-        Effect.gen(function* () {
+        }
+      ),
+      [MessageType.SOBJECT_METADATA_RESPONSE]: Effect.fn(
+        'VscodeSoqlBuilderService.handleSObjectMetadataResponse'
+      )(function* (event) {
+        const activeRequestId = yield* Ref.get(activeMetadataRequestId);
+        if (Option.getOrUndefined(activeRequestId) !== event.requestId) return;
+        const current = yield* SubscriptionRef.get(state);
+        if (event.payload.name !== current.query.sObject) return;
+        const metadata = yield* validateMetadata({
+          childRelationships: event.payload.childRelationships,
+          fields: event.payload.fields,
+          objects: current.metadata.objects,
+          selectedObjectName: event.payload.name
+        });
+        yield* SubscriptionRef.set(state, { ...current, isFieldsLoading: false, metadata });
+      }),
+      [MessageType.TEXT_SOQL_CHANGED]: Effect.fn('VscodeSoqlBuilderService.handleTextSoqlChanged')(
+        function* (event) {
           const current = yield* SubscriptionRef.get(state);
           if (event.payload === current.query.originalSoqlStatement) return;
 
@@ -218,7 +209,7 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
           const objectChanged = query.sObject !== current.query.sObject;
           const nextState: SoqlBuilderState = {
             ...current,
-            isFieldsLoading: query.sObject.length > 0 && objectChanged,
+            isFieldsLoading: query.sObject !== undefined && objectChanged,
             metadata: objectChanged
               ? {
                   childRelationships: [],
@@ -233,31 +224,33 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
           yield* saveViewState(messageService, nextState);
 
           if (query.parseErrors.length > 0 || query.unsupportedSyntax.length > 0) {
-            yield* tryServiceOperation('subscribe', () =>
+            yield* trySendMessage(() =>
               messageService.sendMessage({
                 payload: createSoqlBuilderTelemetry(query),
                 type: MessageType.UI_TELEMETRY
               })
             );
           }
-          if (query.sObject.length > 0 && objectChanged) {
-            yield* requestMetadata(query.sObject, 'subscribe');
+          if (query.sObject !== undefined && objectChanged) {
+            yield* requestMetadata(query.sObject);
           }
-        }),
-      [MessageType.NO_DEFAULT_ORG]: () =>
-        SubscriptionRef.update(state, current => ({
+        }
+      ),
+      [MessageType.NO_DEFAULT_ORG]: Effect.fn('VscodeSoqlBuilderService.handleNoDefaultOrg')(function* () {
+        yield* SubscriptionRef.update(state, current => ({
           ...current,
           hasNoDefaultOrg: true,
           isFieldsLoading: false,
           isObjectsLoading: false
-        })),
-      [MessageType.CONNECTION_CHANGED]: () =>
-        Effect.gen(function* () {
+        }));
+      }),
+      [MessageType.CONNECTION_CHANGED]: Effect.fn('VscodeSoqlBuilderService.handleConnectionChanged')(
+        function* () {
           const current = yield* SubscriptionRef.get(state);
           const nextState: SoqlBuilderState = {
             ...current,
             hasNoDefaultOrg: false,
-            isFieldsLoading: current.query.sObject.length > 0,
+            isFieldsLoading: current.query.sObject !== undefined,
             isObjectsLoading: true,
             metadata: {
               childRelationships: [],
@@ -266,15 +259,22 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
             }
           };
           yield* SubscriptionRef.set(state, nextState);
-          yield* requestObjects('subscribe');
-          if (current.query.sObject.length > 0) {
-            yield* requestMetadata(current.query.sObject, 'subscribe');
+          yield* requestObjects();
+          if (current.query.sObject !== undefined) {
+            yield* requestMetadata(current.query.sObject);
           }
-        }),
-      [MessageType.RUN_SOQL_QUERY_DONE]: () =>
-        SubscriptionRef.update(state, current => ({ ...current, isQueryRunning: false })),
-      [MessageType.GET_QUERY_PLAN_DONE]: () =>
-        SubscriptionRef.update(state, current => ({ ...current, isQueryPlanRunning: false }))
+        }
+      ),
+      [MessageType.RUN_SOQL_QUERY_DONE]: Effect.fn('VscodeSoqlBuilderService.handleRunSoqlQueryDone')(
+        function* () {
+          yield* SubscriptionRef.update(state, current => ({ ...current, isQueryRunning: false }));
+        }
+      ),
+      [MessageType.GET_QUERY_PLAN_DONE]: Effect.fn('VscodeSoqlBuilderService.handleGetQueryPlanDone')(
+        function* () {
+          yield* SubscriptionRef.update(state, current => ({ ...current, isQueryPlanRunning: false }));
+        }
+      )
     })
   );
 
@@ -284,43 +284,45 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
   );
 
   yield* SubscriptionRef.update(state, current => ({ ...current, isObjectsLoading: true }));
-  yield* requestObjects('initialize');
-  if (savedState.query.sObject.length > 0) {
+  yield* requestObjects();
+  if (savedState.query.sObject !== undefined) {
     yield* SubscriptionRef.update(state, current => ({ ...current, isFieldsLoading: true }));
-    yield* requestMetadata(savedState.query.sObject, 'initialize');
+    yield* requestMetadata(savedState.query.sObject);
   }
 
   const dispatch: SoqlBuilderServiceShape['dispatch'] = Match.type<SoqlBuilderAction>().pipe(
     Match.tagsExhaustive({
-      ObjectSelected: action =>
-        Effect.gen(function* () {
-          const current = yield* SubscriptionRef.get(state);
-          const query = {
-            ...createInitialSoqlBuilderQuery(),
-            ...(current.query.headerComments === undefined
-              ? {}
-              : { headerComments: current.query.headerComments }),
-            sObject: action.objectName
-          };
-          yield* publishQuery(
-            {
-              ...current,
-              isFieldsLoading: true,
-              metadata: {
-                childRelationships: [],
-                fields: [],
-                objects: current.metadata.objects
-              }
-            },
-            query
-          );
-          yield* requestMetadata(action.objectName, 'dispatch');
-        }),
-      FieldsSelected: action => modifyQuery(({ query }) => ({ ...query, fields: [...action.fieldNames] })),
-      AllFieldsSelected: () =>
-        modifyQuery(({ metadata, query }) => ({ ...query, fields: metadata.fields.map(field => field.name) })),
-      AllFieldsCleared: () => modifyQuery(({ query }) => ({ ...query, fields: [] })),
-      WhereConditionUpserted: action =>
+      ObjectSelected: Effect.fn('VscodeSoqlBuilderService.dispatchObjectSelected')(function* (action) {
+        const current = yield* SubscriptionRef.get(state);
+        const query = {
+          ...createInitialSoqlBuilderQuery(),
+          ...(current.query.headerComments === undefined ? {} : { headerComments: current.query.headerComments }),
+          sObject: action.objectName
+        };
+        yield* publishQuery(
+          {
+            ...current,
+            isFieldsLoading: true,
+            metadata: {
+              childRelationships: [],
+              fields: [],
+              objects: current.metadata.objects
+            }
+          },
+          query
+        );
+        yield* requestMetadata(action.objectName);
+      }),
+      FieldsSelected: Effect.fn('VscodeSoqlBuilderService.dispatchFieldsSelected')(action =>
+        modifyQuery(({ query }) => ({ ...query, fields: [...action.fieldNames] }))
+      ),
+      AllFieldsSelected: Effect.fn('VscodeSoqlBuilderService.dispatchAllFieldsSelected')(() =>
+        modifyQuery(({ metadata, query }) => ({ ...query, fields: metadata.fields.map(field => field.name) }))
+      ),
+      AllFieldsCleared: Effect.fn('VscodeSoqlBuilderService.dispatchAllFieldsCleared')(() =>
+        modifyQuery(({ query }) => ({ ...query, fields: [] }))
+      ),
+      WhereConditionUpserted: Effect.fn('VscodeSoqlBuilderService.dispatchWhereConditionUpserted')(action =>
         modifyQuery(({ query }) => {
           const existingIndex = query.where.conditions.findIndex(
             condition => condition.index === action.condition.index
@@ -338,21 +340,24 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
               ...(action.andOr === undefined ? {} : { andOr: action.andOr })
             }
           };
-        }),
-      WhereConditionRemoved: action =>
+        })
+      ),
+      WhereConditionRemoved: Effect.fn('VscodeSoqlBuilderService.dispatchWhereConditionRemoved')(action =>
         modifyQuery(({ query }) => ({
           ...query,
           where: {
             ...query.where,
             conditions: query.where.conditions.filter(condition => condition.index !== action.index)
           }
-        })),
-      WhereConjunctionChanged: action =>
+        }))
+      ),
+      WhereConjunctionChanged: Effect.fn('VscodeSoqlBuilderService.dispatchWhereConjunctionChanged')(action =>
         modifyQuery(({ query }) => ({
           ...query,
           where: { ...query.where, andOr: action.andOr }
-        })),
-      OrderByUpserted: action =>
+        }))
+      ),
+      OrderByUpserted: Effect.fn('VscodeSoqlBuilderService.dispatchOrderByUpserted')(action =>
         modifyQuery(({ query }) => {
           const existingIndex = query.orderBy.findIndex(item => item.field === action.orderBy.field);
           const orderBy =
@@ -360,39 +365,39 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
               ? [...query.orderBy, action.orderBy]
               : query.orderBy.map((item, index) => (index === existingIndex ? action.orderBy : item));
           return { ...query, orderBy };
-        }),
-      OrderByRemoved: action =>
+        })
+      ),
+      OrderByRemoved: Effect.fn('VscodeSoqlBuilderService.dispatchOrderByRemoved')(action =>
         modifyQuery(({ query }) => ({
           ...query,
           orderBy: query.orderBy.filter(orderBy => orderBy.field !== action.fieldName)
-        })),
-      LimitChanged: action => modifyQuery(({ query }) => ({ ...query, limit: action.limit })),
-      AllRowsChanged: action => modifyQuery(({ query }) => ({ ...query, allRows: action.allRows })),
-      NotificationsDismissed: () =>
-        Effect.gen(function* () {
+        }))
+      ),
+      LimitChanged: Effect.fn('VscodeSoqlBuilderService.dispatchLimitChanged')(action =>
+        modifyQuery(({ query }) => ({ ...query, limit: action.limit === '' ? undefined : action.limit }))
+      ),
+      AllRowsChanged: Effect.fn('VscodeSoqlBuilderService.dispatchAllRowsChanged')(action =>
+        modifyQuery(({ query }) => ({ ...query, allRows: action.allRows }))
+      ),
+      NotificationsDismissed: Effect.fn('VscodeSoqlBuilderService.dispatchNotificationsDismissed')(
+        function* () {
           const current = yield* SubscriptionRef.get(state);
           const nextState = { ...current, notificationsDismissed: true };
           yield* SubscriptionRef.set(state, nextState);
           yield* saveViewState(messageService, nextState);
-        }),
-      SetDefaultOrgRequested: () =>
-        tryServiceOperation('dispatch', () =>
-          messageService.sendMessage({ type: MessageType.SET_DEFAULT_ORG })
-        ),
-      RunQueryRequested: () =>
-        Effect.gen(function* () {
-          yield* SubscriptionRef.update(state, current => ({ ...current, isQueryRunning: true }));
-          yield* tryServiceOperation('dispatch', () =>
-            messageService.sendMessage({ type: MessageType.RUN_SOQL_QUERY })
-          );
-        }),
-      QueryPlanRequested: () =>
-        Effect.gen(function* () {
-          yield* SubscriptionRef.update(state, current => ({ ...current, isQueryPlanRunning: true }));
-          yield* tryServiceOperation('dispatch', () =>
-            messageService.sendMessage({ type: MessageType.GET_QUERY_PLAN })
-          );
-        })
+        }
+      ),
+      SetDefaultOrgRequested: Effect.fn('VscodeSoqlBuilderService.dispatchSetDefaultOrgRequested')(() =>
+        trySendMessage(() => messageService.sendMessage({ type: MessageType.SET_DEFAULT_ORG }))
+      ),
+      RunQueryRequested: Effect.fn('VscodeSoqlBuilderService.dispatchRunQueryRequested')(function* () {
+        yield* SubscriptionRef.update(state, current => ({ ...current, isQueryRunning: true }));
+        yield* trySendMessage(() => messageService.sendMessage({ type: MessageType.RUN_SOQL_QUERY }));
+      }),
+      QueryPlanRequested: Effect.fn('VscodeSoqlBuilderService.dispatchQueryPlanRequested')(function* () {
+        yield* SubscriptionRef.update(state, current => ({ ...current, isQueryPlanRunning: true }));
+        yield* trySendMessage(() => messageService.sendMessage({ type: MessageType.GET_QUERY_PLAN }));
+      })
     })
   );
 

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/lit/vscodeSoqlBuilderService.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/lit/vscodeSoqlBuilderService.ts
@@ -7,9 +7,12 @@
 
 import {
   SoqlBuilderServiceError,
+  SoqlBuilderStateSchema,
+  createInitialSoqlBuilderQuery,
   createInitialSoqlBuilderState,
   decodeSoqlBuilderMetadata,
   type SoqlBuilderAction,
+  type SoqlBuilderQuery,
   type SoqlBuilderServiceError as ServiceError,
   type SoqlBuilderState
 } from '@salesforce/soql-builder-ui/domain';
@@ -22,6 +25,7 @@ import * as Layer from 'effect/Layer';
 import * as Match from 'effect/Match';
 import * as PubSub from 'effect/PubSub';
 import * as Queue from 'effect/Queue';
+import * as Ref from 'effect/Ref';
 import * as Schema from 'effect/Schema';
 import * as Stream from 'effect/Stream';
 import * as SubscriptionRef from 'effect/SubscriptionRef';
@@ -33,20 +37,13 @@ import {
   MessageType,
   type HostToUiSoqlEditorEvent
 } from '../modules/querybuilder/services/message/soqlEditorEvent';
+import {
+  createSoqlBuilderTelemetry,
+  parseSoqlBuilderQuery,
+  serializeSoqlBuilderQuery
+} from './soqlBuilderModelAdapter';
 
 type ServiceOperation = ServiceError['operation'];
-
-type DeferredSoqlBuilderHostEvent = Extract<
-  HostToUiSoqlEditorEvent,
-  { readonly type: typeof MessageType.RUN_SOQL_QUERY_DONE | typeof MessageType.GET_QUERY_PLAN_DONE }
->;
-
-type SoqlBuilderHostToUiEvent = Exclude<HostToUiSoqlEditorEvent, DeferredSoqlBuilderHostEvent>;
-
-const isSoqlBuilderHostToUiEvent = (
-  event: HostToUiSoqlEditorEvent
-): event is SoqlBuilderHostToUiEvent =>
-  event.type !== MessageType.RUN_SOQL_QUERY_DONE && event.type !== MessageType.GET_QUERY_PLAN_DONE;
 
 const toServiceError = (operation: ServiceOperation, error: unknown): ServiceError =>
   new SoqlBuilderServiceError({
@@ -54,98 +51,66 @@ const toServiceError = (operation: ServiceOperation, error: unknown): ServiceErr
     operation
   });
 
-const tryServiceOperation = (operation: ServiceOperation, evaluate: () => void) =>
+const tryServiceOperation = <A>(operation: ServiceOperation, evaluate: () => A) =>
   Effect.try({
     try: evaluate,
     catch: error => toServiceError(operation, error)
   });
 
-const toObjectMetadata = (names: unknown): unknown =>
-  Array.isArray(names) ? names.map(name => ({ label: name, name, queryable: true })) : names;
-
-const toFieldMetadata = (metadata: unknown): unknown => {
-  if (typeof metadata !== 'object' || metadata === null || !('fields' in metadata)) return metadata;
-  if (!Array.isArray(metadata.fields)) return metadata.fields;
-
-  return metadata.fields.map(field => {
-    if (typeof field !== 'object' || field === null) return field;
-
-    const name = 'name' in field ? field.name : undefined;
-    return {
-      filterable: 'filterable' in field ? field.filterable : false,
-      groupable: 'groupable' in field ? field.groupable : false,
-      label: 'label' in field ? field.label : name,
-      name,
-      sortable: 'sortable' in field ? field.sortable : false,
-      type: 'type' in field ? field.type : undefined
-    };
-  });
-};
+const toObjectMetadata = (names: readonly string[]) =>
+  names.map(name => ({ label: name, name, queryable: true }));
 
 const validateMetadata = (metadata: unknown) =>
   decodeSoqlBuilderMetadata(metadata).pipe(Effect.mapError(error => toServiceError('subscribe', error)));
 
-const SavedStateSchema = Schema.Struct({
-  errorMessage: Schema.optional(Schema.String),
-  hasNoDefaultOrg: Schema.Boolean,
-  isFieldsLoading: Schema.Boolean,
-  isObjectsLoading: Schema.Boolean,
-  metadata: Schema.Unknown,
-  query: Schema.Struct({
-    fields: Schema.Array(Schema.NonEmptyTrimmedString),
-    originalSoqlStatement: Schema.String,
-    sObject: Schema.String
-  })
-});
+const parseExternalQuery = (statement: string) =>
+  tryServiceOperation('subscribe', () => parseSoqlBuilderQuery(statement));
+
+const serializeQuery = (query: SoqlBuilderQuery) =>
+  tryServiceOperation('dispatch', () => serializeSoqlBuilderQuery(query));
 
 const decodeSavedState = (input: unknown) =>
-  Schema.decodeUnknown(SavedStateSchema)(input).pipe(
-    Effect.flatMap(saved =>
-      validateMetadata(saved.metadata).pipe(Effect.map(metadata => ({ ...saved, metadata })))
-    )
+  Schema.decodeUnknown(SoqlBuilderStateSchema)(input).pipe(
+    Effect.orElse(() =>
+      Schema.decodeUnknown(
+        Schema.Struct({
+          headerComments: Schema.optional(Schema.String),
+          allRows: Schema.Boolean,
+          errors: Schema.Array(Schema.Record({ key: Schema.String, value: Schema.Unknown })),
+          fields: Schema.Array(Schema.NonEmptyTrimmedString),
+          limit: Schema.String,
+          orderBy: Schema.Array(Schema.Record({ key: Schema.String, value: Schema.Unknown })),
+          originalSoqlStatement: Schema.String,
+          sObject: Schema.String,
+          unsupported: Schema.Array(Schema.Record({ key: Schema.String, value: Schema.Unknown })),
+          where: Schema.Record({ key: Schema.String, value: Schema.Unknown })
+        })
+      )(input).pipe(
+        Effect.flatMap(saved => parseExternalQuery(saved.originalSoqlStatement)),
+        Effect.map(query => ({ ...createInitialSoqlBuilderState(), query }))
+      )
+    ),
+    Effect.mapError(error => toServiceError('initialize', error))
   );
 
-const formatQuery = (sObject: string, fields: readonly string[]): string => {
-  if (sObject.length === 0) return '';
-  const selection = fields.length > 0 ? fields.join(', ') : 'Id';
-  return `SELECT ${selection}\n    FROM ${sObject}`;
-};
-
-const parseFoundationQuery = (statement: string): SoqlBuilderState['query'] => {
-  const match = /^\s*SELECT\s+([\s\S]+?)\s+FROM\s+([A-Za-z_][\w.]*)/iu.exec(statement);
-  if (!match) return { fields: [], originalSoqlStatement: statement, sObject: '' };
-
-  const fields = match[1]
-    .split(',')
-    .map(field => field.trim())
-    .filter(field => /^[A-Za-z_][\w.]*$/u.test(field));
-  return {
-    fields,
-    originalSoqlStatement: statement,
-    sObject: match[2]
-  };
-};
-
 const saveViewState = (messageService: IMessageService, state: SoqlBuilderState) =>
-  tryServiceOperation('dispatch', () => {
-    messageService.setState({
-      ...state,
-      metadata: {
-        fields: [...state.metadata.fields],
-        objects: [...state.metadata.objects]
-      },
-      query: { ...state.query, fields: [...state.query.fields] }
-    });
-  });
+  tryServiceOperation('dispatch', () => messageService.setState(state));
 
 const makeVscodeSoqlBuilderService = Effect.gen(function* () {
   const messageService = yield* MessageService;
-  const savedState = yield* decodeSavedState(messageService.getState()).pipe(Effect.orElseSucceed(createInitialSoqlBuilderState));
+  const savedState = yield* decodeSavedState(messageService.getState()).pipe(
+    Effect.orElseSucceed(createInitialSoqlBuilderState)
+  );
   const state = yield* SubscriptionRef.make(savedState);
-  const messages = yield* Queue.unbounded<SoqlBuilderHostToUiEvent>();
+  const messages = yield* Queue.unbounded<HostToUiSoqlEditorEvent>();
   const errors = yield* PubSub.unbounded<ServiceError>();
+
+  const requestSequence = yield* Ref.make(0);
+  const activeMetadataRequestId = yield* Ref.make<string | undefined>(undefined);
+  const activeObjectsRequestId = yield* Ref.make<string | undefined>(undefined);
+
   const removeMessageListener = messageService.onMessage(event => {
-    if (isSoqlBuilderHostToUiEvent(event)) messages.unsafeOffer(event);
+    messages.unsafeOffer(event);
   });
   yield* Effect.addFinalizer(() =>
     Effect.sync(removeMessageListener).pipe(
@@ -159,40 +124,148 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
       Effect.catchTag('SoqlBuilderServiceError', error => PubSub.publish(errors, error).pipe(Effect.asVoid))
     );
 
-  const setQuery = (query: SoqlBuilderState['query']) =>
-    SubscriptionRef.update(state, current => ({ ...current, query }));
+  const requestObjects = (operation: ServiceOperation) =>
+    Effect.gen(function* () {
+      const sequence = yield* Ref.updateAndGet(requestSequence, current => current + 1);
+      const requestId = `objects-${sequence}`;
+      yield* Ref.set(activeObjectsRequestId, requestId);
+      yield* tryServiceOperation(operation, () =>
+        messageService.sendMessage({ type: MessageType.SOBJECTS_REQUEST, requestId })
+      );
+    });
 
-  const handleMessage = Match.type<SoqlBuilderHostToUiEvent>().pipe(
+  const requestMetadata = (objectName: string, operation: ServiceOperation) =>
+    Effect.gen(function* () {
+      const sequence = yield* Ref.updateAndGet(requestSequence, current => current + 1);
+      const requestId = `metadata-${sequence}`;
+      yield* Ref.set(activeMetadataRequestId, requestId);
+      yield* tryServiceOperation(operation, () =>
+        messageService.sendMessage({
+          payload: objectName,
+          requestId,
+          type: MessageType.SOBJECT_METADATA_REQUEST
+        })
+      );
+    });
+
+  const publishQuery = (current: SoqlBuilderState, query: SoqlBuilderQuery) =>
+    Effect.gen(function* () {
+      const originalSoqlStatement = yield* serializeQuery(query);
+      const nextState: SoqlBuilderState = {
+        ...current,
+        errorMessage: undefined,
+        notificationsDismissed: false,
+        query: {
+          ...query,
+          originalSoqlStatement,
+          parseErrors: [],
+          unsupportedSyntax: []
+        }
+      };
+      yield* SubscriptionRef.set(state, nextState);
+      yield* tryServiceOperation('dispatch', () =>
+        messageService.sendMessage({
+          payload: originalSoqlStatement,
+          type: MessageType.UI_SOQL_CHANGED
+        })
+      );
+      yield* saveViewState(messageService, nextState);
+      return nextState;
+    });
+
+  const handleMessage = Match.type<HostToUiSoqlEditorEvent>().pipe(
     Match.discriminatorsExhaustive('type')({
       [MessageType.SOBJECTS_RESPONSE]: event =>
         Effect.gen(function* () {
+          const activeRequestId = yield* Ref.get(activeObjectsRequestId);
+          if (event.requestId !== activeRequestId) return;
           const current = yield* SubscriptionRef.get(state);
           const metadata = yield* validateMetadata({
-            fields: current.metadata.fields,
+            ...current.metadata,
             objects: toObjectMetadata(event.payload)
           });
           yield* SubscriptionRef.set(state, { ...current, isObjectsLoading: false, metadata });
         }),
       [MessageType.SOBJECT_METADATA_RESPONSE]: event =>
         Effect.gen(function* () {
+          const activeRequestId = yield* Ref.get(activeMetadataRequestId);
+          if (event.requestId !== activeRequestId) return;
           const current = yield* SubscriptionRef.get(state);
+          if (event.payload.name !== current.query.sObject) return;
           const metadata = yield* validateMetadata({
-            fields: toFieldMetadata(event.payload),
-            objects: current.metadata.objects
+            childRelationships: event.payload.childRelationships,
+            fields: event.payload.fields,
+            objects: current.metadata.objects,
+            selectedObjectName: event.payload.name
           });
           yield* SubscriptionRef.set(state, { ...current, isFieldsLoading: false, metadata });
         }),
-      [MessageType.TEXT_SOQL_CHANGED]: event => setQuery(parseFoundationQuery(event.payload)),
+      [MessageType.TEXT_SOQL_CHANGED]: event =>
+        Effect.gen(function* () {
+          const current = yield* SubscriptionRef.get(state);
+          if (event.payload === current.query.originalSoqlStatement) return;
+
+          const query = yield* parseExternalQuery(event.payload);
+          const objectChanged = query.sObject !== current.query.sObject;
+          const nextState: SoqlBuilderState = {
+            ...current,
+            isFieldsLoading: query.sObject.length > 0 && objectChanged,
+            metadata: objectChanged
+              ? {
+                  childRelationships: [],
+                  fields: [],
+                  objects: current.metadata.objects
+                }
+              : current.metadata,
+            notificationsDismissed: false,
+            query
+          };
+          yield* SubscriptionRef.set(state, nextState);
+          yield* saveViewState(messageService, nextState);
+
+          if (query.parseErrors.length > 0 || query.unsupportedSyntax.length > 0) {
+            yield* tryServiceOperation('subscribe', () =>
+              messageService.sendMessage({
+                payload: createSoqlBuilderTelemetry(query),
+                type: MessageType.UI_TELEMETRY
+              })
+            );
+          }
+          if (query.sObject.length > 0 && objectChanged) {
+            yield* requestMetadata(query.sObject, 'subscribe');
+          }
+        }),
       [MessageType.NO_DEFAULT_ORG]: () =>
-        SubscriptionRef.update(state, current => ({ ...current, hasNoDefaultOrg: true })),
+        SubscriptionRef.update(state, current => ({
+          ...current,
+          hasNoDefaultOrg: true,
+          isFieldsLoading: false,
+          isObjectsLoading: false
+        })),
       [MessageType.CONNECTION_CHANGED]: () =>
-        SubscriptionRef.update(state, current => ({ ...current, hasNoDefaultOrg: false })).pipe(
-          Effect.andThen(
-            tryServiceOperation('subscribe', () =>
-              messageService.sendMessage({ type: MessageType.SOBJECTS_REQUEST })
-            )
-          )
-        )
+        Effect.gen(function* () {
+          const current = yield* SubscriptionRef.get(state);
+          const nextState: SoqlBuilderState = {
+            ...current,
+            hasNoDefaultOrg: false,
+            isFieldsLoading: current.query.sObject.length > 0,
+            isObjectsLoading: true,
+            metadata: {
+              childRelationships: [],
+              fields: [],
+              objects: []
+            }
+          };
+          yield* SubscriptionRef.set(state, nextState);
+          yield* requestObjects('subscribe');
+          if (current.query.sObject.length > 0) {
+            yield* requestMetadata(current.query.sObject, 'subscribe');
+          }
+        }),
+      [MessageType.RUN_SOQL_QUERY_DONE]: () =>
+        SubscriptionRef.update(state, current => ({ ...current, isQueryRunning: false })),
+      [MessageType.GET_QUERY_PLAN_DONE]: () =>
+        SubscriptionRef.update(state, current => ({ ...current, isQueryPlanRunning: false }))
     })
   );
 
@@ -202,48 +275,152 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
   );
 
   yield* SubscriptionRef.update(state, current => ({ ...current, isObjectsLoading: true }));
-  yield* tryServiceOperation('initialize', () =>
-    messageService.sendMessage({ type: MessageType.SOBJECTS_REQUEST })
-  );
+  yield* requestObjects('initialize');
+  if (savedState.query.sObject.length > 0) {
+    yield* SubscriptionRef.update(state, current => ({ ...current, isFieldsLoading: true }));
+    yield* requestMetadata(savedState.query.sObject, 'initialize');
+  }
 
-  const dispatch: SoqlBuilderServiceShape['dispatch'] = (action: SoqlBuilderAction) =>
-    Effect.gen(function* () {
-      const current = yield* SubscriptionRef.get(state);
-      const query =
-        action._tag === 'ObjectSelected'
-          ? {
-              fields: [],
-              originalSoqlStatement: formatQuery(action.objectName, []),
-              sObject: action.objectName
-            }
-          : {
-              ...current.query,
-              fields: [...action.fieldNames],
-              originalSoqlStatement: formatQuery(current.query.sObject, action.fieldNames)
-            };
-      const nextState: SoqlBuilderState = {
-        ...current,
-        isFieldsLoading: action._tag === 'ObjectSelected',
-        metadata:
-          action._tag === 'ObjectSelected' ? { ...current.metadata, fields: [] } : current.metadata,
-        query
-      };
-
-      yield* SubscriptionRef.set(state, nextState);
-      yield* tryServiceOperation('dispatch', () => {
-        if (action._tag === 'ObjectSelected') {
-          messageService.sendMessage({
-            payload: action.objectName,
-            type: MessageType.SOBJECT_METADATA_REQUEST
+  const dispatch: SoqlBuilderServiceShape['dispatch'] = Match.type<SoqlBuilderAction>().pipe(
+    Match.tagsExhaustive({
+      ObjectSelected: action =>
+        Effect.gen(function* () {
+          const current = yield* SubscriptionRef.get(state);
+          const query = {
+            ...createInitialSoqlBuilderQuery(),
+            ...(current.query.headerComments === undefined
+              ? {}
+              : { headerComments: current.query.headerComments }),
+            sObject: action.objectName
+          };
+          yield* publishQuery(
+            {
+              ...current,
+              isFieldsLoading: true,
+              metadata: {
+                childRelationships: [],
+                fields: [],
+                objects: current.metadata.objects
+              }
+            },
+            query
+          );
+          yield* requestMetadata(action.objectName, 'dispatch');
+        }),
+      FieldsSelected: action =>
+        Effect.gen(function* () {
+          const current = yield* SubscriptionRef.get(state);
+          yield* publishQuery(current, { ...current.query, fields: [...action.fieldNames] });
+        }),
+      AllFieldsSelected: () =>
+        Effect.gen(function* () {
+          const current = yield* SubscriptionRef.get(state);
+          yield* publishQuery(current, {
+            ...current.query,
+            fields: current.metadata.fields.map(field => field.name)
           });
-        }
-        messageService.sendMessage({
-          payload: query.originalSoqlStatement,
-          type: MessageType.UI_SOQL_CHANGED
-        });
-      });
-      yield* saveViewState(messageService, nextState);
-    });
+        }),
+      AllFieldsCleared: () =>
+        Effect.gen(function* () {
+          const current = yield* SubscriptionRef.get(state);
+          yield* publishQuery(current, { ...current.query, fields: [] });
+        }),
+      WhereConditionUpserted: action =>
+        Effect.gen(function* () {
+          const current = yield* SubscriptionRef.get(state);
+          const existingIndex = current.query.where.conditions.findIndex(
+            condition => condition.index === action.condition.index
+          );
+          const conditions =
+            existingIndex < 0
+              ? [...current.query.where.conditions, action.condition]
+              : current.query.where.conditions.map((condition, index) =>
+                  index === existingIndex ? action.condition : condition
+                );
+          yield* publishQuery(current, {
+            ...current.query,
+            where: {
+              conditions,
+              ...(action.andOr === undefined ? {} : { andOr: action.andOr })
+            }
+          });
+        }),
+      WhereConditionRemoved: action =>
+        Effect.gen(function* () {
+          const current = yield* SubscriptionRef.get(state);
+          yield* publishQuery(current, {
+            ...current.query,
+            where: {
+              ...current.query.where,
+              conditions: current.query.where.conditions.filter(condition => condition.index !== action.index)
+            }
+          });
+        }),
+      WhereConjunctionChanged: action =>
+        Effect.gen(function* () {
+          const current = yield* SubscriptionRef.get(state);
+          yield* publishQuery(current, {
+            ...current.query,
+            where: { ...current.query.where, andOr: action.andOr }
+          });
+        }),
+      OrderByUpserted: action =>
+        Effect.gen(function* () {
+          const current = yield* SubscriptionRef.get(state);
+          const existingIndex = current.query.orderBy.findIndex(item => item.field === action.orderBy.field);
+          const orderBy =
+            existingIndex < 0
+              ? [...current.query.orderBy, action.orderBy]
+              : current.query.orderBy.map((item, index) =>
+                  index === existingIndex ? action.orderBy : item
+                );
+          yield* publishQuery(current, { ...current.query, orderBy });
+        }),
+      OrderByRemoved: action =>
+        Effect.gen(function* () {
+          const current = yield* SubscriptionRef.get(state);
+          yield* publishQuery(current, {
+            ...current.query,
+            orderBy: current.query.orderBy.filter(orderBy => orderBy.field !== action.fieldName)
+          });
+        }),
+      LimitChanged: action =>
+        Effect.gen(function* () {
+          const current = yield* SubscriptionRef.get(state);
+          yield* publishQuery(current, { ...current.query, limit: action.limit });
+        }),
+      AllRowsChanged: action =>
+        Effect.gen(function* () {
+          const current = yield* SubscriptionRef.get(state);
+          yield* publishQuery(current, { ...current.query, allRows: action.allRows });
+        }),
+      NotificationsDismissed: () =>
+        Effect.gen(function* () {
+          const current = yield* SubscriptionRef.get(state);
+          const nextState = { ...current, notificationsDismissed: true };
+          yield* SubscriptionRef.set(state, nextState);
+          yield* saveViewState(messageService, nextState);
+        }),
+      SetDefaultOrgRequested: () =>
+        tryServiceOperation('dispatch', () =>
+          messageService.sendMessage({ type: MessageType.SET_DEFAULT_ORG })
+        ),
+      RunQueryRequested: () =>
+        Effect.gen(function* () {
+          yield* SubscriptionRef.update(state, current => ({ ...current, isQueryRunning: true }));
+          yield* tryServiceOperation('dispatch', () =>
+            messageService.sendMessage({ type: MessageType.RUN_SOQL_QUERY })
+          );
+        }),
+      QueryPlanRequested: () =>
+        Effect.gen(function* () {
+          yield* SubscriptionRef.update(state, current => ({ ...current, isQueryPlanRunning: true }));
+          yield* tryServiceOperation('dispatch', () =>
+            messageService.sendMessage({ type: MessageType.GET_QUERY_PLAN })
+          );
+        })
+    })
+  );
 
   return SoqlBuilderService.of({
     dispatch,

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/lit/vscodeSoqlBuilderService.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/lit/vscodeSoqlBuilderService.ts
@@ -23,6 +23,7 @@ import {
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
 import * as Match from 'effect/Match';
+import * as Option from 'effect/Option';
 import * as PubSub from 'effect/PubSub';
 import * as Queue from 'effect/Queue';
 import * as Ref from 'effect/Ref';
@@ -106,8 +107,8 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
   const errors = yield* PubSub.unbounded<ServiceError>();
 
   const requestSequence = yield* Ref.make(0);
-  const activeMetadataRequestId = yield* Ref.make<string | undefined>(undefined);
-  const activeObjectsRequestId = yield* Ref.make<string | undefined>(undefined);
+  const activeMetadataRequestId = yield* Ref.make<Option.Option<string>>(Option.none());
+  const activeObjectsRequestId = yield* Ref.make<Option.Option<string>>(Option.none());
 
   const removeMessageListener = messageService.onMessage(event => {
     messages.unsafeOffer(event);
@@ -124,32 +125,37 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
       Effect.catchTag('SoqlBuilderServiceError', error => PubSub.publish(errors, error).pipe(Effect.asVoid))
     );
 
-  const requestObjects = (operation: ServiceOperation) =>
-    Effect.gen(function* () {
-      const sequence = yield* Ref.updateAndGet(requestSequence, current => current + 1);
-      const requestId = `objects-${sequence}`;
-      yield* Ref.set(activeObjectsRequestId, requestId);
-      yield* tryServiceOperation(operation, () =>
-        messageService.sendMessage({ type: MessageType.SOBJECTS_REQUEST, requestId })
-      );
-    });
+  const requestObjects = Effect.fn('VscodeSoqlBuilderService.requestObjects')(function* (
+    operation: ServiceOperation
+  ) {
+    const sequence = yield* Ref.updateAndGet(requestSequence, current => current + 1);
+    const requestId = `objects-${sequence}`;
+    yield* Ref.set(activeObjectsRequestId, Option.some(requestId));
+    yield* tryServiceOperation(operation, () =>
+      messageService.sendMessage({ type: MessageType.SOBJECTS_REQUEST, requestId })
+    );
+  });
 
-  const requestMetadata = (objectName: string, operation: ServiceOperation) =>
-    Effect.gen(function* () {
-      const sequence = yield* Ref.updateAndGet(requestSequence, current => current + 1);
-      const requestId = `metadata-${sequence}`;
-      yield* Ref.set(activeMetadataRequestId, requestId);
-      yield* tryServiceOperation(operation, () =>
-        messageService.sendMessage({
-          payload: objectName,
-          requestId,
-          type: MessageType.SOBJECT_METADATA_REQUEST
-        })
-      );
-    });
+  const requestMetadata = Effect.fn('VscodeSoqlBuilderService.requestMetadata')(function* (
+    objectName: string,
+    operation: ServiceOperation
+  ) {
+    const sequence = yield* Ref.updateAndGet(requestSequence, current => current + 1);
+    const requestId = `metadata-${sequence}`;
+    yield* Ref.set(activeMetadataRequestId, Option.some(requestId));
+    yield* tryServiceOperation(operation, () =>
+      messageService.sendMessage({
+        payload: objectName,
+        requestId,
+        type: MessageType.SOBJECT_METADATA_REQUEST
+      })
+    );
+  });
 
-  const publishQuery = (current: SoqlBuilderState, query: SoqlBuilderQuery) =>
-    Effect.gen(function* () {
+  const publishQuery = Effect.fn('VscodeSoqlBuilderService.publishQuery')(function* (
+    current: SoqlBuilderState,
+    query: SoqlBuilderQuery
+  ) {
       const originalSoqlStatement = yield* serializeQuery(query);
       const nextState: SoqlBuilderState = {
         ...current,
@@ -173,12 +179,15 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
       return nextState;
     });
 
+  const modifyQuery = (update: (current: SoqlBuilderState) => SoqlBuilderQuery) =>
+    SubscriptionRef.get(state).pipe(Effect.flatMap(current => publishQuery(current, update(current))));
+
   const handleMessage = Match.type<HostToUiSoqlEditorEvent>().pipe(
     Match.discriminatorsExhaustive('type')({
       [MessageType.SOBJECTS_RESPONSE]: event =>
         Effect.gen(function* () {
           const activeRequestId = yield* Ref.get(activeObjectsRequestId);
-          if (event.requestId !== activeRequestId) return;
+          if (Option.getOrUndefined(activeRequestId) !== event.requestId) return;
           const current = yield* SubscriptionRef.get(state);
           const metadata = yield* validateMetadata({
             ...current.metadata,
@@ -189,7 +198,7 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
       [MessageType.SOBJECT_METADATA_RESPONSE]: event =>
         Effect.gen(function* () {
           const activeRequestId = yield* Ref.get(activeMetadataRequestId);
-          if (event.requestId !== activeRequestId) return;
+          if (Option.getOrUndefined(activeRequestId) !== event.requestId) return;
           const current = yield* SubscriptionRef.get(state);
           if (event.payload.name !== current.query.sObject) return;
           const metadata = yield* validateMetadata({
@@ -307,93 +316,58 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
           );
           yield* requestMetadata(action.objectName, 'dispatch');
         }),
-      FieldsSelected: action =>
-        Effect.gen(function* () {
-          const current = yield* SubscriptionRef.get(state);
-          yield* publishQuery(current, { ...current.query, fields: [...action.fieldNames] });
-        }),
+      FieldsSelected: action => modifyQuery(({ query }) => ({ ...query, fields: [...action.fieldNames] })),
       AllFieldsSelected: () =>
-        Effect.gen(function* () {
-          const current = yield* SubscriptionRef.get(state);
-          yield* publishQuery(current, {
-            ...current.query,
-            fields: current.metadata.fields.map(field => field.name)
-          });
-        }),
-      AllFieldsCleared: () =>
-        Effect.gen(function* () {
-          const current = yield* SubscriptionRef.get(state);
-          yield* publishQuery(current, { ...current.query, fields: [] });
-        }),
+        modifyQuery(({ metadata, query }) => ({ ...query, fields: metadata.fields.map(field => field.name) })),
+      AllFieldsCleared: () => modifyQuery(({ query }) => ({ ...query, fields: [] })),
       WhereConditionUpserted: action =>
-        Effect.gen(function* () {
-          const current = yield* SubscriptionRef.get(state);
-          const existingIndex = current.query.where.conditions.findIndex(
+        modifyQuery(({ query }) => {
+          const existingIndex = query.where.conditions.findIndex(
             condition => condition.index === action.condition.index
           );
           const conditions =
             existingIndex < 0
-              ? [...current.query.where.conditions, action.condition]
-              : current.query.where.conditions.map((condition, index) =>
+              ? [...query.where.conditions, action.condition]
+              : query.where.conditions.map((condition, index) =>
                   index === existingIndex ? action.condition : condition
                 );
-          yield* publishQuery(current, {
-            ...current.query,
+          return {
+            ...query,
             where: {
               conditions,
               ...(action.andOr === undefined ? {} : { andOr: action.andOr })
             }
-          });
+          };
         }),
       WhereConditionRemoved: action =>
-        Effect.gen(function* () {
-          const current = yield* SubscriptionRef.get(state);
-          yield* publishQuery(current, {
-            ...current.query,
-            where: {
-              ...current.query.where,
-              conditions: current.query.where.conditions.filter(condition => condition.index !== action.index)
-            }
-          });
-        }),
+        modifyQuery(({ query }) => ({
+          ...query,
+          where: {
+            ...query.where,
+            conditions: query.where.conditions.filter(condition => condition.index !== action.index)
+          }
+        })),
       WhereConjunctionChanged: action =>
-        Effect.gen(function* () {
-          const current = yield* SubscriptionRef.get(state);
-          yield* publishQuery(current, {
-            ...current.query,
-            where: { ...current.query.where, andOr: action.andOr }
-          });
-        }),
+        modifyQuery(({ query }) => ({
+          ...query,
+          where: { ...query.where, andOr: action.andOr }
+        })),
       OrderByUpserted: action =>
-        Effect.gen(function* () {
-          const current = yield* SubscriptionRef.get(state);
-          const existingIndex = current.query.orderBy.findIndex(item => item.field === action.orderBy.field);
+        modifyQuery(({ query }) => {
+          const existingIndex = query.orderBy.findIndex(item => item.field === action.orderBy.field);
           const orderBy =
             existingIndex < 0
-              ? [...current.query.orderBy, action.orderBy]
-              : current.query.orderBy.map((item, index) =>
-                  index === existingIndex ? action.orderBy : item
-                );
-          yield* publishQuery(current, { ...current.query, orderBy });
+              ? [...query.orderBy, action.orderBy]
+              : query.orderBy.map((item, index) => (index === existingIndex ? action.orderBy : item));
+          return { ...query, orderBy };
         }),
       OrderByRemoved: action =>
-        Effect.gen(function* () {
-          const current = yield* SubscriptionRef.get(state);
-          yield* publishQuery(current, {
-            ...current.query,
-            orderBy: current.query.orderBy.filter(orderBy => orderBy.field !== action.fieldName)
-          });
-        }),
-      LimitChanged: action =>
-        Effect.gen(function* () {
-          const current = yield* SubscriptionRef.get(state);
-          yield* publishQuery(current, { ...current.query, limit: action.limit });
-        }),
-      AllRowsChanged: action =>
-        Effect.gen(function* () {
-          const current = yield* SubscriptionRef.get(state);
-          yield* publishQuery(current, { ...current.query, allRows: action.allRows });
-        }),
+        modifyQuery(({ query }) => ({
+          ...query,
+          orderBy: query.orderBy.filter(orderBy => orderBy.field !== action.fieldName)
+        })),
+      LimitChanged: action => modifyQuery(({ query }) => ({ ...query, limit: action.limit })),
+      AllRowsChanged: action => modifyQuery(({ query }) => ({ ...query, allRows: action.allRows })),
       NotificationsDismissed: () =>
         Effect.gen(function* () {
           const current = yield* SubscriptionRef.get(state);

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/lit/vscodeSoqlBuilderService.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/lit/vscodeSoqlBuilderService.ts
@@ -24,10 +24,8 @@ import {
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
 import * as Match from 'effect/Match';
-import * as Option from 'effect/Option';
 import * as PubSub from 'effect/PubSub';
 import * as Queue from 'effect/Queue';
-import * as Ref from 'effect/Ref';
 import * as Schema from 'effect/Schema';
 import * as Stream from 'effect/Stream';
 import * as SubscriptionRef from 'effect/SubscriptionRef';
@@ -37,9 +35,7 @@ import {
 } from '../modules/querybuilder/services/message/iMessageService';
 import {
   MessageType,
-  RequestIdSchema,
-  type HostToUiSoqlEditorEvent,
-  type RequestId
+  type HostToUiSoqlEditorEvent
 } from '../modules/querybuilder/services/message/soqlEditorEvent';
 import {
   createSoqlBuilderTelemetry,
@@ -68,23 +64,14 @@ const parseExternalQuery = (statement: string) => tryQueryOperation(() => parseS
 
 const serializeQuery = (query: SoqlBuilderQuery) => tryQueryOperation(() => serializeSoqlBuilderQuery(query));
 
+const LegacySavedStateSchema = Schema.Struct({
+  originalSoqlStatement: Schema.String
+});
+
 const decodeSavedState = (input: unknown) =>
   Schema.decodeUnknown(SoqlBuilderStateSchema)(input).pipe(
     Effect.orElse(() =>
-      Schema.decodeUnknown(
-        Schema.Struct({
-          headerComments: Schema.optional(Schema.String),
-          allRows: Schema.Boolean,
-          errors: Schema.Array(Schema.Record({ key: Schema.String, value: Schema.Unknown })),
-          fields: Schema.Array(Schema.NonEmptyTrimmedString),
-          limit: Schema.String,
-          orderBy: Schema.Array(Schema.Record({ key: Schema.String, value: Schema.Unknown })),
-          originalSoqlStatement: Schema.String,
-          sObject: Schema.String,
-          unsupported: Schema.Array(Schema.Record({ key: Schema.String, value: Schema.Unknown })),
-          where: Schema.Record({ key: Schema.String, value: Schema.Unknown })
-        })
-      )(input).pipe(
+      Schema.decodeUnknown(LegacySavedStateSchema)(input).pipe(
         Effect.flatMap(saved => parseExternalQuery(saved.originalSoqlStatement)),
         Effect.map(query => ({ ...createInitialSoqlBuilderState(), query }))
       )
@@ -104,10 +91,6 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
   const messages = yield* Queue.unbounded<HostToUiSoqlEditorEvent>();
   const errors = yield* PubSub.unbounded<ServiceError>();
 
-  const requestSequence = yield* Ref.make(0);
-  const activeMetadataRequestId = yield* Ref.make<Option.Option<RequestId>>(Option.none());
-  const activeObjectsRequestId = yield* Ref.make<Option.Option<RequestId>>(Option.none());
-
   const removeMessageListener = messageService.onMessage(event => {
     messages.unsafeOffer(event);
   });
@@ -121,25 +104,18 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
   const reportMessageError = <A>(handler: Effect.Effect<A, ServiceError>) =>
     handler.pipe(Effect.catchAll(error => PubSub.publish(errors, error).pipe(Effect.asVoid)));
 
-  const requestObjects = Effect.fn('VscodeSoqlBuilderService.requestObjects')(function* () {
-    const sequence = yield* Ref.updateAndGet(requestSequence, current => current + 1);
-    const requestId = yield* Schema.decode(RequestIdSchema)(`objects-${sequence}`).pipe(Effect.orDie);
-    yield* Ref.set(activeObjectsRequestId, Option.some(requestId));
-    yield* trySendMessage(() => messageService.sendMessage({ type: MessageType.SOBJECTS_REQUEST, requestId }));
-  });
+  const requestObjects = Effect.fn('VscodeSoqlBuilderService.requestObjects')(() =>
+    trySendMessage(() => messageService.sendMessage({ type: MessageType.SOBJECTS_REQUEST }))
+  );
 
-  const requestMetadata = Effect.fn('VscodeSoqlBuilderService.requestMetadata')(function* (objectName: string) {
-    const sequence = yield* Ref.updateAndGet(requestSequence, current => current + 1);
-    const requestId = yield* Schema.decode(RequestIdSchema)(`metadata-${sequence}`).pipe(Effect.orDie);
-    yield* Ref.set(activeMetadataRequestId, Option.some(requestId));
-    yield* trySendMessage(() =>
+  const requestMetadata = Effect.fn('VscodeSoqlBuilderService.requestMetadata')((objectName: string) =>
+    trySendMessage(() =>
       messageService.sendMessage({
         payload: objectName,
-        requestId,
         type: MessageType.SOBJECT_METADATA_REQUEST
       })
-    );
-  });
+    )
+  );
 
   const publishQuery = Effect.fn('VscodeSoqlBuilderService.publishQuery')(function* (
     current: SoqlBuilderState,
@@ -175,8 +151,6 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
     Match.discriminatorsExhaustive('type')({
       [MessageType.SOBJECTS_RESPONSE]: Effect.fn('VscodeSoqlBuilderService.handleSObjectsResponse')(
         function* (event) {
-          const activeRequestId = yield* Ref.get(activeObjectsRequestId);
-          if (Option.getOrUndefined(activeRequestId) !== event.requestId) return;
           const current = yield* SubscriptionRef.get(state);
           const metadata = yield* validateMetadata({
             ...current.metadata,
@@ -188,8 +162,6 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
       [MessageType.SOBJECT_METADATA_RESPONSE]: Effect.fn(
         'VscodeSoqlBuilderService.handleSObjectMetadataResponse'
       )(function* (event) {
-        const activeRequestId = yield* Ref.get(activeMetadataRequestId);
-        if (Option.getOrUndefined(activeRequestId) !== event.requestId) return;
         const current = yield* SubscriptionRef.get(state);
         if (event.payload.name !== current.query.sObject) return;
         const metadata = yield* validateMetadata({
@@ -373,9 +345,16 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
           orderBy: query.orderBy.filter(orderBy => orderBy.field !== action.fieldName)
         }))
       ),
-      LimitChanged: Effect.fn('VscodeSoqlBuilderService.dispatchLimitChanged')(action =>
-        modifyQuery(({ query }) => ({ ...query, limit: action.limit === '' ? undefined : action.limit }))
-      ),
+      LimitChanged: Effect.fn('VscodeSoqlBuilderService.dispatchLimitChanged')(function* (action) {
+        if (action.limit._tag === 'Invalid') {
+          const current = yield* SubscriptionRef.get(state);
+          const nextState = { ...current, query: { ...current.query, limit: action.limit } };
+          yield* SubscriptionRef.set(state, nextState);
+          yield* saveViewState(messageService, nextState);
+          return;
+        }
+        yield* modifyQuery(({ query }) => ({ ...query, limit: action.limit }));
+      }),
       AllRowsChanged: Effect.fn('VscodeSoqlBuilderService.dispatchAllRowsChanged')(action =>
         modifyQuery(({ query }) => ({ ...query, allRows: action.allRows }))
       ),

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/messages/i18n.ts
@@ -76,7 +76,7 @@ export const messages = {
 
   // query preview
   label_soql_query: 'SOQL Query',
-  label_soql_query_inputs: 'SOQL query inputs',
+  label_soql_query_inputs: 'SOQL Query Inputs',
 
   // placeholders
   placeholder_search_object: 'Search object...',

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/services/message/soqlEditorEvent.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/services/message/soqlEditorEvent.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { SObjectSchema } from '@salesforce/vscode-services';
 import * as Schema from 'effect/Schema';
 
 export const MessageType = {
@@ -30,52 +31,7 @@ export type MessageType = (typeof MessageType)[keyof typeof MessageType];
 export const RequestIdSchema = Schema.String.pipe(Schema.brand('@soql/RequestId'));
 export type RequestId = Schema.Schema.Type<typeof RequestIdSchema>;
 
-// Deliberately duplicated rather than shared from @salesforce/vscode-services: this file is bundled by the
-// legacy rollup pipeline (rollup.config.mjs), where a CJS require of that package transitively hits effect's
-// CJS Schema build, which unconditionally requires fast-check and fails to resolve under rollup.
-const SObjectFieldSchema = Schema.Struct({
-  aggregatable: Schema.Boolean,
-  custom: Schema.Boolean,
-  defaultValue: Schema.NullOr(Schema.Unknown),
-  extraTypeInfo: Schema.NullOr(Schema.String),
-  filterable: Schema.Boolean,
-  groupable: Schema.Boolean,
-  inlineHelpText: Schema.NullOr(Schema.String),
-  label: Schema.String,
-  length: Schema.optional(Schema.Number),
-  name: Schema.String,
-  nillable: Schema.Boolean,
-  picklistValues: Schema.Array(
-    Schema.Struct({
-      active: Schema.Boolean,
-      label: Schema.NullOr(Schema.String),
-      value: Schema.String
-    })
-  ),
-  precision: Schema.optional(Schema.Number),
-  referenceTo: Schema.Array(Schema.String),
-  relationshipName: Schema.NullOr(Schema.String),
-  scale: Schema.optional(Schema.Number),
-  sortable: Schema.Boolean,
-  type: Schema.String
-});
-
-const SObjectMetadataSchema = Schema.Struct({
-  name: Schema.String,
-  label: Schema.String,
-  custom: Schema.Boolean,
-  queryable: Schema.Boolean,
-  childRelationships: Schema.Array(
-    Schema.Struct({
-      childSObject: Schema.String,
-      field: Schema.String,
-      relationshipName: Schema.NullOr(Schema.String)
-    })
-  ),
-  fields: Schema.Array(SObjectFieldSchema)
-});
-
-export type SObjectMetadata = Pick<typeof SObjectMetadataSchema.Type, 'fields'>;
+export type SObjectMetadata = Pick<typeof SObjectSchema.Type, 'fields'>;
 
 const eventWithoutPayload = <T extends MessageType>(type: T) => Schema.Struct({ type: Schema.Literal(type) });
 
@@ -106,7 +62,7 @@ const SObjectMetadataRequestEventSchema = Schema.Struct({
 });
 const SObjectMetadataResponseEventSchema = Schema.Struct({
   type: Schema.Literal(MessageType.SOBJECT_METADATA_RESPONSE),
-  payload: SObjectMetadataSchema,
+  payload: SObjectSchema,
   requestId: Schema.optional(RequestIdSchema)
 });
 const SObjectsResponseEventSchema = Schema.Struct({

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/services/message/soqlEditorEvent.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/services/message/soqlEditorEvent.ts
@@ -27,6 +27,12 @@ export const MessageType = {
 
 export type MessageType = (typeof MessageType)[keyof typeof MessageType];
 
+export const RequestIdSchema = Schema.String.pipe(Schema.brand('@soql/RequestId'));
+export type RequestId = Schema.Schema.Type<typeof RequestIdSchema>;
+
+// Deliberately duplicated rather than shared from @salesforce/vscode-services: this file is bundled by the
+// legacy rollup pipeline (rollup.config.mjs), where a CJS require of that package transitively hits effect's
+// CJS Schema build, which unconditionally requires fast-check and fails to resolve under rollup.
 const SObjectFieldSchema = Schema.Struct({
   aggregatable: Schema.Boolean,
   custom: Schema.Boolean,
@@ -76,7 +82,7 @@ const eventWithoutPayload = <T extends MessageType>(type: T) => Schema.Struct({ 
 const UiActivatedEventSchema = eventWithoutPayload(MessageType.UI_ACTIVATED);
 const SObjectsRequestEventSchema = Schema.Struct({
   type: Schema.Literal(MessageType.SOBJECTS_REQUEST),
-  requestId: Schema.optional(Schema.String)
+  requestId: Schema.optional(RequestIdSchema)
 });
 const RunSoqlQueryEventSchema = eventWithoutPayload(MessageType.RUN_SOQL_QUERY);
 const RunSoqlQueryDoneEventSchema = eventWithoutPayload(MessageType.RUN_SOQL_QUERY_DONE);
@@ -96,17 +102,17 @@ const UiTelemetryEventSchema = Schema.Struct({
 const SObjectMetadataRequestEventSchema = Schema.Struct({
   type: Schema.Literal(MessageType.SOBJECT_METADATA_REQUEST),
   payload: Schema.String,
-  requestId: Schema.optional(Schema.String)
+  requestId: Schema.optional(RequestIdSchema)
 });
 const SObjectMetadataResponseEventSchema = Schema.Struct({
   type: Schema.Literal(MessageType.SOBJECT_METADATA_RESPONSE),
   payload: SObjectMetadataSchema,
-  requestId: Schema.optional(Schema.String)
+  requestId: Schema.optional(RequestIdSchema)
 });
 const SObjectsResponseEventSchema = Schema.Struct({
   type: Schema.Literal(MessageType.SOBJECTS_RESPONSE),
   payload: Schema.Array(Schema.String),
-  requestId: Schema.optional(Schema.String)
+  requestId: Schema.optional(RequestIdSchema)
 });
 const TextSoqlChangedEventSchema = Schema.Struct({
   type: Schema.Literal(MessageType.TEXT_SOQL_CHANGED),

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/services/message/soqlEditorEvent.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/services/message/soqlEditorEvent.ts
@@ -28,17 +28,13 @@ export const MessageType = {
 
 export type MessageType = (typeof MessageType)[keyof typeof MessageType];
 
-export const RequestIdSchema = Schema.String.pipe(Schema.brand('@soql/RequestId'));
-export type RequestId = Schema.Schema.Type<typeof RequestIdSchema>;
-
 export type SObjectMetadata = Pick<typeof SObjectSchema.Type, 'fields'>;
 
 const eventWithoutPayload = <T extends MessageType>(type: T) => Schema.Struct({ type: Schema.Literal(type) });
 
 const UiActivatedEventSchema = eventWithoutPayload(MessageType.UI_ACTIVATED);
 const SObjectsRequestEventSchema = Schema.Struct({
-  type: Schema.Literal(MessageType.SOBJECTS_REQUEST),
-  requestId: Schema.optional(RequestIdSchema)
+  type: Schema.Literal(MessageType.SOBJECTS_REQUEST)
 });
 const RunSoqlQueryEventSchema = eventWithoutPayload(MessageType.RUN_SOQL_QUERY);
 const RunSoqlQueryDoneEventSchema = eventWithoutPayload(MessageType.RUN_SOQL_QUERY_DONE);
@@ -57,18 +53,15 @@ const UiTelemetryEventSchema = Schema.Struct({
 });
 const SObjectMetadataRequestEventSchema = Schema.Struct({
   type: Schema.Literal(MessageType.SOBJECT_METADATA_REQUEST),
-  payload: Schema.String,
-  requestId: Schema.optional(RequestIdSchema)
+  payload: Schema.String
 });
 const SObjectMetadataResponseEventSchema = Schema.Struct({
   type: Schema.Literal(MessageType.SOBJECT_METADATA_RESPONSE),
-  payload: SObjectSchema,
-  requestId: Schema.optional(RequestIdSchema)
+  payload: SObjectSchema
 });
 const SObjectsResponseEventSchema = Schema.Struct({
   type: Schema.Literal(MessageType.SOBJECTS_RESPONSE),
-  payload: Schema.Array(Schema.String),
-  requestId: Schema.optional(RequestIdSchema)
+  payload: Schema.Array(Schema.String)
 });
 const TextSoqlChangedEventSchema = Schema.Struct({
   type: Schema.Literal(MessageType.TEXT_SOQL_CHANGED),

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/services/message/soqlEditorEvent.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/services/message/soqlEditorEvent.ts
@@ -28,26 +28,56 @@ export const MessageType = {
 export type MessageType = (typeof MessageType)[keyof typeof MessageType];
 
 const SObjectFieldSchema = Schema.Struct({
+  aggregatable: Schema.Boolean,
+  custom: Schema.Boolean,
+  defaultValue: Schema.NullOr(Schema.Unknown),
+  extraTypeInfo: Schema.NullOr(Schema.String),
+  filterable: Schema.Boolean,
+  groupable: Schema.Boolean,
+  inlineHelpText: Schema.NullOr(Schema.String),
+  label: Schema.String,
+  length: Schema.optional(Schema.Number),
   name: Schema.String,
-  type: Schema.String,
   nillable: Schema.Boolean,
-  picklistValues: Schema.optional(Schema.NullOr(Schema.Array(Schema.Unknown))),
-  filterable: Schema.optional(Schema.Boolean),
-  groupable: Schema.optional(Schema.Boolean),
-  label: Schema.optional(Schema.String),
-  sortable: Schema.optional(Schema.Boolean)
+  picklistValues: Schema.Array(
+    Schema.Struct({
+      active: Schema.Boolean,
+      label: Schema.NullOr(Schema.String),
+      value: Schema.String
+    })
+  ),
+  precision: Schema.optional(Schema.Number),
+  referenceTo: Schema.Array(Schema.String),
+  relationshipName: Schema.NullOr(Schema.String),
+  scale: Schema.optional(Schema.Number),
+  sortable: Schema.Boolean,
+  type: Schema.String
 });
 
 const SObjectMetadataSchema = Schema.Struct({
+  name: Schema.String,
+  label: Schema.String,
+  custom: Schema.Boolean,
+  queryable: Schema.Boolean,
+  childRelationships: Schema.Array(
+    Schema.Struct({
+      childSObject: Schema.String,
+      field: Schema.String,
+      relationshipName: Schema.NullOr(Schema.String)
+    })
+  ),
   fields: Schema.Array(SObjectFieldSchema)
 });
 
-export type SObjectMetadata = typeof SObjectMetadataSchema.Type;
+export type SObjectMetadata = Pick<typeof SObjectMetadataSchema.Type, 'fields'>;
 
 const eventWithoutPayload = <T extends MessageType>(type: T) => Schema.Struct({ type: Schema.Literal(type) });
 
 const UiActivatedEventSchema = eventWithoutPayload(MessageType.UI_ACTIVATED);
-const SObjectsRequestEventSchema = eventWithoutPayload(MessageType.SOBJECTS_REQUEST);
+const SObjectsRequestEventSchema = Schema.Struct({
+  type: Schema.Literal(MessageType.SOBJECTS_REQUEST),
+  requestId: Schema.optional(Schema.String)
+});
 const RunSoqlQueryEventSchema = eventWithoutPayload(MessageType.RUN_SOQL_QUERY);
 const RunSoqlQueryDoneEventSchema = eventWithoutPayload(MessageType.RUN_SOQL_QUERY_DONE);
 const ConnectionChangedEventSchema = eventWithoutPayload(MessageType.CONNECTION_CHANGED);
@@ -65,15 +95,18 @@ const UiTelemetryEventSchema = Schema.Struct({
 });
 const SObjectMetadataRequestEventSchema = Schema.Struct({
   type: Schema.Literal(MessageType.SOBJECT_METADATA_REQUEST),
-  payload: Schema.String
+  payload: Schema.String,
+  requestId: Schema.optional(Schema.String)
 });
 const SObjectMetadataResponseEventSchema = Schema.Struct({
   type: Schema.Literal(MessageType.SOBJECT_METADATA_RESPONSE),
-  payload: SObjectMetadataSchema
+  payload: SObjectMetadataSchema,
+  requestId: Schema.optional(Schema.String)
 });
 const SObjectsResponseEventSchema = Schema.Struct({
   type: Schema.Literal(MessageType.SOBJECTS_RESPONSE),
-  payload: Schema.Array(Schema.String)
+  payload: Schema.Array(Schema.String),
+  requestId: Schema.optional(Schema.String)
 });
 const TextSoqlChangedEventSchema = Schema.Struct({
   type: Schema.Literal(MessageType.TEXT_SOQL_CHANGED),

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/rollup.config.mjs
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/rollup.config.mjs
@@ -96,6 +96,15 @@ export default {
     alias({
       entries: [
         { find: 'os', replacement: 'os-browserify/browser' },
+        // The published services API is CommonJS. Resolve its browser-safe schema from the canonical ESM source
+        // so Rollup can tree-shake Effect instead of retaining the complete Schema module through a CJS require.
+        {
+          find: '@salesforce/vscode-services',
+          replacement: path.resolve(
+            __dirname,
+            '../../../salesforcedx-vscode-services/src/core/schemas/sObject.ts'
+          )
+        },
         // Non-component module: messages catalog (path ends with messages/i18n.ts for eslint-local-rules)
         {
           find: 'querybuilder/messages',

--- a/packages/salesforcedx-vscode-soql/test/baselines/soql-ui-bundles.json
+++ b/packages/salesforcedx-vscode-soql/test/baselines/soql-ui-bundles.json
@@ -6,12 +6,12 @@
       "name": "legacy builder application",
       "files": ["src/soql-builder-ui/dist/app.js"],
       "baseline": {
-        "rawBytes": 880931,
-        "gzipBytes": 231443
+        "rawBytes": 933725,
+        "gzipBytes": 246879
       },
       "budget": {
-        "rawBytes": 925000,
-        "gzipBytes": 242000
+        "rawBytes": 981000,
+        "gzipBytes": 260000
       }
     },
     {

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-builder-ui/lit/vscodeSoqlBuilderService.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-builder-ui/lit/vscodeSoqlBuilderService.test.ts
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+  SoqlBuilderServiceError,
+  SoqlBuilderStateSchema,
+  type SoqlBuilderAction,
+  type SoqlBuilderState
+} from '@salesforce/soql-builder-ui/domain';
+import { SoqlBuilderService } from '@salesforce/soql-builder-ui/service';
+import * as Duration from 'effect/Duration';
+import * as Effect from 'effect/Effect';
+import * as Fiber from 'effect/Fiber';
+import * as Layer from 'effect/Layer';
+import * as Option from 'effect/Option';
+import * as Schema from 'effect/Schema';
+import * as Stream from 'effect/Stream';
+import {
+  parseSoqlBuilderQuery,
+  serializeSoqlBuilderQuery
+} from '../../../../src/soql-builder-ui/lit/soqlBuilderModelAdapter';
+import { VscodeSoqlBuilderServiceLive } from '../../../../src/soql-builder-ui/lit/vscodeSoqlBuilderService';
+import {
+  MessageService,
+  type IMessageService
+} from '../../../../src/soql-builder-ui/modules/querybuilder/services/message/iMessageService';
+import {
+  MessageType,
+  type SoqlEditorEvent
+} from '../../../../src/soql-builder-ui/modules/querybuilder/services/message/soqlEditorEvent';
+
+const accountMetadata = {
+  childRelationships: [],
+  custom: false,
+  fields: [
+    {
+      aggregatable: false,
+      custom: false,
+      defaultValue: null,
+      extraTypeInfo: null,
+      filterable: true,
+      groupable: true,
+      inlineHelpText: null,
+      label: 'Account ID',
+      name: 'Id',
+      nillable: false,
+      picklistValues: [],
+      referenceTo: [],
+      relationshipName: null,
+      sortable: true,
+      type: 'id'
+    }
+  ],
+  label: 'Account',
+  name: 'Account',
+  queryable: true
+} as const;
+
+const makeMessageHarness = (savedState?: unknown) => {
+  const messages: SoqlEditorEvent[] = [];
+  const states: unknown[] = [];
+  let listener: ((event: SoqlEditorEvent) => void) | undefined;
+  let finalized = false;
+  const service: IMessageService = {
+    getState: () => savedState,
+    onMessage: callback => {
+      listener = callback;
+      return () => {
+        finalized = true;
+        listener = undefined;
+      };
+    },
+    sendMessage: message => messages.push(message),
+    setState: state => states.push(state)
+  };
+
+  return {
+    emit: (event: SoqlEditorEvent) => listener?.(event),
+    isFinalized: () => finalized,
+    layer: Layer.succeed(MessageService, service),
+    messages,
+    states
+  };
+};
+
+const runWithService = <A>(
+  messageLayer: Layer.Layer<MessageService>,
+  body: (service: SoqlBuilderService) => Effect.Effect<A, SoqlBuilderServiceError>
+) =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const service = yield* SoqlBuilderService;
+      return yield* body(service);
+    }).pipe(Effect.provide(VscodeSoqlBuilderServiceLive.pipe(Layer.provide(messageLayer))), Effect.scoped)
+  );
+
+const lastSavedState = (states: readonly unknown[]): SoqlBuilderState =>
+  Schema.decodeUnknownSync(SoqlBuilderStateSchema)(states.at(-1));
+
+describe('VscodeSoqlBuilderService', () => {
+  it('round-trips every supported query clause through the typed model adapter', () => {
+    const statement =
+      "// retained comment\nSELECT Name, Id FROM Account WHERE Name = 'Acme' AND Id != NULL ORDER BY Name DESC NULLS LAST LIMIT 10 ALL ROWS";
+    const parsed = parseSoqlBuilderQuery(statement);
+    const restored = parseSoqlBuilderQuery(serializeSoqlBuilderQuery(parsed));
+
+    expect(restored.headerComments).toContain('retained comment');
+    expect(restored.fields).toEqual(['Name', 'Id']);
+    expect(restored.where.andOr).toBe('AND');
+    expect(restored.where.conditions).toHaveLength(2);
+    expect(restored.orderBy).toEqual([{ field: 'Name', order: 'DESC', nulls: 'NULLS LAST' }]);
+    expect(restored.limit).toBe('10');
+    expect(restored.allRows).toBe(true);
+  });
+
+  it('maps every public action to immutable state and the existing host messages', async () => {
+    const harness = makeMessageHarness();
+
+    await runWithService(harness.layer, service =>
+      Effect.gen(function* () {
+        const actions: SoqlBuilderAction[] = [
+          { _tag: 'ObjectSelected', objectName: 'Account' },
+          { _tag: 'FieldsSelected', fieldNames: ['Id', 'Name'] },
+          { _tag: 'AllFieldsSelected' },
+          { _tag: 'AllFieldsCleared' },
+          {
+            _tag: 'WhereConditionUpserted',
+            andOr: 'AND',
+            condition: {
+              condition: {
+                compareValue: { type: 'STRING', value: "'Acme'" },
+                field: { fieldName: 'Name' },
+                operator: '='
+              },
+              index: 0
+            }
+          },
+          { _tag: 'WhereConjunctionChanged', andOr: 'OR' },
+          { _tag: 'WhereConditionRemoved', index: 0 },
+          {
+            _tag: 'OrderByUpserted',
+            orderBy: { field: 'Name', nulls: 'NULLS LAST', order: 'ASC' }
+          },
+          { _tag: 'OrderByRemoved', fieldName: 'Name' },
+          { _tag: 'LimitChanged', limit: '25' },
+          { _tag: 'AllRowsChanged', allRows: true },
+          { _tag: 'NotificationsDismissed' },
+          { _tag: 'SetDefaultOrgRequested' },
+          { _tag: 'RunQueryRequested' },
+          { _tag: 'QueryPlanRequested' }
+        ];
+
+        for (const action of actions) yield* service.dispatch(action);
+      })
+    );
+
+    const messageTypes = harness.messages.map(message => message.type);
+    expect(messageTypes[0]).toBe(MessageType.SOBJECTS_REQUEST);
+    expect(messageTypes).toContain(MessageType.SOBJECT_METADATA_REQUEST);
+    expect(messageTypes).toContain(MessageType.UI_SOQL_CHANGED);
+    expect(messageTypes).toContain(MessageType.SET_DEFAULT_ORG);
+    expect(messageTypes).toContain(MessageType.RUN_SOQL_QUERY);
+    expect(messageTypes).toContain(MessageType.GET_QUERY_PLAN);
+
+    const state = lastSavedState(harness.states);
+    expect(state.query.sObject).toBe('Account');
+    expect(state.query.limit).toBe('25');
+    expect(state.query.allRows).toBe(true);
+    expect(state.notificationsDismissed).toBe(true);
+  });
+
+  it('restores the complete query and does not echo external text changes', async () => {
+    const harness = makeMessageHarness();
+    const statement =
+      "// retained comment\nSELECT Name FROM Account WHERE Name = 'Acme' ORDER BY Name DESC NULLS LAST LIMIT 10 ALL ROWS";
+
+    const state = await runWithService(harness.layer, service =>
+      Effect.gen(function* () {
+        const stateFiber = yield* service.stateChanges.pipe(Stream.runHead, Effect.fork);
+        yield* Effect.sleep(Duration.millis(10));
+        harness.emit({ type: MessageType.TEXT_SOQL_CHANGED, payload: statement });
+        return Option.getOrThrow(yield* Fiber.join(stateFiber));
+      })
+    );
+
+    expect(state.query.headerComments).toContain('retained comment');
+    expect(state.query.fields).toEqual(['Name']);
+    expect(state.query.where.conditions).toHaveLength(1);
+    expect(state.query.orderBy).toEqual([{ field: 'Name', order: 'DESC', nulls: 'NULLS LAST' }]);
+    expect(state.query.limit).toBe('10');
+    expect(state.query.allRows).toBe(true);
+    expect(harness.messages.filter(message => message.type === MessageType.UI_SOQL_CHANGED)).toHaveLength(0);
+  });
+
+  it('ignores stale metadata responses and accepts only the active request', async () => {
+    const harness = makeMessageHarness();
+
+    const state = await runWithService(harness.layer, service =>
+      Effect.gen(function* () {
+        yield* service.dispatch({ _tag: 'ObjectSelected', objectName: 'Account' });
+        const accountRequest = harness.messages.findLast(
+          message => message.type === MessageType.SOBJECT_METADATA_REQUEST
+        );
+        yield* service.dispatch({ _tag: 'ObjectSelected', objectName: 'Contact' });
+        const contactRequest = harness.messages.findLast(
+          message => message.type === MessageType.SOBJECT_METADATA_REQUEST
+        );
+
+        const stateFiber = yield* service.stateChanges.pipe(Stream.runHead, Effect.fork);
+        yield* Effect.sleep(Duration.millis(10));
+        harness.emit({
+          type: MessageType.SOBJECT_METADATA_RESPONSE,
+          payload: accountMetadata,
+          requestId: accountRequest?.requestId
+        });
+        harness.emit({
+          type: MessageType.SOBJECT_METADATA_RESPONSE,
+          payload: { ...accountMetadata, label: 'Contact', name: 'Contact' },
+          requestId: contactRequest?.requestId
+        });
+        return Option.getOrThrow(yield* Fiber.join(stateFiber));
+      })
+    );
+
+    expect(state.metadata.selectedObjectName).toBe('Contact');
+    expect(state.isFieldsLoading).toBe(false);
+  });
+
+  it('tracks query and query-plan progress until the host reports completion', async () => {
+    const harness = makeMessageHarness();
+
+    await runWithService(harness.layer, service =>
+      Effect.gen(function* () {
+        yield* service.dispatch({ _tag: 'RunQueryRequested' });
+        yield* service.dispatch({ _tag: 'QueryPlanRequested' });
+
+        const running = yield* service.initialState;
+        expect(running.isQueryRunning).toBe(true);
+        expect(running.isQueryPlanRunning).toBe(true);
+
+        harness.emit({ type: MessageType.RUN_SOQL_QUERY_DONE });
+        harness.emit({ type: MessageType.GET_QUERY_PLAN_DONE });
+        yield* Effect.sleep(Duration.millis(10));
+
+        const completed = yield* service.initialState;
+        expect(completed.isQueryRunning).toBe(false);
+        expect(completed.isQueryPlanRunning).toBe(false);
+      })
+    );
+  });
+
+  it('runs the message-listener finalizer when its scoped layer closes', async () => {
+    const harness = makeMessageHarness();
+    await runWithService(harness.layer, () => Effect.void);
+    expect(harness.isFinalized()).toBe(true);
+  });
+});

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-builder-ui/lit/vscodeSoqlBuilderService.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-builder-ui/lit/vscodeSoqlBuilderService.test.ts
@@ -113,7 +113,7 @@ describe('VscodeSoqlBuilderService', () => {
     expect(restored.where.andOr).toBe('AND');
     expect(restored.where.conditions).toHaveLength(2);
     expect(restored.orderBy).toEqual([{ field: 'Name', order: 'DESC', nulls: 'NULLS LAST' }]);
-    expect(restored.limit).toBe('10');
+    expect(restored.limit).toEqual({ _tag: 'Valid', value: 10 });
     expect(restored.allRows).toBe(true);
   });
 
@@ -146,7 +146,7 @@ describe('VscodeSoqlBuilderService', () => {
             orderBy: { field: 'Name', nulls: 'NULLS LAST', order: 'ASC' }
           },
           { _tag: 'OrderByRemoved', fieldName: 'Name' },
-          { _tag: 'LimitChanged', limit: '25' },
+          { _tag: 'LimitChanged', limit: { _tag: 'Valid', value: 25 } },
           { _tag: 'AllRowsChanged', allRows: true },
           { _tag: 'NotificationsDismissed' },
           { _tag: 'SetDefaultOrgRequested' },
@@ -168,7 +168,7 @@ describe('VscodeSoqlBuilderService', () => {
 
     const state = lastSavedState(harness.states);
     expect(state.query.sObject).toBe('Account');
-    expect(state.query.limit).toBe('25');
+    expect(state.query.limit).toEqual({ _tag: 'Valid', value: 25 });
     expect(state.query.allRows).toBe(true);
     expect(state.notificationsDismissed).toBe(true);
   });
@@ -191,36 +191,66 @@ describe('VscodeSoqlBuilderService', () => {
     expect(state.query.fields).toEqual(['Name']);
     expect(state.query.where.conditions).toHaveLength(1);
     expect(state.query.orderBy).toEqual([{ field: 'Name', order: 'DESC', nulls: 'NULLS LAST' }]);
-    expect(state.query.limit).toBe('10');
+    expect(state.query.limit).toEqual({ _tag: 'Valid', value: 10 });
     expect(state.query.allRows).toBe(true);
     expect(harness.messages.filter(message => message.type === MessageType.UI_SOQL_CHANGED)).toHaveLength(0);
   });
 
-  it('ignores stale metadata responses and accepts only the active request', async () => {
+  it('restores a legacy string limit as a valid numeric limit', async () => {
+    const harness = makeMessageHarness({
+      limit: '10',
+      originalSoqlStatement: 'SELECT Id FROM Account LIMIT 10'
+    });
+
+    const state = await runWithService(harness.layer, service => service.initialState);
+
+    expect(state.query.limit).toEqual({ _tag: 'Valid', value: 10 });
+  });
+
+  it('retains invalid limit input without publishing malformed SOQL', async () => {
     const harness = makeMessageHarness();
 
     const state = await runWithService(harness.layer, service =>
       Effect.gen(function* () {
         yield* service.dispatch({ _tag: 'ObjectSelected', objectName: 'Account' });
-        const accountRequest = harness.messages.findLast(
-          message => message.type === MessageType.SOBJECT_METADATA_REQUEST
+        const publishedBeforeInvalid = harness.messages.filter(
+          message => message.type === MessageType.UI_SOQL_CHANGED
+        ).length;
+
+        yield* service.dispatch({ _tag: 'LimitChanged', limit: { _tag: 'Invalid', input: '-1' } });
+        const invalidState = yield* service.initialState;
+        expect(invalidState.query.limit).toEqual({ _tag: 'Invalid', input: '-1' });
+        expect(harness.messages.filter(message => message.type === MessageType.UI_SOQL_CHANGED)).toHaveLength(
+          publishedBeforeInvalid
         );
+
+        yield* service.dispatch({ _tag: 'LimitChanged', limit: { _tag: 'Empty' } });
+        return yield* service.initialState;
+      })
+    );
+
+    expect(state.query.limit).toEqual({ _tag: 'Empty' });
+    const lastQueryMessage = harness.messages.findLast(message => message.type === MessageType.UI_SOQL_CHANGED);
+    expect(lastQueryMessage?.payload).not.toContain('LIMIT');
+  });
+
+  it('ignores metadata responses for an object that is no longer selected', async () => {
+    const harness = makeMessageHarness();
+
+    const state = await runWithService(harness.layer, service =>
+      Effect.gen(function* () {
+        yield* service.dispatch({ _tag: 'ObjectSelected', objectName: 'Account' });
         yield* service.dispatch({ _tag: 'ObjectSelected', objectName: 'Contact' });
-        const contactRequest = harness.messages.findLast(
-          message => message.type === MessageType.SOBJECT_METADATA_REQUEST
-        );
 
         const stateFiber = yield* service.stateChanges.pipe(Stream.runHead, Effect.fork);
         yield* Effect.sleep(Duration.millis(10));
         harness.emit({
           type: MessageType.SOBJECT_METADATA_RESPONSE,
-          payload: accountMetadata,
-          requestId: accountRequest?.requestId
+          payload: accountMetadata
         });
         harness.emit({
           type: MessageType.SOBJECT_METADATA_RESPONSE,
-          payload: { ...accountMetadata, label: 'Contact', name: 'Contact' },
-          requestId: contactRequest?.requestId
+          payload: { ...accountMetadata, label: 'Contact', name: 'Contact' }
         });
         return Option.getOrThrow(yield* Fiber.join(stateFiber));
       })

--- a/packages/soql-builder-ui/package.json
+++ b/packages/soql-builder-ui/package.json
@@ -44,6 +44,9 @@
     "compile": {
       "command": "tsc --pretty",
       "clean": "if-file-deleted",
+      "dependencies": [
+        "../salesforcedx-vscode-services-types:compile"
+      ],
       "files": [
         "src/**/*.ts",
         "tsconfig.json",
@@ -113,6 +116,7 @@
     }
   },
   "dependencies": {
+    "@salesforce/vscode-services": "*",
     "@vscode-elements/elements": "^2.5.1",
     "effect": "^3.21.2",
     "lit": "3.3.3"

--- a/packages/soql-builder-ui/src/application.ts
+++ b/packages/soql-builder-ui/src/application.ts
@@ -21,7 +21,7 @@ import {
   type SoqlBuilderServiceError,
   type SoqlBuilderState
 } from './domain.js';
-import { SoqlBuilderController, SoqlBuilderControllerLive } from './effect/soqlBuilderController.js';
+import { SoqlBuilderController } from './effect/soqlBuilderController.js';
 
 export type SoqlBuilderView = {
   viewState: SoqlBuilderState;
@@ -45,7 +45,7 @@ export class SoqlBuilderApplication {
     private readonly view: SoqlBuilderView,
     serviceLayer: Layer.Layer<SoqlBuilderService, SoqlBuilderServiceError>
   ) {
-    this.runtime = ManagedRuntime.make(SoqlBuilderControllerLive.pipe(Layer.provide(serviceLayer)));
+    this.runtime = ManagedRuntime.make(SoqlBuilderController.Default.pipe(Layer.provide(serviceLayer)));
   }
 
   public readonly connect = (): void => {
@@ -81,7 +81,7 @@ export class SoqlBuilderApplication {
         );
       }).pipe(
         Effect.scoped,
-        Effect.catchTag('SoqlBuilderServiceError', error =>
+        Effect.catchAll(error =>
           Effect.sync(() => {
             this.view.viewState = {
               ...createInitialSoqlBuilderState(),

--- a/packages/soql-builder-ui/src/components/soqlBuilderElement.ts
+++ b/packages/soql-builder-ui/src/components/soqlBuilderElement.ts
@@ -73,6 +73,8 @@ export class SoqlBuilderElement extends LitElement {
 
   protected override render() {
     const state = this.viewState;
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- an empty statement must still render as `nothing`, unlike a merely-unset one; `??` would not collapse ''
+    const queryPreview = state.query.originalSoqlStatement ? state.query.originalSoqlStatement : nothing;
     return html`
       <main>
         ${state.errorMessage || state.hasNoDefaultOrg
@@ -88,7 +90,7 @@ export class SoqlBuilderElement extends LitElement {
                       filter="startsWithPerTerm"
                       label=${this.labels.from}
                       ?disabled=${state.isObjectsLoading}
-                      .value=${state.query.sObject}
+                      .value=${state.query.sObject ?? ''}
                       @change=${this.handleObjectChange}
                     >
                       ${state.metadata.objects.map(
@@ -103,7 +105,7 @@ export class SoqlBuilderElement extends LitElement {
                       combobox
                       filter="startsWithPerTerm"
                       label=${this.labels.fields}
-                      ?disabled=${state.isFieldsLoading || state.query.sObject.length === 0}
+                      ?disabled=${state.isFieldsLoading || state.query.sObject === undefined}
                       .value=${state.query.fields}
                       @change=${this.handleFieldsChange}
                     >
@@ -115,7 +117,7 @@ export class SoqlBuilderElement extends LitElement {
                 </section>
                 <section class="preview" aria-live="polite">
                   <div class="preview-title">${this.labels.query}</div>
-                  <pre data-testid="query-preview">${state.query.originalSoqlStatement || nothing}</pre>
+                  <pre data-testid="query-preview">${queryPreview}</pre>
                 </section>
               </div>
             `}

--- a/packages/soql-builder-ui/src/components/soqlBuilderElement.ts
+++ b/packages/soql-builder-ui/src/components/soqlBuilderElement.ts
@@ -64,7 +64,11 @@ export class SoqlBuilderElement extends LitElement {
 
   public override disconnectedCallback(): void {
     super.disconnectedCallback();
-    void this.lifecycle?.disconnect();
+    // disconnectedCallback must stay synchronous (Custom Elements contract); attach a catch
+    // so a rejected teardown does not surface as a silent unhandled rejection.
+    void Promise.resolve(this.lifecycle?.disconnect()).catch(() => {
+      // disconnect rejections during teardown are non-actionable
+    });
   }
 
   protected override render() {

--- a/packages/soql-builder-ui/src/domain.ts
+++ b/packages/soql-builder-ui/src/domain.ts
@@ -29,9 +29,12 @@ const SoqlFieldMetadataSchema = Schema.Struct({
   filterable: Schema.Boolean,
   groupable: Schema.Boolean,
   inlineHelpText: Schema.NullOr(Schema.String),
-  label: Schema.NonEmptyTrimmedString,
+  // Host describe payloads (see salesforcedx-vscode-services SObjectFieldSchema) allow empty
+  // strings here; keep these as plain String so a single sparse field cannot fail the whole
+  // metadata decode and blank the UI.
+  label: Schema.String,
   length: Schema.optional(Schema.Number),
-  name: Schema.NonEmptyTrimmedString,
+  name: Schema.String,
   nillable: Schema.Boolean,
   picklistValues: Schema.Array(SoqlPicklistValueSchema),
   precision: Schema.optional(Schema.Number),
@@ -39,7 +42,7 @@ const SoqlFieldMetadataSchema = Schema.Struct({
   relationshipName: Schema.NullOr(Schema.String),
   scale: Schema.optional(Schema.Number),
   sortable: Schema.Boolean,
-  type: Schema.NonEmptyTrimmedString
+  type: Schema.String
 });
 
 const SoqlChildRelationshipSchema = Schema.Struct({

--- a/packages/soql-builder-ui/src/domain.ts
+++ b/packages/soql-builder-ui/src/domain.ts
@@ -15,32 +15,107 @@ const SoqlObjectMetadataSchema = Schema.Struct({
   queryable: Schema.Boolean
 });
 
+const SoqlPicklistValueSchema = Schema.Struct({
+  active: Schema.Boolean,
+  label: Schema.NullOr(Schema.String),
+  value: Schema.String
+});
+
 const SoqlFieldMetadataSchema = Schema.Struct({
-  name: Schema.NonEmptyTrimmedString,
-  label: Schema.NonEmptyTrimmedString,
-  type: Schema.NonEmptyTrimmedString,
+  aggregatable: Schema.Boolean,
+  custom: Schema.Boolean,
+  defaultValue: Schema.NullOr(Schema.Unknown),
+  extraTypeInfo: Schema.NullOr(Schema.String),
   filterable: Schema.Boolean,
   groupable: Schema.Boolean,
-  sortable: Schema.Boolean
+  inlineHelpText: Schema.NullOr(Schema.String),
+  label: Schema.NonEmptyTrimmedString,
+  length: Schema.optional(Schema.Number),
+  name: Schema.NonEmptyTrimmedString,
+  nillable: Schema.Boolean,
+  picklistValues: Schema.Array(SoqlPicklistValueSchema),
+  precision: Schema.optional(Schema.Number),
+  referenceTo: Schema.Array(Schema.String),
+  relationshipName: Schema.NullOr(Schema.String),
+  scale: Schema.optional(Schema.Number),
+  sortable: Schema.Boolean,
+  type: Schema.NonEmptyTrimmedString
+});
+
+const SoqlChildRelationshipSchema = Schema.Struct({
+  childSObject: Schema.NonEmptyTrimmedString,
+  field: Schema.NonEmptyTrimmedString,
+  relationshipName: Schema.NullOr(Schema.String)
 });
 
 const SoqlBuilderMetadataSchema = Schema.Struct({
   objects: Schema.Array(SoqlObjectMetadataSchema),
-  fields: Schema.Array(SoqlFieldMetadataSchema)
+  fields: Schema.Array(SoqlFieldMetadataSchema),
+  childRelationships: Schema.Array(SoqlChildRelationshipSchema),
+  selectedObjectName: Schema.optional(Schema.NonEmptyTrimmedString)
 });
 
-export type SoqlBuilderState = {
-  readonly metadata: typeof SoqlBuilderMetadataSchema.Type;
-  readonly errorMessage?: string;
-  readonly hasNoDefaultOrg: boolean;
-  readonly isFieldsLoading: boolean;
-  readonly isObjectsLoading: boolean;
-  readonly query: {
-    readonly fields: readonly string[];
-    readonly originalSoqlStatement: string;
-    readonly sObject: string;
-  };
-};
+const SoqlOrderBySchema = Schema.Struct({
+  field: Schema.NonEmptyTrimmedString,
+  order: Schema.optional(Schema.Literal('ASC', 'DESC')),
+  nulls: Schema.optional(Schema.Literal('NULLS FIRST', 'NULLS LAST'))
+});
+
+const SoqlLiteralSchema = Schema.Struct({
+  kind: Schema.optional(Schema.Literal('literal')),
+  type: Schema.Literal('BOOLEAN', 'CURRENCY', 'DATE', 'NULL', 'NUMBER', 'STRING'),
+  value: Schema.String
+});
+
+export type SoqlLiteral = typeof SoqlLiteralSchema.Type;
+
+const SoqlWhereConditionSchema = Schema.Struct({
+  index: Schema.NonNegativeInt,
+  condition: Schema.Struct({
+    kind: Schema.optional(Schema.Literal('fieldCompare', 'includes', 'inList')),
+    field: Schema.Struct({
+      kind: Schema.optional(Schema.Literal('fieldRef')),
+      fieldName: Schema.NonEmptyTrimmedString
+    }),
+    operator: Schema.Literal('=', '!=', '<>', '<=', '>=', '<', '>', 'LIKE', 'IN', 'NOT IN', 'INCLUDES', 'EXCLUDES'),
+    compareValue: Schema.optional(SoqlLiteralSchema),
+    values: Schema.optional(SoqlLiteralSchema.pipe(Schema.Array))
+  })
+});
+
+export type SoqlWhereCondition = typeof SoqlWhereConditionSchema.Type;
+
+const SoqlBuilderQuerySchema = Schema.Struct({
+  headerComments: Schema.optional(Schema.String),
+  allRows: Schema.Boolean,
+  fields: Schema.Array(Schema.NonEmptyTrimmedString),
+  limit: Schema.String,
+  orderBy: Schema.Array(SoqlOrderBySchema),
+  originalSoqlStatement: Schema.String,
+  parseErrors: Schema.Array(Schema.Record({ key: Schema.String, value: Schema.Unknown })),
+  sObject: Schema.String,
+  unsupportedSyntax: Schema.Array(Schema.Record({ key: Schema.String, value: Schema.Unknown })),
+  where: Schema.Struct({
+    andOr: Schema.optional(Schema.Literal('AND', 'OR')),
+    conditions: Schema.Array(SoqlWhereConditionSchema)
+  })
+});
+
+export type SoqlBuilderQuery = typeof SoqlBuilderQuerySchema.Type;
+
+export const SoqlBuilderStateSchema = Schema.Struct({
+  metadata: SoqlBuilderMetadataSchema,
+  errorMessage: Schema.optional(Schema.String),
+  hasNoDefaultOrg: Schema.Boolean,
+  isFieldsLoading: Schema.Boolean,
+  isObjectsLoading: Schema.Boolean,
+  isQueryPlanRunning: Schema.Boolean,
+  isQueryRunning: Schema.Boolean,
+  notificationsDismissed: Schema.Boolean,
+  query: SoqlBuilderQuerySchema
+});
+
+export type SoqlBuilderState = typeof SoqlBuilderStateSchema.Type;
 
 export const SoqlBuilderActionSchema = Schema.Union(
   Schema.TaggedStruct('ObjectSelected', {
@@ -48,7 +123,35 @@ export const SoqlBuilderActionSchema = Schema.Union(
   }),
   Schema.TaggedStruct('FieldsSelected', {
     fieldNames: Schema.Array(Schema.NonEmptyTrimmedString)
-  })
+  }),
+  Schema.TaggedStruct('AllFieldsSelected', {}),
+  Schema.TaggedStruct('AllFieldsCleared', {}),
+  Schema.TaggedStruct('WhereConditionUpserted', {
+    condition: SoqlWhereConditionSchema,
+    andOr: Schema.optional(Schema.Literal('AND', 'OR'))
+  }),
+  Schema.TaggedStruct('WhereConditionRemoved', {
+    index: Schema.NonNegativeInt
+  }),
+  Schema.TaggedStruct('WhereConjunctionChanged', {
+    andOr: Schema.Literal('AND', 'OR')
+  }),
+  Schema.TaggedStruct('OrderByUpserted', {
+    orderBy: SoqlOrderBySchema
+  }),
+  Schema.TaggedStruct('OrderByRemoved', {
+    fieldName: Schema.NonEmptyTrimmedString
+  }),
+  Schema.TaggedStruct('LimitChanged', {
+    limit: Schema.String
+  }),
+  Schema.TaggedStruct('AllRowsChanged', {
+    allRows: Schema.Boolean
+  }),
+  Schema.TaggedStruct('NotificationsDismissed', {}),
+  Schema.TaggedStruct('SetDefaultOrgRequested', {}),
+  Schema.TaggedStruct('RunQueryRequested', {}),
+  Schema.TaggedStruct('QueryPlanRequested', {})
 );
 
 export type SoqlBuilderAction = typeof SoqlBuilderActionSchema.Type;
@@ -85,17 +188,29 @@ export const decodeSoqlBuilderMetadata = (input: unknown) =>
     )
   );
 
+export const createInitialSoqlBuilderQuery = (): SoqlBuilderQuery => ({
+  allRows: false,
+  fields: [],
+  limit: '',
+  orderBy: [],
+  originalSoqlStatement: '',
+  parseErrors: [],
+  sObject: '',
+  unsupportedSyntax: [],
+  where: { conditions: [] }
+});
+
 export const createInitialSoqlBuilderState = (): SoqlBuilderState => ({
   metadata: {
+    childRelationships: [],
     fields: [],
     objects: []
   },
   hasNoDefaultOrg: false,
   isFieldsLoading: false,
   isObjectsLoading: false,
-  query: {
-    fields: [],
-    originalSoqlStatement: '',
-    sObject: ''
-  }
+  isQueryPlanRunning: false,
+  isQueryRunning: false,
+  notificationsDismissed: false,
+  query: createInitialSoqlBuilderQuery()
 });

--- a/packages/soql-builder-ui/src/domain.ts
+++ b/packages/soql-builder-ui/src/domain.ts
@@ -69,11 +69,31 @@ const SoqlUnsupportedSyntaxSchema = Schema.Struct({
   })
 });
 
+export const SoqlLimitSchema = Schema.Union(
+  Schema.TaggedStruct('Empty', {}),
+  Schema.TaggedStruct('Valid', {
+    value: Schema.NonNegativeInt.pipe(Schema.lessThanOrEqualTo(Number.MAX_SAFE_INTEGER))
+  }),
+  Schema.TaggedStruct('Invalid', {
+    input: Schema.String.pipe(Schema.minLength(1))
+  })
+);
+
+export type SoqlLimit = typeof SoqlLimitSchema.Type;
+
+export const soqlLimitFromInput = (input: string): SoqlLimit => {
+  if (input.length === 0) return { _tag: 'Empty' };
+  if (!/^\d+$/u.test(input)) return { _tag: 'Invalid', input };
+
+  const value = Number(input);
+  return Number.isSafeInteger(value) ? { _tag: 'Valid', value } : { _tag: 'Invalid', input };
+};
+
 const SoqlBuilderQuerySchema = Schema.Struct({
   headerComments: Schema.optional(Schema.String),
   allRows: Schema.Boolean,
   fields: Schema.Array(Schema.NonEmptyTrimmedString),
-  limit: Schema.optional(Schema.String),
+  limit: SoqlLimitSchema,
   orderBy: Schema.Array(SoqlOrderBySchema),
   originalSoqlStatement: Schema.optional(Schema.String),
   parseErrors: Schema.Array(SoqlParseErrorSchema),
@@ -127,7 +147,7 @@ export const SoqlBuilderActionSchema = Schema.Union(
     fieldName: Schema.NonEmptyTrimmedString
   }),
   Schema.TaggedStruct('LimitChanged', {
-    limit: Schema.String
+    limit: SoqlLimitSchema
   }),
   Schema.TaggedStruct('AllRowsChanged', {
     allRows: Schema.Boolean
@@ -191,6 +211,7 @@ export const decodeSoqlBuilderMetadata = (input: unknown) =>
 export const createInitialSoqlBuilderQuery = (): SoqlBuilderQuery => ({
   allRows: false,
   fields: [],
+  limit: { _tag: 'Empty' },
   orderBy: [],
   parseErrors: [],
   unsupportedSyntax: [],

--- a/packages/soql-builder-ui/src/domain.ts
+++ b/packages/soql-builder-ui/src/domain.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { ChildRelationshipSchema, SObjectFieldSchema } from '@salesforce/vscode-services';
 import * as Effect from 'effect/Effect';
 import * as ParseResult from 'effect/ParseResult';
 import * as Schema from 'effect/Schema';
@@ -15,46 +16,10 @@ const SoqlObjectMetadataSchema = Schema.Struct({
   queryable: Schema.Boolean
 });
 
-const SoqlPicklistValueSchema = Schema.Struct({
-  active: Schema.Boolean,
-  label: Schema.NullOr(Schema.String),
-  value: Schema.String
-});
-
-const SoqlFieldMetadataSchema = Schema.Struct({
-  aggregatable: Schema.Boolean,
-  custom: Schema.Boolean,
-  defaultValue: Schema.NullOr(Schema.Unknown),
-  extraTypeInfo: Schema.NullOr(Schema.String),
-  filterable: Schema.Boolean,
-  groupable: Schema.Boolean,
-  inlineHelpText: Schema.NullOr(Schema.String),
-  // Host describe payloads (see salesforcedx-vscode-services SObjectFieldSchema) allow empty
-  // strings here; keep these as plain String so a single sparse field cannot fail the whole
-  // metadata decode and blank the UI.
-  label: Schema.String,
-  length: Schema.optional(Schema.Number),
-  name: Schema.String,
-  nillable: Schema.Boolean,
-  picklistValues: Schema.Array(SoqlPicklistValueSchema),
-  precision: Schema.optional(Schema.Number),
-  referenceTo: Schema.Array(Schema.String),
-  relationshipName: Schema.NullOr(Schema.String),
-  scale: Schema.optional(Schema.Number),
-  sortable: Schema.Boolean,
-  type: Schema.String
-});
-
-const SoqlChildRelationshipSchema = Schema.Struct({
-  childSObject: Schema.NonEmptyTrimmedString,
-  field: Schema.NonEmptyTrimmedString,
-  relationshipName: Schema.NullOr(Schema.String)
-});
-
 const SoqlBuilderMetadataSchema = Schema.Struct({
   objects: Schema.Array(SoqlObjectMetadataSchema),
-  fields: Schema.Array(SoqlFieldMetadataSchema),
-  childRelationships: Schema.Array(SoqlChildRelationshipSchema),
+  fields: Schema.Array(SObjectFieldSchema),
+  childRelationships: Schema.Array(ChildRelationshipSchema),
   selectedObjectName: Schema.optional(Schema.NonEmptyTrimmedString)
 });
 
@@ -88,16 +53,32 @@ const SoqlWhereConditionSchema = Schema.Struct({
 
 export type SoqlWhereCondition = typeof SoqlWhereConditionSchema.Type;
 
+const SoqlParseErrorSchema = Schema.Struct({
+  type: Schema.String,
+  message: Schema.String,
+  lineNumber: Schema.Number,
+  charInLine: Schema.Number,
+  grammarRule: Schema.optional(Schema.String)
+});
+
+const SoqlUnsupportedSyntaxSchema = Schema.Struct({
+  unmodeledSyntax: Schema.String,
+  reason: Schema.Struct({
+    reasonCode: Schema.String,
+    message: Schema.String
+  })
+});
+
 const SoqlBuilderQuerySchema = Schema.Struct({
   headerComments: Schema.optional(Schema.String),
   allRows: Schema.Boolean,
   fields: Schema.Array(Schema.NonEmptyTrimmedString),
-  limit: Schema.String,
+  limit: Schema.optional(Schema.String),
   orderBy: Schema.Array(SoqlOrderBySchema),
-  originalSoqlStatement: Schema.String,
-  parseErrors: Schema.Array(Schema.Record({ key: Schema.String, value: Schema.Unknown })),
-  sObject: Schema.String,
-  unsupportedSyntax: Schema.Array(Schema.Record({ key: Schema.String, value: Schema.Unknown })),
+  originalSoqlStatement: Schema.optional(Schema.String),
+  parseErrors: Schema.Array(SoqlParseErrorSchema),
+  sObject: Schema.optional(Schema.String),
+  unsupportedSyntax: Schema.Array(SoqlUnsupportedSyntaxSchema),
   where: Schema.Struct({
     andOr: Schema.optional(Schema.Literal('AND', 'OR')),
     conditions: Schema.Array(SoqlWhereConditionSchema)
@@ -172,14 +153,30 @@ export class InvalidSoqlBuilderMetadataError extends Schema.TaggedError<InvalidS
   }
 }
 
-export class SoqlBuilderServiceError extends Schema.TaggedError<SoqlBuilderServiceError>()('SoqlBuilderServiceError', {
-  operation: Schema.Literal('initialize', 'subscribe', 'dispatch'),
+export class SoqlBuilderMessageChannelError extends Schema.TaggedError<SoqlBuilderMessageChannelError>()(
+  'SoqlBuilderMessageChannelError',
+  {
+    details: Schema.String
+  }
+) {
+  public override get message(): string {
+    return this.details;
+  }
+}
+
+export class SoqlBuilderQueryError extends Schema.TaggedError<SoqlBuilderQueryError>()('SoqlBuilderQueryError', {
   details: Schema.String
 }) {
   public override get message(): string {
     return this.details;
   }
 }
+
+/** The error channel shared by every `SoqlBuilderService` implementation: host-transport breakdowns, malformed SOQL, and invalid metadata. */
+export type SoqlBuilderServiceError =
+  | SoqlBuilderMessageChannelError
+  | SoqlBuilderQueryError
+  | InvalidSoqlBuilderMetadataError;
 
 export const decodeSoqlBuilderMetadata = (input: unknown) =>
   Schema.decodeUnknown(SoqlBuilderMetadataSchema)(input).pipe(
@@ -194,11 +191,8 @@ export const decodeSoqlBuilderMetadata = (input: unknown) =>
 export const createInitialSoqlBuilderQuery = (): SoqlBuilderQuery => ({
   allRows: false,
   fields: [],
-  limit: '',
   orderBy: [],
-  originalSoqlStatement: '',
   parseErrors: [],
-  sObject: '',
   unsupportedSyntax: [],
   where: { conditions: [] }
 });

--- a/packages/soql-builder-ui/src/effect/soqlBuilderController.ts
+++ b/packages/soql-builder-ui/src/effect/soqlBuilderController.ts
@@ -5,45 +5,36 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import type { SoqlBuilderAction, SoqlBuilderServiceError, SoqlBuilderState } from '../domain.js';
-import * as Context from 'effect/Context';
+import type { SoqlBuilderServiceError, SoqlBuilderState } from '../domain.js';
 import * as Effect from 'effect/Effect';
-import * as Layer from 'effect/Layer';
 import * as Stream from 'effect/Stream';
 import * as SubscriptionRef from 'effect/SubscriptionRef';
 import { SoqlBuilderService } from './soqlBuilderService.js';
-
-export type SoqlBuilderController = {
-  readonly states: Stream.Stream<SoqlBuilderState>;
-  readonly dispatch: (action: SoqlBuilderAction) => Effect.Effect<void, SoqlBuilderServiceError>;
-};
-
-export const SoqlBuilderController = Context.GenericTag<SoqlBuilderController>(
-  '@salesforce/soql-builder-ui/controller'
-);
 
 const stateWithServiceError = (state: SoqlBuilderState, error: SoqlBuilderServiceError): SoqlBuilderState => ({
   ...state,
   errorMessage: error.message
 });
 
-const makeSoqlBuilderController = Effect.gen(function* () {
-  const service = yield* SoqlBuilderService;
-  const initialState = yield* service.initialState;
-  const state = yield* SubscriptionRef.make(initialState);
+export class SoqlBuilderController extends Effect.Service<SoqlBuilderController>()(
+  '@salesforce/soql-builder-ui/controller',
+  {
+    accessors: true,
+    scoped: Effect.gen(function* () {
+      const service = yield* SoqlBuilderService;
+      const initialState = yield* service.initialState;
+      const state = yield* SubscriptionRef.make(initialState);
 
-  yield* service.stateChanges.pipe(
-    Stream.runForEach(nextState => SubscriptionRef.set(state, nextState)),
-    Effect.catchTag('SoqlBuilderServiceError', error =>
-      SubscriptionRef.update(state, current => stateWithServiceError(current, error))
-    ),
-    Effect.forkScoped
-  );
+      yield* service.stateChanges.pipe(
+        Stream.runForEach(nextState => SubscriptionRef.set(state, nextState)),
+        Effect.catchAll(error => SubscriptionRef.update(state, current => stateWithServiceError(current, error))),
+        Effect.forkScoped
+      );
 
-  return SoqlBuilderController.of({
-    dispatch: service.dispatch,
-    states: state.changes
-  });
-});
-
-export const SoqlBuilderControllerLive = Layer.scoped(SoqlBuilderController, makeSoqlBuilderController);
+      return {
+        dispatch: service.dispatch,
+        states: state.changes
+      };
+    })
+  }
+) {}

--- a/packages/soql-builder-ui/src/effect/soqlBuilderController.ts
+++ b/packages/soql-builder-ui/src/effect/soqlBuilderController.ts
@@ -34,7 +34,9 @@ const makeSoqlBuilderController = Effect.gen(function* () {
 
   yield* service.stateChanges.pipe(
     Stream.runForEach(nextState => SubscriptionRef.set(state, nextState)),
-    Effect.catchAll(error => SubscriptionRef.update(state, current => stateWithServiceError(current, error))),
+    Effect.catchTag('SoqlBuilderServiceError', error =>
+      SubscriptionRef.update(state, current => stateWithServiceError(current, error))
+    ),
     Effect.forkScoped
   );
 

--- a/packages/soql-builder-ui/src/testing/fakeSoqlBuilderService.ts
+++ b/packages/soql-builder-ui/src/testing/fakeSoqlBuilderService.ts
@@ -5,9 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import type { SoqlBuilderAction, SoqlBuilderState } from '../domain.js';
+import type { SoqlBuilderAction, SoqlBuilderServiceError, SoqlBuilderState } from '../domain.js';
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
+import * as PubSub from 'effect/PubSub';
 import * as Queue from 'effect/Queue';
 import * as Ref from 'effect/Ref';
 import * as Stream from 'effect/Stream';
@@ -20,6 +21,7 @@ import {
 type FakeSoqlBuilderService = {
   readonly layer: Layer.Layer<SoqlBuilderService>;
   readonly emit: (state: SoqlBuilderState) => Effect.Effect<void>;
+  readonly fail: (error: SoqlBuilderServiceError) => Effect.Effect<boolean>;
   readonly isFinalized: Effect.Effect<boolean>;
   readonly nextAction: Effect.Effect<SoqlBuilderAction>;
   readonly recordedActions: Effect.Effect<readonly SoqlBuilderAction[]>;
@@ -30,21 +32,29 @@ export const makeFakeSoqlBuilderService = (initialState: SoqlBuilderState) =>
     const state = yield* SubscriptionRef.make(initialState);
     const actions = yield* Ref.make<readonly SoqlBuilderAction[]>([]);
     const actionQueue = yield* Queue.unbounded<SoqlBuilderAction>();
+    const failures = yield* PubSub.unbounded<SoqlBuilderServiceError>();
     const finalized = yield* Ref.make(false);
     const service: SoqlBuilderServiceShape = {
       dispatch: action =>
         Ref.update(actions, current => [...current, action]).pipe(Effect.andThen(Queue.offer(actionQueue, action))),
       initialState: SubscriptionRef.get(state),
-      stateChanges: state.changes.pipe(Stream.drop(1))
+      stateChanges: Stream.merge(
+        state.changes.pipe(Stream.drop(1)),
+        Stream.fromPubSub(failures).pipe(Stream.mapEffect(error => Effect.fail(error)))
+      )
     };
 
     return {
       emit: nextState => SubscriptionRef.set(state, nextState),
+      fail: error => PubSub.publish(failures, error),
       isFinalized: Ref.get(finalized),
       layer: Layer.scoped(
         SoqlBuilderService,
         Effect.acquireRelease(Effect.succeed(service), () =>
-          Ref.set(finalized, true).pipe(Effect.andThen(Queue.shutdown(actionQueue)))
+          Ref.set(finalized, true).pipe(
+            Effect.andThen(Queue.shutdown(actionQueue)),
+            Effect.andThen(PubSub.shutdown(failures))
+          )
         )
       ),
       nextAction: Queue.take(actionQueue),

--- a/packages/soql-builder-ui/test/controller.test.mjs
+++ b/packages/soql-builder-ui/test/controller.test.mjs
@@ -6,7 +6,7 @@ import * as Effect from 'effect/Effect';
 import * as Fiber from 'effect/Fiber';
 import * as Layer from 'effect/Layer';
 import * as Stream from 'effect/Stream';
-import { createInitialSoqlBuilderState } from '../out/src/domain.js';
+import { SoqlBuilderServiceError, createInitialSoqlBuilderState } from '../out/src/domain.js';
 import { SoqlBuilderController, SoqlBuilderControllerLive } from '../out/src/effect/soqlBuilderController.js';
 import { makeFakeSoqlBuilderService } from '../out/src/testing/fakeSoqlBuilderService.js';
 
@@ -46,4 +46,29 @@ test('the scoped controller streams service state and records actions determinis
     ['', 'Account']
   );
   assert.deepEqual(result.actions, [{ _tag: 'ObjectSelected', objectName: 'Account' }]);
+});
+
+test('the fake service propagates typed failures through controller state', async () => {
+  const initialState = createInitialSoqlBuilderState();
+  const states = await Effect.runPromise(
+    Effect.gen(function* () {
+      const fake = yield* makeFakeSoqlBuilderService(initialState);
+      const controllerLayer = SoqlBuilderControllerLive.pipe(Layer.provide(fake.layer));
+
+      return yield* Effect.gen(function* () {
+        const controller = yield* SoqlBuilderController;
+        const stateFiber = yield* controller.states.pipe(Stream.take(2), Stream.runCollect, Effect.fork);
+        yield* Effect.sleep(Duration.millis(10));
+        yield* fake.fail(
+          new SoqlBuilderServiceError({
+            details: 'metadata subscription failed',
+            operation: 'subscribe'
+          })
+        );
+        return Chunk.toReadonlyArray(yield* Fiber.join(stateFiber));
+      }).pipe(Effect.provide(controllerLayer), Effect.scoped);
+    })
+  );
+
+  assert.equal(states.at(-1)?.errorMessage, 'metadata subscription failed');
 });

--- a/packages/soql-builder-ui/test/controller.test.mjs
+++ b/packages/soql-builder-ui/test/controller.test.mjs
@@ -1,13 +1,13 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import * as Chunk from 'effect/Chunk';
-import * as Duration from 'effect/Duration';
+import * as Deferred from 'effect/Deferred';
 import * as Effect from 'effect/Effect';
 import * as Fiber from 'effect/Fiber';
 import * as Layer from 'effect/Layer';
 import * as Stream from 'effect/Stream';
-import { SoqlBuilderServiceError, createInitialSoqlBuilderState } from '../out/src/domain.js';
-import { SoqlBuilderController, SoqlBuilderControllerLive } from '../out/src/effect/soqlBuilderController.js';
+import { SoqlBuilderMessageChannelError, createInitialSoqlBuilderState } from '../out/src/domain.js';
+import { SoqlBuilderController } from '../out/src/effect/soqlBuilderController.js';
 import { makeFakeSoqlBuilderService } from '../out/src/testing/fakeSoqlBuilderService.js';
 
 test('the scoped controller streams service state and records actions deterministically', async () => {
@@ -23,13 +23,19 @@ test('the scoped controller streams service state and records actions determinis
   const result = await Effect.runPromise(
     Effect.gen(function* () {
       const fake = yield* makeFakeSoqlBuilderService(initialState);
-      const controllerLayer = SoqlBuilderControllerLive.pipe(Layer.provide(fake.layer));
+      const controllerLayer = SoqlBuilderController.Default.pipe(Layer.provide(fake.layer));
 
       return yield* Effect.gen(function* () {
         const controller = yield* SoqlBuilderController;
-        const stateFiber = yield* controller.states.pipe(Stream.take(2), Stream.runCollect, Effect.fork);
+        const subscribed = yield* Deferred.make();
+        const stateFiber = yield* controller.states.pipe(
+          Stream.tap(() => Deferred.succeed(subscribed, undefined)),
+          Stream.take(2),
+          Stream.runCollect,
+          Effect.fork
+        );
 
-        yield* Effect.sleep(Duration.millis(10));
+        yield* Deferred.await(subscribed);
         yield* fake.emit(nextState);
         yield* controller.dispatch({ _tag: 'ObjectSelected', objectName: 'Account' });
 
@@ -43,7 +49,7 @@ test('the scoped controller streams service state and records actions determinis
 
   assert.deepEqual(
     result.states.map(state => state.query.sObject),
-    ['', 'Account']
+    [undefined, 'Account']
   );
   assert.deepEqual(result.actions, [{ _tag: 'ObjectSelected', objectName: 'Account' }]);
 });
@@ -53,16 +59,21 @@ test('the fake service propagates typed failures through controller state', asyn
   const states = await Effect.runPromise(
     Effect.gen(function* () {
       const fake = yield* makeFakeSoqlBuilderService(initialState);
-      const controllerLayer = SoqlBuilderControllerLive.pipe(Layer.provide(fake.layer));
+      const controllerLayer = SoqlBuilderController.Default.pipe(Layer.provide(fake.layer));
 
       return yield* Effect.gen(function* () {
         const controller = yield* SoqlBuilderController;
-        const stateFiber = yield* controller.states.pipe(Stream.take(2), Stream.runCollect, Effect.fork);
-        yield* Effect.sleep(Duration.millis(10));
+        const subscribed = yield* Deferred.make();
+        const stateFiber = yield* controller.states.pipe(
+          Stream.tap(() => Deferred.succeed(subscribed, undefined)),
+          Stream.take(2),
+          Stream.runCollect,
+          Effect.fork
+        );
+        yield* Deferred.await(subscribed);
         yield* fake.fail(
-          new SoqlBuilderServiceError({
-            details: 'metadata subscription failed',
-            operation: 'subscribe'
+          new SoqlBuilderMessageChannelError({
+            details: 'metadata subscription failed'
           })
         );
         return Chunk.toReadonlyArray(yield* Fiber.join(stateFiber));

--- a/packages/soql-builder-ui/test/domain.test.mjs
+++ b/packages/soql-builder-ui/test/domain.test.mjs
@@ -5,8 +5,10 @@ import * as Schema from 'effect/Schema';
 import {
   InvalidSoqlBuilderMetadataError,
   SoqlBuilderActionSchema,
+  SoqlLimitSchema,
   createInitialSoqlBuilderState,
-  decodeSoqlBuilderMetadata
+  decodeSoqlBuilderMetadata,
+  soqlLimitFromInput
 } from '../out/src/domain.js';
 
 const accountField = {
@@ -63,6 +65,7 @@ test('creates independent initial states', () => {
   assert.notEqual(first.metadata, second.metadata);
   assert.notEqual(first.query, second.query);
   assert.deepEqual(first.query.where.conditions, []);
+  assert.deepEqual(first.query.limit, { _tag: 'Empty' });
   assert.equal(first.isQueryRunning, false);
   assert.equal(first.isQueryPlanRunning, false);
 });
@@ -89,7 +92,7 @@ test('the public action Schema covers all builder operations', () => {
     { _tag: 'WhereConjunctionChanged', andOr: 'OR' },
     { _tag: 'OrderByUpserted', orderBy: { field: 'Name', order: 'ASC', nulls: 'NULLS LAST' } },
     { _tag: 'OrderByRemoved', fieldName: 'Name' },
-    { _tag: 'LimitChanged', limit: '25' },
+    { _tag: 'LimitChanged', limit: { _tag: 'Valid', value: 25 } },
     { _tag: 'AllRowsChanged', allRows: true },
     { _tag: 'NotificationsDismissed' },
     { _tag: 'SetDefaultOrgRequested' },
@@ -100,4 +103,20 @@ test('the public action Schema covers all builder operations', () => {
   for (const action of actions) {
     assert.equal(Schema.is(SoqlBuilderActionSchema)(action), true, action._tag);
   }
+});
+
+test('represents empty, valid, and invalid limit input explicitly', () => {
+  assert.deepEqual(soqlLimitFromInput(''), { _tag: 'Empty' });
+  assert.deepEqual(soqlLimitFromInput('0'), { _tag: 'Valid', value: 0 });
+  assert.deepEqual(soqlLimitFromInput('25'), { _tag: 'Valid', value: 25 });
+  assert.deepEqual(soqlLimitFromInput('-1'), { _tag: 'Invalid', input: '-1' });
+  assert.deepEqual(soqlLimitFromInput('1.5'), { _tag: 'Invalid', input: '1.5' });
+  assert.deepEqual(soqlLimitFromInput('9007199254740992'), {
+    _tag: 'Invalid',
+    input: '9007199254740992'
+  });
+
+  assert.equal(Schema.is(SoqlLimitSchema)({ _tag: 'Valid', value: -1 }), false);
+  assert.equal(Schema.is(SoqlLimitSchema)({ _tag: 'Valid', value: Number.MAX_SAFE_INTEGER + 1 }), false);
+  assert.equal(Schema.is(SoqlLimitSchema)({ _tag: 'Invalid', input: '' }), false);
 });

--- a/packages/soql-builder-ui/test/domain.test.mjs
+++ b/packages/soql-builder-ui/test/domain.test.mjs
@@ -1,26 +1,39 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import * as Effect from 'effect/Effect';
+import * as Schema from 'effect/Schema';
 import {
   InvalidSoqlBuilderMetadataError,
+  SoqlBuilderActionSchema,
   createInitialSoqlBuilderState,
   decodeSoqlBuilderMetadata
 } from '../out/src/domain.js';
+
+const accountField = {
+  aggregatable: false,
+  custom: false,
+  defaultValue: null,
+  extraTypeInfo: null,
+  filterable: true,
+  groupable: true,
+  inlineHelpText: null,
+  label: 'Account ID',
+  name: 'Id',
+  nillable: false,
+  picklistValues: [],
+  referenceTo: [],
+  relationshipName: null,
+  sortable: true,
+  type: 'id'
+};
 
 test('decodes the browser-safe metadata DTO', async () => {
   const metadata = await Effect.runPromise(
     decodeSoqlBuilderMetadata({
       objects: [{ name: 'Account', label: 'Account', queryable: true }],
-      fields: [
-        {
-          name: 'Id',
-          label: 'Account ID',
-          type: 'id',
-          filterable: true,
-          groupable: true,
-          sortable: true
-        }
-      ]
+      fields: [accountField],
+      childRelationships: [],
+      selectedObjectName: 'Account'
     })
   );
 
@@ -33,7 +46,8 @@ test('rejects invalid metadata with the typed boundary error', async () => {
     Effect.flip(
       decodeSoqlBuilderMetadata({
         objects: [{ name: '', label: 'Account', queryable: true }],
-        fields: []
+        fields: [],
+        childRelationships: []
       })
     )
   );
@@ -48,4 +62,42 @@ test('creates independent initial states', () => {
   assert.notEqual(first, second);
   assert.notEqual(first.metadata, second.metadata);
   assert.notEqual(first.query, second.query);
+  assert.deepEqual(first.query.where.conditions, []);
+  assert.equal(first.isQueryRunning, false);
+  assert.equal(first.isQueryPlanRunning, false);
+});
+
+test('the public action Schema covers all builder operations', () => {
+  const actions = [
+    { _tag: 'ObjectSelected', objectName: 'Account' },
+    { _tag: 'FieldsSelected', fieldNames: ['Id'] },
+    { _tag: 'AllFieldsSelected' },
+    { _tag: 'AllFieldsCleared' },
+    {
+      _tag: 'WhereConditionUpserted',
+      condition: {
+        index: 0,
+        condition: {
+          field: { fieldName: 'Name' },
+          operator: '=',
+          compareValue: { type: 'STRING', value: "'Acme'" }
+        }
+      },
+      andOr: 'AND'
+    },
+    { _tag: 'WhereConditionRemoved', index: 0 },
+    { _tag: 'WhereConjunctionChanged', andOr: 'OR' },
+    { _tag: 'OrderByUpserted', orderBy: { field: 'Name', order: 'ASC', nulls: 'NULLS LAST' } },
+    { _tag: 'OrderByRemoved', fieldName: 'Name' },
+    { _tag: 'LimitChanged', limit: '25' },
+    { _tag: 'AllRowsChanged', allRows: true },
+    { _tag: 'NotificationsDismissed' },
+    { _tag: 'SetDefaultOrgRequested' },
+    { _tag: 'RunQueryRequested' },
+    { _tag: 'QueryPlanRequested' }
+  ];
+
+  for (const action of actions) {
+    assert.equal(Schema.is(SoqlBuilderActionSchema)(action), true, action._tag);
+  }
 });

--- a/packages/soql-model/src/index.ts
+++ b/packages/soql-model/src/index.ts
@@ -5,8 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export { AndOr, ConditionOperator, SObjectFieldType } from './model/model';
-export type { ErrorType, LiteralType, Query, Select, SelectExprs, UiOperatorValue } from './model/model';
+export { AndOr, ConditionOperator, NullsOrder, Order, SObjectFieldType } from './model/model';
+export type { Condition, ErrorType, LiteralType, Query, Select, SelectExprs, UiOperatorValue } from './model/model';
 export {
   REASON_UNMODELED_COMPLEXGROUP,
   REASON_UNMODELED_FUNCTIONREFERENCE,


### PR DESCRIPTION
### What does this PR do?

Expands the browser-safe Lit Effect service contract to represent the complete SOQL Builder state and typed action surface. Adds the model adapter, VS Code service mappings, correlated metadata handling, deterministic fake-service coverage, and contract tests needed by later Lit component stories.

This is the top layer of stack #8023 and is based on PR #8022. The legacy LWC builder remains the default, so this layer does not change current production UI behavior.

### What issues does this PR fix or reference?

@W-23928675@

### Functionality Before

The production Lit foundation supported the initial object and field selection slice, but its public Effect contract did not represent the complete builder state and action surface required by the remaining migration stories.

### Functionality After

The Lit UI package exposes browser-safe schemas for complete builder state and actions, while the extension-owned service maps those actions and host events through the existing SOQL model and message boundaries. Contract tests cover state publication, typed failures, metadata decoding, action mapping, and lifecycle behavior.