### PR TITLE
fix: clear source tracking status bar when default org is deleted - W-23950821

### DIFF
--- a/.claude/skills/services-extension-consumption/SKILL.md
+++ b/.claude/skills/services-extension-consumption/SKILL.md
@@ -241,6 +241,16 @@ Ref behavior (concise):
 - `TargetOrgRef` snapshot without username: optional `ConfigUtil.getUsername()` (project default) before treating as no target org.
 - `TargetOrgRef` value is always an object (never `undefined`); only fields like `orgId` within it are optional.
 
+### Clearing the Default Org
+
+Call `ClearDefaultOrgRef()` to reset the in-process org ref (e.g., after deleting the default org):
+
+```typescript
+yield* api.services.ClearDefaultOrgRef();
+```
+
+Clears the reactive ref without rewriting config. Use when the CLI already mutated config but the in-process ref must reset to notify observers (e.g., the source tracking status bar icons). See `orgDeleteDefaultCommand` for an example.
+
 ## Complete Example Pattern
 
 ```typescript

--- a/packages/salesforcedx-vscode-metadata/src/statusBar/sourceTrackingStatusBar.ts
+++ b/packages/salesforcedx-vscode-metadata/src/statusBar/sourceTrackingStatusBar.ts
@@ -133,10 +133,9 @@ export const createSourceTrackingStatusBar = Effect.fn('createSourceTrackingStat
     Stream.as('conflictDetectionSettingChange')
   );
   const orgChangeStream = targetOrgRef.changes.pipe(
-    // React once we know the org's tracking status ('tracksSource' present), OR when the org is gone.
-    // Deleting/logging out of the default org clears the ref to a state with no orgId (and no
-    // tracksSource key); without the `!orgInfo.orgId` branch that cleared state is filtered out and
-    // the status bar icons linger even though the source-tracked org is gone. (W-23950821)
+    // Pass when tracking status is known ('tracksSource' present) OR the ref has no orgId — the cleared
+    // state after the default org is deleted/logged out. Without the `!orgInfo.orgId` branch that cleared
+    // state is dropped and the icons linger on the gone org. (W-23950821)
     Stream.filter(orgInfo => orgInfo && typeof orgInfo === 'object' && ('tracksSource' in orgInfo || !orgInfo.orgId)),
     Stream.tap(orgInfo =>
       Effect.sync(() => {

--- a/packages/salesforcedx-vscode-metadata/src/statusBar/sourceTrackingStatusBar.ts
+++ b/packages/salesforcedx-vscode-metadata/src/statusBar/sourceTrackingStatusBar.ts
@@ -133,7 +133,11 @@ export const createSourceTrackingStatusBar = Effect.fn('createSourceTrackingStat
     Stream.as('conflictDetectionSettingChange')
   );
   const orgChangeStream = targetOrgRef.changes.pipe(
-    Stream.filter(orgInfo => orgInfo && typeof orgInfo === 'object' && 'tracksSource' in orgInfo),
+    // React once we know the org's tracking status ('tracksSource' present), OR when the org is gone.
+    // Deleting/logging out of the default org clears the ref to a state with no orgId (and no
+    // tracksSource key); without the `!orgInfo.orgId` branch that cleared state is filtered out and
+    // the status bar icons linger even though the source-tracked org is gone. (W-23950821)
+    Stream.filter(orgInfo => orgInfo && typeof orgInfo === 'object' && ('tracksSource' in orgInfo || !orgInfo.orgId)),
     Stream.tap(orgInfo =>
       Effect.sync(() => {
         if (!orgInfo.tracksSource || !orgInfo.orgId) {

--- a/packages/salesforcedx-vscode-org/src/commands/orgDelete.ts
+++ b/packages/salesforcedx-vscode-org/src/commands/orgDelete.ts
@@ -76,12 +76,10 @@ export const orgDeleteDefaultCommand = Effect.fn('orgDeleteDefaultCommand')(func
     catch: e => new ConfigRefreshError({ message: isError(e) ? e.message : String(e) })
   });
 
-  // The CLI delete unsets target-org, but updateConfigAndStateAggregators swallows the post-delete
-  // getConnection failure and never clears the in-process defaultOrgRef; clear it here deterministically
-  // so reactive consumers (e.g. the source tracking status bar icons) reset instead of lingering on the
-  // now-deleted org. (W-23950821, same root cause as the logout fix W-23069610.) The CLI already unset
-  // config, so we only need to clear the reactive ref (not re-write config). The deleted org is the
-  // default by definition here, so the clear is unconditional.
+  // updateConfigAndStateAggregators swallows its post-delete getConnection failure, so the in-process
+  // defaultOrgRef is never cleared and reactive consumers (e.g. the source tracking status bar) linger on
+  // the deleted org. The CLI already unset config, so reset only the reactive ref here; unconditional
+  // because this command deletes the default org by definition. (W-23950821; cf. logout fix W-23069610.)
   yield* api.services.ClearDefaultOrgRef();
 });
 

--- a/packages/salesforcedx-vscode-org/src/commands/orgDelete.ts
+++ b/packages/salesforcedx-vscode-org/src/commands/orgDelete.ts
@@ -75,6 +75,14 @@ export const orgDeleteDefaultCommand = Effect.fn('orgDeleteDefaultCommand')(func
     try: () => updateConfigAndStateAggregators(),
     catch: e => new ConfigRefreshError({ message: isError(e) ? e.message : String(e) })
   });
+
+  // The CLI delete unsets target-org, but updateConfigAndStateAggregators swallows the post-delete
+  // getConnection failure and never clears the in-process defaultOrgRef; clear it here deterministically
+  // so reactive consumers (e.g. the source tracking status bar icons) reset instead of lingering on the
+  // now-deleted org. (W-23950821, same root cause as the logout fix W-23069610.) The CLI already unset
+  // config, so we only need to clear the reactive ref (not re-write config). The deleted org is the
+  // default by definition here, so the clear is unconditional.
+  yield* api.services.ClearDefaultOrgRef();
 });
 
 /** Display label for an org's type, used in user-facing channel/notification text. */

--- a/packages/salesforcedx-vscode-org/test/jest/commands/orgDelete.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/commands/orgDelete.test.ts
@@ -34,6 +34,10 @@ const userCancellationError = { _tag: 'UserCancellationError', message: 'User ca
 
 type OrgSnapshot = { orgId?: string; username?: string; isScratch?: boolean; isSandbox?: boolean };
 
+// The default-delete command clears the reactive org ref after a successful delete so reactive consumers
+// (e.g. the source tracking status bar icons) reset instead of lingering on the now-deleted org (W-23950821).
+const mockClearDefaultOrgRef = jest.fn(() => Effect.void);
+
 const buildServices = (orgInfo: OrgSnapshot, confirm: boolean, simpleExec: jest.Mock) => ({
   PromptService: Effect.succeed({
     confirmOrThrow: (_params: { message: string; confirmLabel: string }) =>
@@ -45,7 +49,8 @@ const buildServices = (orgInfo: OrgSnapshot, confirm: boolean, simpleExec: jest.
   }),
   TerminalService: Effect.succeed({ simpleExec }),
   ChannelService: Effect.succeed({ appendToChannel: () => Effect.void }),
-  TargetOrgRef: () => SubscriptionRef.make(orgInfo)
+  TargetOrgRef: () => SubscriptionRef.make(orgInfo),
+  ClearDefaultOrgRef: mockClearDefaultOrgRef
 });
 
 const run = (orgInfo: OrgSnapshot, confirm: boolean, simpleExec: jest.Mock) =>
@@ -61,6 +66,8 @@ describe('orgDeleteDefaultCommand', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUpdateConfigAndStateAggregators.mockResolvedValue(undefined);
+    // resetMocks:true (jest.base.config) clears impls each test, so (re)set the return here
+    mockClearDefaultOrgRef.mockReturnValue(Effect.void);
   });
 
   it('runs `sf org delete scratch` for a scratch default org', async () => {
@@ -74,6 +81,8 @@ describe('orgDeleteDefaultCommand', () => {
       timeout: Duration.seconds(120)
     });
     expect(mockUpdateConfigAndStateAggregators).toHaveBeenCalledTimes(1);
+    // clears the reactive org ref so the source tracking status bar icons reset (W-23950821)
+    expect(mockClearDefaultOrgRef).toHaveBeenCalledTimes(1);
   });
 
   it('runs `sf org delete sandbox` for a sandbox default org', async () => {
@@ -108,6 +117,8 @@ describe('orgDeleteDefaultCommand', () => {
     if (Exit.isFailure(exit)) expect(JSON.stringify(exit.cause)).toContain('OrgNotDeletableError');
     expect(simpleExec).not.toHaveBeenCalled();
     expect(mockUpdateConfigAndStateAggregators).not.toHaveBeenCalled();
+    // nothing was deleted, so the org ref must not be cleared
+    expect(mockClearDefaultOrgRef).not.toHaveBeenCalled();
   });
 
   it('fails with UserCancellationError and does not exec when the user declines', async () => {
@@ -118,6 +129,8 @@ describe('orgDeleteDefaultCommand', () => {
     if (Exit.isFailure(exit)) expect(JSON.stringify(exit.cause)).toContain('UserCancellationError');
     expect(simpleExec).not.toHaveBeenCalled();
     expect(mockUpdateConfigAndStateAggregators).not.toHaveBeenCalled();
+    // user declined, so the org ref must not be cleared
+    expect(mockClearDefaultOrgRef).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/salesforcedx-vscode-services/src/index.ts
+++ b/packages/salesforcedx-vscode-services/src/index.ts
@@ -23,7 +23,7 @@ import { ComponentSetService } from './core/componentSetService';
 import { watchConfigFiles } from './core/configFileWatcher';
 import { ConfigService } from './core/configService';
 import { ConnectionService } from './core/connectionService';
-import { getDefaultOrgRef, getTelemetryIdentitySnapshot } from './core/defaultOrgRef';
+import { clearDefaultOrgRef, getDefaultOrgRef, getTelemetryIdentitySnapshot } from './core/defaultOrgRef';
 import { ExecuteAnonymousService } from './core/executeAnonymousService';
 import { subscribeLifecycleWarnings } from './core/lifecycleWarningListener';
 import { LightningComponentService } from './core/lightningComponentService';
@@ -158,6 +158,7 @@ export type SalesforceVSCodeServicesApi = {
     TransmogrifierService: typeof TransmogrifierService;
     ActiveMetadataOperationRef: typeof getActiveMetadataOperationRef;
     TargetOrgRef: typeof getDefaultOrgRef;
+    ClearDefaultOrgRef: typeof clearDefaultOrgRef;
     TelemetryIdentitySnapshot: typeof getTelemetryIdentitySnapshot;
     TerminalService: typeof TerminalService;
     TraceFlagItemStruct: typeof TraceFlagItemStruct;
@@ -508,6 +509,7 @@ export const activate = async (context: vscode.ExtensionContext): Promise<Salesf
         SourceTrackingService,
         ActiveMetadataOperationRef: getActiveMetadataOperationRef,
         TargetOrgRef: getDefaultOrgRef,
+        ClearDefaultOrgRef: clearDefaultOrgRef,
         TelemetryIdentitySnapshot: getTelemetryIdentitySnapshot,
         TerminalService,
         TransmogrifierService,


### PR DESCRIPTION
## What & why

When a **source-tracked scratch org that is the default org** is deleted, the source-tracking status bar icon lingered on the now-deleted org instead of resetting. Same class of bug as the logout fix (W-23069610).

Work item: [W-23950821](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002iRJsGYAW/view)

## Root cause

Two gaps combined to leave the icon stale:

1. **The cleared state was never emitted.** `orgDeleteDefaultCommand` relied on `updateConfigAndStateAggregators()`, whose post-delete `getConnection()` failure is swallowed — so the in-process `defaultOrgRef` was never cleared and reactive consumers never saw the org go away. (The global-config unset the CLI performs isn't detected either: the config file watcher is workspace-only.)
2. **The cleared state was filtered out.** The status bar's `orgChangeStream` filter only reacted when `tracksSource` was present, so a cleared ref (no `orgId`, no `tracksSource` key) was dropped.

## Changes

- **`orgDelete.ts`** — `orgDeleteDefaultCommand` now deterministically clears the in-process `defaultOrgRef` via `api.services.ClearDefaultOrgRef()` after the CLI delete. The CLI already unset config, so only the reactive ref needs clearing; the deleted org is the default by definition here, so the clear is unconditional.
- **`sourceTrackingStatusBar.ts`** — widened the `orgChangeStream` filter so a cleared ref (no `orgId` / no `tracksSource` key) is no longer filtered out, and the status bar item hides when the source-tracked org is gone.
- **`services/index.ts`** — exposed `ClearDefaultOrgRef` on the `SalesforceVSCodeServicesApi` surface, wired to the existing `clearDefaultOrgRef` helper.
- Documented `ClearDefaultOrgRef` in the services consumption skill.

## Testing

- `orgDelete.test.ts` (jest): asserts the ref **is** cleared on a successful default-org delete and **is not** cleared on cancel / non-deletable orgs — **9/9 pass**.
- `services/index.test.ts` (jest): confirms the API object assembles at runtime with the new key — **3/3 pass**.
- Full monorepo pre-commit (compile + lint + knip + effect-diagnostics) passes.

@W-23950821@