### PR TITLE
feat(services): add project namespace eligibility - W-23971749

### DIFF
--- a/packages/salesforcedx-vscode-services/src/core/projectService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/projectService.ts
@@ -21,6 +21,7 @@ import * as vscode from 'vscode';
 import { URI, Utils } from 'vscode-uri';
 import { toUri } from '../vscode/uriUtils';
 import { WorkspaceService } from '../vscode/workspaceService';
+import { artifactNamespacesEqual, type ArtifactNamespace } from './artifactIdentity';
 import { unknownToErrorCause } from './shared';
 
 export class FailedToResolveSfProjectError extends Schema.TaggedError<FailedToResolveSfProjectError>()(
@@ -128,6 +129,14 @@ const readVsCodeTestWebDiskRootMarker = Effect.promise(async (): Promise<string 
 export const sfProjectCacheKey = (workspaceDirFsPath: string) =>
   Effect.map(readVsCodeTestWebDiskRootMarker, markerPath => markerPath ?? normalize(workspaceDirFsPath));
 
+export const canonicalProjectNamespace = (value: unknown): ArtifactNamespace =>
+  typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+
+export const isWorkspaceNamespaceEligible = (
+  requestedNamespace: ArtifactNamespace,
+  projectNamespace: ArtifactNamespace
+): boolean => artifactNamespacesEqual(requestedNamespace, projectNamespace);
+
 /** VS Code Web test mounts are not readable by Node `SfProject.resolve`; used when resolve fails on the disk key. */
 const workspaceRootSalesforceManifestExistsViaVscodeFs = Effect.promise(async (): Promise<boolean> => {
   const folders = vscode.workspace.workspaceFolders;
@@ -187,6 +196,19 @@ export class ProjectService extends Effect.Service<ProjectService>()('ProjectSer
       yield* setProjectOpenedContext(projectOpenedContext, true, 'workspace_non_empty');
       return project;
     });
+
+    /** Return the canonical project namespace, or null for an explicitly unnamespaced project. */
+    const getProjectNamespace = Effect.fn('ProjectService.getProjectNamespace')(function* () {
+      const project = yield* getSfProject();
+      return canonicalProjectNamespace(project.getSfProjectJson().getContents().namespace);
+    });
+
+    /** Determine whether an exact artifact namespace is eligible for attribution to this workspace. */
+    const isArtifactNamespaceWorkspaceEligible = Effect.fn('ProjectService.isArtifactNamespaceWorkspaceEligible')(
+      function* (requestedNamespace: ArtifactNamespace) {
+        return isWorkspaceNamespaceEligible(requestedNamespace, yield* getProjectNamespace());
+      }
+    );
 
     /** Check if a URI is within any package directory */
     const isInPackageDirectories = Effect.fn('ProjectService.isInPackageDirectories')(function* (uri: URI) {
@@ -271,6 +293,8 @@ export class ProjectService extends Effect.Service<ProjectService>()('ProjectSer
     return {
       isSalesforceProject,
       getSfProject,
+      getProjectNamespace,
+      isArtifactNamespaceWorkspaceEligible,
       isInPackageDirectories,
       ensureInPackageDirectories,
       getSoqlMetadataPath,

--- a/packages/salesforcedx-vscode-services/test/jest/core/projectService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/projectService.test.ts
@@ -11,9 +11,15 @@ import * as Exit from 'effect/Exit';
 import * as Layer from 'effect/Layer';
 import * as Option from 'effect/Option';
 import * as Ref from 'effect/Ref';
+import { SfProject } from '@salesforce/core';
 import * as vscode from 'vscode';
 import { URI } from 'vscode-uri';
-import { ProjectService, setProjectOpenedContext } from '../../../src/core/projectService';
+import {
+  canonicalProjectNamespace,
+  isWorkspaceNamespaceEligible,
+  ProjectService,
+  setProjectOpenedContext
+} from '../../../src/core/projectService';
 import { NoWorkspaceOpenError, WorkspaceService } from '../../../src/vscode/workspaceService';
 
 const workspaceLayer = (uri: URI | undefined) =>
@@ -89,5 +95,60 @@ describe('ProjectService opened context', () => {
     expect(vscode.commands.executeCommand).toHaveBeenNthCalledWith(1, 'setContext', 'sf:project_opened', true);
     expect(vscode.commands.executeCommand).toHaveBeenNthCalledWith(2, 'setContext', 'sf:project_opened', false);
     expect(vscode.commands.executeCommand).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('ProjectService namespace', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    ['MyPackage', 'MyPackage'],
+    ['  MyPackage  ', 'MyPackage'],
+    ['', null],
+    ['   ', null],
+    [undefined, null],
+    [42, null]
+  ])('normalizes project namespace %p to %p', (value, expected) => {
+    expect(canonicalProjectNamespace(value)).toBe(expected);
+  });
+
+  it.each([
+    ['MyPackage', 'mypackage', true],
+    [null, null, true],
+    ['MyPackage', null, false],
+    [null, 'MyPackage', false],
+    ['MyPackage', 'OtherPackage', false]
+  ] as const)(
+    'evaluates requested namespace %p against project namespace %p',
+    (requestedNamespace, projectNamespace, expected) => {
+      expect(isWorkspaceNamespaceEligible(requestedNamespace, projectNamespace)).toBe(expected);
+    }
+  );
+
+  it('reads canonical namespace casing through ProjectService', async () => {
+    jest.spyOn(SfProject, 'resolve').mockResolvedValue({
+      getSfProjectJson: () => ({ getContents: () => ({ namespace: 'MyPackage' }) })
+    } as unknown as SfProject);
+
+    const namespace = await Effect.runPromise(
+      ProjectService.getProjectNamespace().pipe(Effect.provide(layerFor(URI.file('/project-namespace'))))
+    );
+
+    expect(namespace).toBe('MyPackage');
+  });
+
+  it('reports a missing Salesforce project as a typed resolution failure', async () => {
+    jest.spyOn(SfProject, 'resolve').mockRejectedValue(new Error('not a Salesforce project'));
+
+    const exit = await Effect.runPromiseExit(
+      ProjectService.getProjectNamespace().pipe(Effect.provide(layerFor(URI.file('/missing-project-namespace'))))
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    expect(Exit.isFailure(exit) ? Option.getOrUndefined(Cause.failureOption(exit.cause)) : undefined).toMatchObject({
+      _tag: 'FailedToResolveSfProjectError'
+    });
   });
 });

--- a/packages/salesforcedx-vscode-services/test/jest/core/templateService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/templateService.test.ts
@@ -80,6 +80,8 @@ const createMockProjectService = (): Layer.Layer<ProjectService> => {
     ProjectService.make({
       isSalesforceProject: () => Effect.succeed(true),
       getSfProject: () => Effect.succeed(mockSfProject),
+      getProjectNamespace: () => Effect.succeed(null),
+      isArtifactNamespaceWorkspaceEligible: namespace => Effect.succeed(namespace === null),
       isInPackageDirectories: () => Effect.succeed(true),
       ensureInPackageDirectories: () => Effect.void,
       getSoqlMetadataPath: () => Effect.succeed(URI.file('/test/soql')),


### PR DESCRIPTION
### What does this PR do?

Adds project namespace access and workspace-attribution eligibility to `ProjectService`:

- reads and canonicalizes `sfdx-project.json` namespace values
- compares requested and project namespaces case-insensitively
- treats `null` as an explicitly unnamespaced project/request
- covers absent, empty, matching, mismatching, mixed-case, and project-resolution cases
- updates test implementations through Effect Layers as the service contract expands

Production consumers obtain `ProjectService` from its Effect tag; service instances are not passed as helper parameters. Pure namespace helpers accept domain values only.

This is layer 2 of the [W-23971749 stack](https://github.com/forcedotcom/salesforcedx-vscode/stacks/8036) and does not change finder behavior.

### What issues does this PR fix or reference?

@W-23971749@

### Functionality Before

Services could resolve an `SfProject`, but had no canonical project namespace API or shared rule for deciding whether a namespaced artifact may be attributed to workspace source.

### Functionality After

Effect consumers can ask `ProjectService` for the canonical namespace or exact workspace eligibility without manually threading project/service dependencies.

### Validation

- focused ProjectService and TemplateService Jest tests
- production and test TypeScript compilation
- repository pre-commit and pre-push workflows

### Stack

1. #8033 — canonical artifact identity
2. This PR — project namespace access and eligibility
3. #8035 — namespace-aware catalog keys and inventory correlation
