### PR TITLE
fix(ci): pass dry-run as a boolean and publish Open VSX via ovsx - @W-23955061@

### DIFF
--- a/.github/workflows/publishOpenVSX.yml
+++ b/.github/workflows/publishOpenVSX.yml
@@ -51,6 +51,9 @@ jobs:
     env:
       OVSX_PAT: ${{ secrets.IDEE_OVSX_PAT }}
       GH_TOKEN: ${{ github.token }}
+      # This job doesn't check out the repo, so `gh release download` can't infer the
+      # repo from a .git dir. GH_REPO gives the gh CLI its repo context directly.
+      GH_REPO: ${{ github.repository }}
       PUBLISH_VERSION: ${{ needs.prepare-release-metadata.outputs.RELEASE_VERSION }}
       RELEASE_TAG: ${{ needs.prepare-release-metadata.outputs.RELEASE_TAG }}
     steps:
@@ -79,6 +82,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
+      # This job doesn't check out the repo, so `gh release download` can't infer the
+      # repo from a .git dir. GH_REPO gives the gh CLI its repo context directly.
+      GH_REPO: ${{ github.repository }}
       PUBLISH_VERSION: ${{ needs.prepare-release-metadata.outputs.RELEASE_VERSION }}
       RELEASE_TAG: ${{ needs.prepare-release-metadata.outputs.RELEASE_TAG }}
     steps:

--- a/.github/workflows/publishOpenVSX.yml
+++ b/.github/workflows/publishOpenVSX.yml
@@ -47,11 +47,31 @@ jobs:
   publish:
     needs: ['ctc-open', 'prepare-release-metadata']
     if: always() && needs.prepare-release-metadata.result == 'success' && (inputs.dry-run || needs.ctc-open.result == 'success')
-    uses: salesforcecli/github-workflows/.github/workflows/vscode-publish-release-vsix.yml@main
-    with:
-      release-tag: ${{ needs.prepare-release-metadata.outputs.RELEASE_TAG }}
-      dry-run: ${{ inputs.dry-run }}
-    secrets: inherit
+    runs-on: ubuntu-latest
+    env:
+      OVSX_PAT: ${{ secrets.IDEE_OVSX_PAT }}
+      GH_TOKEN: ${{ github.token }}
+      PUBLISH_VERSION: ${{ needs.prepare-release-metadata.outputs.RELEASE_VERSION }}
+      RELEASE_TAG: ${{ needs.prepare-release-metadata.outputs.RELEASE_TAG }}
+    steps:
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
+      - name: Download VSIXs from release
+        run: |
+          mkdir ./extensions
+          gh release download "$RELEASE_TAG" -D ./extensions
+      - name: Display downloaded vsix files
+        run: ls -R ./extensions
+      # The shared release-vsix workflow only publishes to the VS Code Marketplace (vsce); Open VSX
+      # must be published inline via `ovsx`, matching the verify-published job below which polls Open
+      # VSX. Skipped on dry-run so a manual run can download/inspect the VSIXs without publishing.
+      - name: Publish to Open VSX
+        if: inputs.dry-run != true
+        uses: salesforcecli/github-workflows/.github/actions/retry@main
+        with:
+          command: |
+            cmd=$(find ./extensions -type f -name "*.vsix" -print0 | xargs -0 -I {} printf 'npx ovsx publish --skip-duplicate "%s" -p "%s" && ' '{}' "${OVSX_PAT}" | sed 's/ && $//') && [ -n "$cmd" ] && eval "$cmd" && echo "SUCCESSFULLY published"
 
   verify-published:
     needs: ['prepare-release-metadata', 'publish']

--- a/.github/workflows/publishOpenVSX.yml
+++ b/.github/workflows/publishOpenVSX.yml
@@ -93,7 +93,7 @@ jobs:
           gh release download "$RELEASE_TAG" -D ./extensions
       - name: Verify published versions landed on OpenVSX
         run: |
-          TIMEOUT="${POLL_TIMEOUT:-600}"
+          TIMEOUT="${POLL_TIMEOUT:-1200}"
           INTERVAL="${POLL_INTERVAL:-30}"
           deadline=$(( $(date +%s) + TIMEOUT ))
           pending=()

--- a/.github/workflows/publishOpenVSX.yml
+++ b/.github/workflows/publishOpenVSX.yml
@@ -51,8 +51,7 @@ jobs:
     env:
       OVSX_PAT: ${{ secrets.IDEE_OVSX_PAT }}
       GH_TOKEN: ${{ github.token }}
-      # This job doesn't check out the repo, so `gh release download` can't infer the
-      # repo from a .git dir. GH_REPO gives the gh CLI its repo context directly.
+      # No checkout, so give the gh CLI its repo context for `gh release download`.
       GH_REPO: ${{ github.repository }}
       PUBLISH_VERSION: ${{ needs.prepare-release-metadata.outputs.RELEASE_VERSION }}
       RELEASE_TAG: ${{ needs.prepare-release-metadata.outputs.RELEASE_TAG }}
@@ -66,9 +65,7 @@ jobs:
           gh release download "$RELEASE_TAG" -D ./extensions
       - name: Display downloaded vsix files
         run: ls -R ./extensions
-      # The shared release-vsix workflow only publishes to the VS Code Marketplace (vsce); Open VSX
-      # must be published inline via `ovsx`, matching the verify-published job below which polls Open
-      # VSX. Skipped on dry-run so a manual run can download/inspect the VSIXs without publishing.
+      # Open VSX has no shared publisher workflow, so publish inline via `ovsx`.
       - name: Publish to Open VSX
         if: inputs.dry-run != true
         uses: salesforcecli/github-workflows/.github/actions/retry@main
@@ -82,8 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
-      # This job doesn't check out the repo, so `gh release download` can't infer the
-      # repo from a .git dir. GH_REPO gives the gh CLI its repo context directly.
+      # No checkout, so give the gh CLI its repo context for `gh release download`.
       GH_REPO: ${{ github.repository }}
       PUBLISH_VERSION: ${{ needs.prepare-release-metadata.outputs.RELEASE_VERSION }}
       RELEASE_TAG: ${{ needs.prepare-release-metadata.outputs.RELEASE_TAG }}

--- a/.github/workflows/publishOpenVSX.yml
+++ b/.github/workflows/publishOpenVSX.yml
@@ -47,31 +47,11 @@ jobs:
   publish:
     needs: ['ctc-open', 'prepare-release-metadata']
     if: always() && needs.prepare-release-metadata.result == 'success' && (inputs.dry-run || needs.ctc-open.result == 'success')
-    runs-on: ubuntu-latest
-    env:
-      OVSX_PAT: ${{ secrets.IDEE_OVSX_PAT }}
-      GH_TOKEN: ${{ github.token }}
-      # No checkout, so give the gh CLI its repo context for `gh release download`.
-      GH_REPO: ${{ github.repository }}
-      PUBLISH_VERSION: ${{ needs.prepare-release-metadata.outputs.RELEASE_VERSION }}
-      RELEASE_TAG: ${{ needs.prepare-release-metadata.outputs.RELEASE_TAG }}
-    steps:
-      - uses: actions/setup-node@v7
-        with:
-          node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
-      - name: Download VSIXs from release
-        run: |
-          mkdir ./extensions
-          gh release download "$RELEASE_TAG" -D ./extensions
-      - name: Display downloaded vsix files
-        run: ls -R ./extensions
-      # Open VSX has no shared publisher workflow, so publish inline via `ovsx`.
-      - name: Publish to Open VSX
-        if: inputs.dry-run != true
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          command: |
-            cmd=$(find ./extensions -type f -name "*.vsix" -print0 | xargs -0 -I {} printf 'npx ovsx publish --skip-duplicate "%s" -p "%s" && ' '{}' "${OVSX_PAT}" | sed 's/ && $//') && [ -n "$cmd" ] && eval "$cmd" && echo "SUCCESSFULLY published"
+    uses: salesforcecli/github-workflows/.github/workflows/openvsx-publish-release-vsix.yml@main
+    with:
+      release-tag: ${{ needs.prepare-release-metadata.outputs.RELEASE_TAG }}
+      dry-run: ${{ inputs.dry-run == true }}
+    secrets: inherit
 
   verify-published:
     needs: ['prepare-release-metadata', 'publish']

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -139,9 +139,7 @@ jobs:
     uses: salesforcecli/github-workflows/.github/workflows/vscode-publish-release-vsix.yml@main
     with:
       release-tag: ${{ needs.prepare-release-metadata.outputs.RELEASE_TAG }}
-      # `release`-triggered runs have an empty `inputs` context, so `${{ inputs.dry-run }}`
-      # yields "" — an invalid value for the reusable workflow's typed `boolean` input, which
-      # fails the job at instantiation. Coerce to a real boolean (empty/false -> false).
+      # `inputs` is empty on release runs; coerce to a real boolean for the typed input.
       dry-run: ${{ inputs.dry-run || false }}
     secrets: inherit
 

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -139,8 +139,7 @@ jobs:
     uses: salesforcecli/github-workflows/.github/workflows/vscode-publish-release-vsix.yml@main
     with:
       release-tag: ${{ needs.prepare-release-metadata.outputs.RELEASE_TAG }}
-      # `inputs` is empty on release runs; coerce to a real boolean for the typed input.
-      dry-run: ${{ inputs.dry-run || false }}
+      dry-run: ${{ inputs.dry-run == true }}
     secrets: inherit
 
   ctcCloseSuccess:

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -139,7 +139,10 @@ jobs:
     uses: salesforcecli/github-workflows/.github/workflows/vscode-publish-release-vsix.yml@main
     with:
       release-tag: ${{ needs.prepare-release-metadata.outputs.RELEASE_TAG }}
-      dry-run: ${{ inputs.dry-run }}
+      # `release`-triggered runs have an empty `inputs` context, so `${{ inputs.dry-run }}`
+      # yields "" — an invalid value for the reusable workflow's typed `boolean` input, which
+      # fails the job at instantiation. Coerce to a real boolean (empty/false -> false).
+      dry-run: ${{ inputs.dry-run || false }}
     secrets: inherit
 
   ctcCloseSuccess:

--- a/contributing/publishing.md
+++ b/contributing/publishing.md
@@ -75,15 +75,23 @@ Merge to `main` triggers [testBuildAndRelease](https://github.com/forcedotcom/sa
 - Send Slack notification
 - Create git tag + GitHub release
 
-Then triggers `publishVSCode.yml`:
+Then triggers two separate publish workflows:
+
+**`publishVSCode.yml` (Microsoft Marketplace):** Publishes to VS Code Marketplace only.
 - Verify release exists (required for manual workflow_dispatch triggers)
 - Download VSIX files; validate ≥1 present, exit if missing
-- Call the shared release-asset publisher to publish every VSIX in the GitHub release to VS Code Marketplace
+- Call the shared release-asset publisher via `vsce` to publish every VSIX to VS Code Marketplace
+- Dispatch Web Console release (if CBW_TRIGGER_ENABLED, default enabled)
 - Send approval notification
+
+**`publishOpenVSX.yml` (Open VSX Registry):** Publishes to Open VSX only.
+- Download VSIX files from release
+- Publish via `npx ovsx publish --skip-duplicate` (skipped on dry-run)
+- Poll Open VSX for availability verification
 
 **Manual workflow_dispatch triggers:** Specify the release tag (for example, `v67.10.0`) and ensure `testBuildAndRelease.yml` has already created that GitHub release with VSIX artifacts. The workflow validates the release exists before attempting downloads and will fail early with a clear error if the release is missing.
 
-Before approving marketplace publish, download VSIX files, install locally, verify functionality.
+Before approving marketplace publishes, download VSIX files, install locally, verify functionality.
 
 Use [gh cli](https://cli.github.com/) (replace `v64.8.0` with your tag; `code` → `code-insiders` as needed):
 


### PR DESCRIPTION
## What & Why

The v67.13.3 release-publish workflows both failed: the `publish` job errored at instantiation, so `verify-published`/`ctcCloseSuccess` never ran and only `ctcCloseFail` executed. Issues 1–2 below (from #7996) caused that instantiation failure; fixing it then surfaced two pre-existing latent problems in the Open VSX verify path (issues 3–4) — masked until now because the publish job always failed first on `release`, so `verify-published` never actually ran. This PR fixes all four.

### 1. `dry-run` passed as an empty string to a typed `boolean` input (both workflows)

The `publish` job passed `dry-run: ${{ inputs.dry-run }}` into a reusable workflow whose `dry-run` input is typed `boolean`. On `release`-triggered runs the `inputs` context is empty, so the expression yields `""` — an invalid boolean — which fails the job **before any step runs** (zero child jobs). This is the same class of bug as #7993 ("pass nightly as boolean"). Pre-#7996 this workflow passed the literal `dry-run: false`.

**Fix:** normalize to a real boolean with `dry-run: ${{ inputs.dry-run == true }}`. `inputs.dry-run` is a genuine boolean on `workflow_dispatch` and `null` on `release`; the `== true` comparison yields a proper `true`/`false` in every trigger case (null coerces to `0`, so release → `false`), with no empty string ever reaching the typed input.

### 2. Open VSX was publishing to the wrong registry (`publishOpenVSX.yml`)

#7996 pointed `publishOpenVSX`'s `publish` job at the shared `vscode-publish-release-vsix.yml` workflow, which only runs `vsce publish` (VS Code Marketplace). But its `verify-published` job polls **Open VSX** via `npx ovsx get`, so verification could never pass.

**Fix:** call the purpose-built shared `salesforcecli/github-workflows/.github/workflows/openvsx-publish-release-vsix.yml@main` reusable workflow, which downloads the release VSIXs and runs `npx ovsx publish --skip-duplicate -p $IDEE_OVSX_PAT` per extension (with `--pre-release` handling). This replaces the wrong `vsce` workflow without us maintaining an inline `ovsx` job.

`publishVSCode.yml` (Marketplace) keeps the shared `vsce` workflow — only the boolean is fixed there.

### 3. `gh release download` had no repo context in `verify-published` (`publishOpenVSX.yml`)

The `verify-published` job doesn't check out the repo, so `gh release download` failed with `fatal: not a git repository` — it couldn't infer which repo to pull the VSIXs from.

**Fix:** set `GH_REPO: ${{ github.repository }}` on the job — the `gh` CLI honors it directly, avoiding an unnecessary source checkout.

### 4. Open VSX verify poll timeout too short

`verify-published` polls Open VSX until every published version is queryable. Open VSX indexing can lag past the previous 600s window (it did for v67.13.3 — two of 17 extensions hadn't indexed in time), which fails the job even though publishing succeeded.

**Fix:** double the poll timeout to `POLL_TIMEOUT:-1200` (20 min).

### Docs

`contributing/publishing.md` now documents the two publish workflows separately — `publishVSCode.yml` (Marketplace via `vsce`) and `publishOpenVSX.yml` (Open VSX via `ovsx`, then poll to verify).

## Testing

- `validateActions` reports 0 failures on both files.
- Both workflows parse as valid YAML.
- The change to `publishVSCode.yml` is a one-line boolean normalization; `publishOpenVSX.yml` now delegates publishing to the shared Open VSX reusable workflow.
- **Verified end-to-end via manual `workflow_dispatch` from this branch for v67.13.3:** Microsoft Marketplace published successfully, and Open VSX published all 17 extensions (confirmed live via the Open VSX API). Note: the earlier verify-published timeout that fired against a 600s window is what motivated fix #4.
@W-23955061@