### PR TITLE
feat(services): add canonical artifact identity - W-23971749

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46437,7 +46437,7 @@
     },
     "packages/salesforcedx-vscode-services-types": {
       "name": "@salesforce/vscode-services",
-      "version": "67.14.0",
+      "version": "67.15.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.43",

--- a/packages/salesforcedx-vscode-services-types/package.json
+++ b/packages/salesforcedx-vscode-services-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/vscode-services",
-  "version": "67.14.0",
+  "version": "67.15.0",
   "description": "TypeScript type definitions for Salesforce VS Code Services extension API",
   "author": "Salesforce",
   "license": "BSD-3-Clause",

--- a/packages/salesforcedx-vscode-services/src/core/artifactIdentity.ts
+++ b/packages/salesforcedx-vscode-services/src/core/artifactIdentity.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Schema from 'effect/Schema';
+
+export const ArtifactTargetKindSchema = Schema.Literal('metadata-component', 'sobject', 'apex-type');
+export type ArtifactTargetKind = typeof ArtifactTargetKindSchema.Type;
+
+export const ArtifactNamespaceSchema = Schema.NullOr(Schema.NonEmptyTrimmedString);
+export type ArtifactNamespace = typeof ArtifactNamespaceSchema.Type;
+
+const ArtifactIdentityFields = {
+  namespace: ArtifactNamespaceSchema,
+  name: Schema.NonEmptyTrimmedString
+} as const;
+
+export const MetadataComponentArtifactIdentitySchema = Schema.Struct({
+  kind: Schema.Literal('metadata-component'),
+  metadataType: Schema.NonEmptyTrimmedString,
+  ...ArtifactIdentityFields
+});
+export type MetadataComponentArtifactIdentity = typeof MetadataComponentArtifactIdentitySchema.Type;
+
+export const SObjectArtifactIdentitySchema = Schema.Struct({
+  kind: Schema.Literal('sobject'),
+  ...ArtifactIdentityFields
+});
+export type SObjectArtifactIdentity = typeof SObjectArtifactIdentitySchema.Type;
+
+export const ApexTypeArtifactIdentitySchema = Schema.Struct({
+  kind: Schema.Literal('apex-type'),
+  ...ArtifactIdentityFields
+});
+export type ApexTypeArtifactIdentity = typeof ApexTypeArtifactIdentitySchema.Type;
+
+/** Provider-neutral identity shared by workspace, org, cache, and persistence providers. */
+export const ArtifactIdentitySchema = Schema.Union(
+  MetadataComponentArtifactIdentitySchema,
+  SObjectArtifactIdentitySchema,
+  ApexTypeArtifactIdentitySchema
+);
+export type ArtifactIdentity = typeof ArtifactIdentitySchema.Type;
+
+/** Locale-independent comparison normalization. Canonical provider casing remains on the identity itself. */
+export const normalizeArtifactIdentityPart = (value: string): string => value.toLowerCase();
+
+export const normalizeArtifactNamespace = (namespace: ArtifactNamespace): ArtifactNamespace =>
+  namespace === null ? null : normalizeArtifactIdentityPart(namespace);
+
+export const normalizeArtifactIdentity = (identity: ArtifactIdentity): ArtifactIdentity => ({
+  ...identity,
+  ...(identity.kind === 'metadata-component'
+    ? { metadataType: normalizeArtifactIdentityPart(identity.metadataType) }
+    : {}),
+  namespace: normalizeArtifactNamespace(identity.namespace),
+  name: normalizeArtifactIdentityPart(identity.name)
+});
+
+/** Stable comparison/cache key. Namespace remains a distinct tuple member rather than being added to the name. */
+export const artifactIdentityKey = (identity: ArtifactIdentity): string => {
+  const normalized = normalizeArtifactIdentity(identity);
+  return JSON.stringify([
+    normalized.kind,
+    normalized.kind === 'metadata-component' ? normalized.metadataType : null,
+    normalized.namespace,
+    normalized.name
+  ]);
+};
+
+export const artifactIdentitiesEqual = (left: ArtifactIdentity, right: ArtifactIdentity): boolean =>
+  artifactIdentityKey(left) === artifactIdentityKey(right);
+
+export const artifactNamespacesEqual = (left: ArtifactNamespace, right: ArtifactNamespace): boolean =>
+  normalizeArtifactNamespace(left) === normalizeArtifactNamespace(right);

--- a/packages/salesforcedx-vscode-services/src/index.ts
+++ b/packages/salesforcedx-vscode-services/src/index.ts
@@ -176,6 +176,26 @@ type PublicSdkLayerFor = (
 export type { AliasService } from './core/alias';
 export type { TelemetryIdentitySnapshot } from './core/defaultOrgRef';
 export {
+  ApexTypeArtifactIdentitySchema,
+  ArtifactIdentitySchema,
+  ArtifactNamespaceSchema,
+  ArtifactTargetKindSchema,
+  MetadataComponentArtifactIdentitySchema,
+  SObjectArtifactIdentitySchema,
+  artifactIdentitiesEqual,
+  artifactIdentityKey,
+  artifactNamespacesEqual,
+  normalizeArtifactIdentity,
+  normalizeArtifactIdentityPart,
+  normalizeArtifactNamespace,
+  type ApexTypeArtifactIdentity,
+  type ArtifactIdentity,
+  type ArtifactNamespace,
+  type ArtifactTargetKind,
+  type MetadataComponentArtifactIdentity,
+  type SObjectArtifactIdentity
+} from './core/artifactIdentity';
+export {
   TemplateService,
   type ApexClassCreateOptions,
   type ApexTriggerCreateOptions,

--- a/packages/salesforcedx-vscode-services/test/jest/core/artifactIdentity.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/artifactIdentity.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Schema from 'effect/Schema';
+import {
+  ApexTypeArtifactIdentitySchema,
+  ArtifactIdentitySchema,
+  artifactIdentitiesEqual,
+  artifactIdentityKey,
+  artifactNamespacesEqual,
+  normalizeArtifactIdentity
+} from '../../../src/core/artifactIdentity';
+
+describe('artifact identity', () => {
+  it.each([
+    { kind: 'apex-type', namespace: null, name: 'GlobalType' },
+    { kind: 'apex-type', namespace: 'System', name: 'String' },
+    { kind: 'apex-type', namespace: 'MyPackage', name: 'Outer.Inner' },
+    { kind: 'sobject', namespace: null, name: 'Widget__c' },
+    { kind: 'metadata-component', metadataType: 'ApexClass', namespace: null, name: 'Example' }
+  ] as const)('decodes a canonical $kind identity for $name', identity => {
+    expect(Schema.decodeUnknownSync(ArtifactIdentitySchema)(identity)).toEqual(identity);
+  });
+
+  it('requires an explicit null namespace for a global identity', () => {
+    expect(() =>
+      Schema.decodeUnknownSync(ApexTypeArtifactIdentitySchema)({ kind: 'apex-type', name: 'String' })
+    ).toThrow('namespace');
+    expect(() =>
+      Schema.decodeUnknownSync(ApexTypeArtifactIdentitySchema)({ kind: 'apex-type', namespace: '', name: 'String' })
+    ).toThrow('namespace');
+  });
+
+  it('normalizes comparison fields without changing the canonical input', () => {
+    const identity = {
+      kind: 'metadata-component',
+      metadataType: 'ApexClass',
+      namespace: 'MyPackage',
+      name: 'Outer.Inner'
+    } as const;
+
+    expect(normalizeArtifactIdentity(identity)).toEqual({
+      kind: 'metadata-component',
+      metadataType: 'apexclass',
+      namespace: 'mypackage',
+      name: 'outer.inner'
+    });
+    expect(identity).toEqual({
+      kind: 'metadata-component',
+      metadataType: 'ApexClass',
+      namespace: 'MyPackage',
+      name: 'Outer.Inner'
+    });
+  });
+
+  it('matches namespace and name case-insensitively', () => {
+    expect(
+      artifactIdentitiesEqual(
+        { kind: 'apex-type', namespace: 'System', name: 'String' },
+        { kind: 'apex-type', namespace: 'SYSTEM', name: 'string' }
+      )
+    ).toBe(true);
+    expect(artifactNamespacesEqual('MyPackage', 'mypackage')).toBe(true);
+  });
+
+  it('does not conflate namespace with inner-type qualification', () => {
+    const namespacedInner = { kind: 'apex-type', namespace: 'MyPackage', name: 'Outer.Inner' } as const;
+    const dottedName = { kind: 'apex-type', namespace: null, name: 'MyPackage.Outer.Inner' } as const;
+
+    expect(artifactIdentitiesEqual(namespacedInner, dottedName)).toBe(false);
+    expect(artifactIdentityKey(namespacedInner)).not.toBe(artifactIdentityKey(dottedName));
+  });
+
+  it('distinguishes target kind and metadata type', () => {
+    expect(
+      artifactIdentitiesEqual(
+        { kind: 'apex-type', namespace: null, name: 'Widget__c' },
+        { kind: 'sobject', namespace: null, name: 'Widget__c' }
+      )
+    ).toBe(false);
+    expect(
+      artifactIdentitiesEqual(
+        { kind: 'metadata-component', metadataType: 'ApexClass', namespace: null, name: 'Example' },
+        { kind: 'metadata-component', metadataType: 'ApexTrigger', namespace: null, name: 'Example' }
+      )
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Introduces the provider-neutral artifact identity foundation for Org Metadata Catalog lookup work:

- Effect Schemas and inferred TypeScript types for metadata components, SObjects, and Apex types
- a required `string | null` namespace represented separately from artifact names and Apex inner-type qualification
- case-insensitive normalization, equality, and stable key helpers that preserve canonical provider casing
- focused coverage for global, `System`, package, metadata, and inner-type identities

This is layer 1 of the [W-23971749 stack](https://github.com/forcedotcom/salesforcedx-vscode/stacks/8036) and does not change finder behavior.

### What issues does this PR fix or reference?

@W-23971749@

### Functionality Before

Services had no shared, namespace-aware identity contract suitable for correlating workspace, org, cache, and persistence providers.

### Functionality After

Services has one schema-backed identity vocabulary and stable comparison/key behavior for later catalog and provider layers.

### Validation

- focused Jest identity tests
- package TypeScript and ESLint checks
- repository pre-commit and pre-push workflows

### Stack

1. This PR — canonical artifact identity
2. #8034 — project namespace access and eligibility
3. #8035 — namespace-aware catalog keys and inventory correlation
