### PR TITLE
feat(services): make catalog identity namespace-aware - W-23971749

### DIFF
--- a/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogInventory.ts
+++ b/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogInventory.ts
@@ -10,7 +10,7 @@ import type { OrgMetadataPresence } from './orgMetadataCatalogTypes';
 import * as Effect from 'effect/Effect';
 import { URI } from 'vscode-uri';
 import { FOLDERED_METADATA_TYPES, MetadataDescribeService } from '../core/metadataDescribeService';
-import { emptyPresence, typeCacheKey } from './orgCatalogKeys';
+import { emptyPresence, findInventoryComponent, typeCacheKey } from './orgCatalogKeys';
 import { mergeInventory, projectChildren } from './orgCatalogProjection';
 import { OrgCatalogState } from './orgCatalogState';
 import { OrgCatalogWorkspace } from './orgCatalogWorkspace';
@@ -62,10 +62,14 @@ export class OrgCatalogInventory extends Effect.Service<OrgCatalogInventory>()('
               : metadataDescribeService
                   .listMetadata(xmlName, undefined, orgId)
                   .pipe(Effect.map(components => ({ components, folders: [] })));
-        const [orgListing, workspaceUris] = yield* Effect.all(
+        const [orgListing, workspaceInventory] = yield* Effect.all(
           [
             listOrgComponents,
-            workspace.scanWorkspace(xmlName).pipe(Effect.catchAll(() => Effect.succeed(new Map<string, URI>())))
+            workspace
+              .scanWorkspaceInventory(xmlName)
+              .pipe(
+                Effect.catchAll(() => Effect.succeed({ namespace: null, components: new Map<string, URI>() } as const))
+              )
           ],
           { concurrency: 'unbounded' }
         );
@@ -78,7 +82,8 @@ export class OrgCatalogInventory extends Effect.Service<OrgCatalogInventory>()('
             orgId,
             xmlName,
             orgComponents: orgListing.components,
-            workspaceUris,
+            workspaceUris: workspaceInventory.components,
+            workspaceNamespace: workspaceInventory.namespace,
             observedAt
           }),
           folders: new Map(orgListing.folders.map(folder => [folder.fullName, folder]))
@@ -93,8 +98,12 @@ export class OrgCatalogInventory extends Effect.Service<OrgCatalogInventory>()('
       orgId: string,
       reference: OrgMetadataComponentReference
     ) {
-      const cachedEntry = (yield* state.getInventory(orgId, reference.xmlName))?.components.get(reference.fullName);
-      const entry = cachedEntry ?? (yield* loadType(orgId, reference.xmlName)).components.get(reference.fullName);
+      const cachedEntry = findInventoryComponent(
+        (yield* state.getInventory(orgId, reference.xmlName))?.components ?? new Map(),
+        reference
+      );
+      const entry =
+        cachedEntry ?? findInventoryComponent((yield* loadType(orgId, reference.xmlName)).components, reference);
       return entry
         ? ({
             inOrg: entry.inOrg,
@@ -109,9 +118,12 @@ export class OrgCatalogInventory extends Effect.Service<OrgCatalogInventory>()('
       reference: OrgMetadataComponentReference
     ) {
       const cached = yield* state.getInventory(orgId, reference.xmlName);
-      const inventory = cached?.components.has(reference.fullName) ? cached : yield* loadType(orgId, reference.xmlName);
+      const inventory =
+        cached && findInventoryComponent(cached.components, reference)
+          ? cached
+          : yield* loadType(orgId, reference.xmlName);
       return (
-        inventory.components.get(reference.fullName) ??
+        findInventoryComponent(inventory.components, reference) ??
         projectChildren(
           entryUri,
           orgId,

--- a/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogKeys.ts
+++ b/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogKeys.ts
@@ -5,14 +5,54 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import type { OrgMetadataPresence } from './orgMetadataCatalogTypes';
-import type { OrgMetadataComponentReference } from './orgMetadataReference';
+import type { OrgMetadataCatalogInternalEntry, OrgMetadataPresence } from './orgMetadataCatalogTypes';
+import {
+  artifactIdentitiesEqual,
+  artifactIdentityKey,
+  type ArtifactNamespace,
+  type MetadataComponentArtifactIdentity
+} from '../core/artifactIdentity';
+import { isOrgMetadataComponentReference, type OrgMetadataComponentReference } from './orgMetadataReference';
 
 export const emptyPresence = (): OrgMetadataPresence => ({ inOrg: false, inWorkspace: false });
 
+const metadataComponentArtifactIdentity = (
+  reference: OrgMetadataComponentReference,
+  namespace: ArtifactNamespace = null
+): MetadataComponentArtifactIdentity => ({
+  kind: 'metadata-component',
+  metadataType: reference.xmlName,
+  namespace,
+  name: reference.fullName
+});
+
 /** Identity key for a metadata component reference, independent of the org it was observed in. */
-export const componentIdentity = (reference: OrgMetadataComponentReference): string =>
-  `${reference.xmlName}\0${reference.fullName}`;
+export const componentIdentity = (
+  reference: OrgMetadataComponentReference,
+  namespace: ArtifactNamespace = null
+): string => artifactIdentityKey(metadataComponentArtifactIdentity(reference, namespace));
+
+/**
+ * Exact namespace lookup for new callers, with a simple-name compatibility fallback only when namespace is omitted.
+ * The fallback preserves existing catalog APIs until their request references carry required-null namespace identity.
+ */
+export const findInventoryComponent = (
+  components: ReadonlyMap<string, OrgMetadataCatalogInternalEntry>,
+  reference: OrgMetadataComponentReference,
+  namespace?: ArtifactNamespace
+): OrgMetadataCatalogInternalEntry | undefined => {
+  if (namespace !== undefined) return components.get(componentIdentity(reference, namespace));
+  const globalMatch = components.get(componentIdentity(reference));
+  if (globalMatch) return globalMatch;
+  return [...components.values()].find(
+    entry =>
+      isOrgMetadataComponentReference(entry.reference) &&
+      artifactIdentitiesEqual(
+        metadataComponentArtifactIdentity(entry.reference),
+        metadataComponentArtifactIdentity(reference)
+      )
+  );
+};
 
 /**
  * Derives the set of SObject api names whose describe caches are affected by a

--- a/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogProjection.ts
+++ b/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogProjection.ts
@@ -7,7 +7,9 @@
 
 import type { ListedMetadataComponent, TypeInventory } from './orgCatalogInternalTypes';
 import type { OrgMetadataCatalogInternalEntry as OrgMetadataCatalogEntry } from './orgMetadataCatalogTypes';
+import type { ArtifactNamespace } from '../core/artifactIdentity';
 import { URI } from 'vscode-uri';
+import { componentIdentity, findInventoryComponent } from './orgCatalogKeys';
 import { isOrgMetadataComponentReference } from './orgMetadataReference';
 
 export const mergeInventory = ({
@@ -16,6 +18,7 @@ export const mergeInventory = ({
   xmlName,
   orgComponents,
   workspaceUris,
+  workspaceNamespace = null,
   observedAt
 }: {
   readonly entryUri: (orgId: string, xmlName: string, fullName: string) => URI;
@@ -23,11 +26,12 @@ export const mergeInventory = ({
   readonly xmlName: string;
   readonly orgComponents: readonly ListedMetadataComponent[];
   readonly workspaceUris: ReadonlyMap<string, URI>;
+  readonly workspaceNamespace?: ArtifactNamespace;
   readonly observedAt: string;
 }): ReadonlyMap<string, OrgMetadataCatalogEntry> => {
   const orgInventory = orgComponents.reduce(
     (entries, component) =>
-      entries.set(component.fullName, {
+      entries.set(componentIdentity({ xmlName, fullName: component.fullName }, component.namespacePrefix ?? null), {
         orgId,
         observedAt,
         provenance: 'metadata-api',
@@ -47,16 +51,20 @@ export const mergeInventory = ({
     new Map<string, OrgMetadataCatalogEntry>()
   );
   return [...workspaceUris].reduce((entries, [fullName, workspaceUri]) => {
-    const existing = entries.get(fullName);
-    return entries.set(fullName, {
+    const reference = { xmlName, fullName };
+    const key = componentIdentity(reference, workspaceNamespace);
+    const existing = entries.get(key);
+    const canonicalReference =
+      existing && isOrgMetadataComponentReference(existing.reference) ? existing.reference : reference;
+    return entries.set(key, {
       orgId,
       observedAt: existing?.observedAt ?? new Date().toISOString(),
       provenance: existing ? 'metadata-api+workspace' : 'workspace',
-      reference: { xmlName, fullName },
+      reference: canonicalReference,
       documentUri: existing?.documentUri ?? entryUri(orgId, xmlName, fullName),
       name: existing?.name ?? fullName.split('/').at(-1) ?? fullName,
       kind: 'component',
-      namespacePrefix: existing?.namespacePrefix,
+      namespacePrefix: existing?.namespacePrefix ?? workspaceNamespace ?? undefined,
       manageableState: existing?.manageableState,
       fileName: existing?.fileName,
       lastModifiedByName: existing?.lastModifiedByName,
@@ -78,7 +86,10 @@ export const projectChildren = (
 ): OrgMetadataCatalogEntry[] => {
   const prefix = parentFullName ? `${parentFullName}/` : '';
   const childNames = new Set<string>();
-  [...inventory.components.keys(), ...inventory.folders.keys()].forEach(fullName => {
+  const componentFullNames = [...inventory.components.values()].flatMap(component =>
+    isOrgMetadataComponentReference(component.reference) ? [component.reference.fullName] : []
+  );
+  [...componentFullNames, ...inventory.folders.keys()].forEach(fullName => {
     if (!fullName.startsWith(prefix)) return;
     const name = fullName.slice(prefix.length).split('/')[0];
     if (name) childNames.add(name);
@@ -86,9 +97,9 @@ export const projectChildren = (
   return [...childNames]
     .map(name => {
       const fullName = `${prefix}${name}`;
-      const component = inventory.components.get(fullName);
+      const component = findInventoryComponent(inventory.components, { xmlName, fullName });
       const folder = inventory.folders.get(fullName);
-      const hasDescendants = [...inventory.components.keys(), ...inventory.folders.keys()].some(candidate =>
+      const hasDescendants = [...componentFullNames, ...inventory.folders.keys()].some(candidate =>
         candidate.startsWith(`${fullName}/`)
       );
       if (!folder && !hasDescendants && component) return { ...component, name };

--- a/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogRemoteSource.ts
+++ b/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogRemoteSource.ts
@@ -16,7 +16,7 @@ import { ConnectionService } from '../core/connectionService';
 import { unknownToErrorCause } from '../core/shared';
 import { FsService } from '../vscode/fsService';
 import { OrgCatalogInventory } from './orgCatalogInventory';
-import { componentIdentity, typeCacheKey } from './orgCatalogKeys';
+import { componentIdentity, findInventoryComponent, typeCacheKey } from './orgCatalogKeys';
 import { OrgCatalogRemoteRetrieve } from './orgCatalogRemoteRetrieve';
 import { OrgCatalogState } from './orgCatalogState';
 import { OrgMetadataCatalogError } from './orgMetadataCatalogErrors';
@@ -156,8 +156,9 @@ export class OrgCatalogRemoteSource extends Effect.Service<OrgCatalogRemoteSourc
             uniqueReferences,
             reference =>
               Effect.gen(function* () {
-                const loadedEntry = (yield* state.getInventory(orgId, reference.xmlName))?.components.get(
-                  reference.fullName
+                const loadedEntry = findInventoryComponent(
+                  (yield* state.getInventory(orgId, reference.xmlName))?.components ?? new Map(),
+                  reference
                 );
                 const entry = forceRefresh ? loadedEntry : yield* inventories.getEntry(orgId, reference);
                 if (!forceRefresh && !entry?.inOrg) {
@@ -199,7 +200,7 @@ export class OrgCatalogRemoteSource extends Effect.Service<OrgCatalogRemoteSourc
                 const key = typeCacheKey(orgId, reference.xmlName);
                 const inventory = next.get(key);
                 if (!inventory) return;
-                const currentEntry = inventory.components.get(reference.fullName);
+                const currentEntry = findInventoryComponent(inventory.components, reference);
                 const remoteLastModifiedDate = artifact.remoteLastModifiedDate;
                 const updatedEntry: OrgMetadataCatalogEntry = {
                   ...currentEntry,
@@ -218,7 +219,10 @@ export class OrgCatalogRemoteSource extends Effect.Service<OrgCatalogRemoteSourc
                 next.set(key, {
                   ...inventory,
                   observedAt,
-                  components: new Map(inventory.components).set(reference.fullName, updatedEntry)
+                  components: new Map(inventory.components).set(
+                    componentIdentity(reference, currentEntry?.namespacePrefix ?? null),
+                    updatedEntry
+                  )
                 });
               });
               return next;

--- a/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogState.ts
+++ b/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogState.ts
@@ -20,7 +20,7 @@ import * as HashSet from 'effect/HashSet';
 import * as Order from 'effect/Order';
 import * as Queue from 'effect/Queue';
 import * as Ref from 'effect/Ref';
-import { metadataListingKey, sobjectDescriptionKey, typeCacheKey } from './orgCatalogKeys';
+import { componentIdentity, metadataListingKey, sobjectDescriptionKey, typeCacheKey } from './orgCatalogKeys';
 import {
   OrgMetadataCatalogStore,
   type OrgMetadataCatalogSnapshot,
@@ -208,7 +208,7 @@ export class OrgCatalogState extends Effect.Service<OrgCatalogState>()('OrgCatal
                 orgId,
                 new Map(
                   snapshot.tracking.map(observation => [
-                    `${observation.xmlName}\0${observation.fullName}`,
+                    componentIdentity({ xmlName: observation.xmlName, fullName: observation.fullName }),
                     {
                       reference: { xmlName: observation.xmlName, fullName: observation.fullName },
                       signature: observation.signature

--- a/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogTreeProjection.ts
+++ b/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogTreeProjection.ts
@@ -11,6 +11,7 @@ import * as vscode from 'vscode';
 import { MetadataDescribeService } from '../core/metadataDescribeService';
 import { TransmogrifierService } from '../core/transmogrifierService';
 import { OrgCatalogInventory } from './orgCatalogInventory';
+import { findInventoryComponent } from './orgCatalogKeys';
 import { projectChildren } from './orgCatalogProjection';
 import { OrgCatalogState } from './orgCatalogState';
 import { OrgCatalogWorkspace } from './orgCatalogWorkspace';
@@ -126,9 +127,12 @@ export class OrgCatalogTreeProjection extends Effect.Service<OrgCatalogTreeProje
           `${objectEntry.reference.fullName}.${field.name}`,
           `${objectEntry.reference.fullName}.${unqualifiedName}`
         ];
-        const fullName = candidates.find(candidate => fieldInventory.components.has(candidate)) ?? candidates[0];
+        const fullName =
+          candidates.find(candidate =>
+            findInventoryComponent(fieldInventory.components, { xmlName: 'CustomField', fullName: candidate })
+          ) ?? candidates[0];
         if (inventoriedFullNames.has(fullName)) return [];
-        const existing = fieldInventory.components.get(fullName);
+        const existing = findInventoryComponent(fieldInventory.components, { xmlName: 'CustomField', fullName });
         return [
           {
             ...(existing ?? {
@@ -182,7 +186,9 @@ export class OrgCatalogTreeProjection extends Effect.Service<OrgCatalogTreeProje
           .toSorted((left, right) => left.name.localeCompare(right.name));
       }
       const inventory = yield* inventories.loadType(orgId, reference.xmlName);
-      const component = reference.fullName ? inventory.components.get(reference.fullName) : undefined;
+      const component = reference.fullName
+        ? findInventoryComponent(inventory.components, { xmlName: reference.xmlName, fullName: reference.fullName })
+        : undefined;
       if (component && reference.xmlName === 'CustomObject') {
         return yield* getCustomFieldChildren(orgId, component);
       }

--- a/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogWorkspace.ts
+++ b/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogWorkspace.ts
@@ -28,13 +28,16 @@ export class OrgCatalogWorkspace extends Effect.Service<OrgCatalogWorkspace>()('
       MetadataRetrieveService,
       ProjectService
     ]);
-    const scanWorkspace = Effect.fn('OrgCatalogWorkspace.scanWorkspace')(function* (xmlName: string) {
-      const project = yield* projectService.getSfProject();
+    const scanWorkspaceInventory = Effect.fn('OrgCatalogWorkspace.scanWorkspaceInventory')(function* (xmlName: string) {
+      const [project, namespace] = yield* Effect.all([
+        projectService.getSfProject(),
+        projectService.getProjectNamespace()
+      ]);
       const packageDirectories = project.getPackageDirectories().map(directory => directory.fullPath);
       const componentSet = yield* metadataRetrieveService.buildComponentSetFromSource(packageDirectories, [
         { type: xmlName, fullName: '*' }
       ]);
-      return [...componentSet.getSourceComponents()].reduce((workspaceUris, component) => {
+      const components = [...componentSet.getSourceComponents()].reduce((workspaceUris, component) => {
         if (component.type.name !== xmlName) return workspaceUris;
         // Decomposed child metadata (for example CustomField) has an XML source file but no
         // `content` path. Treat the XML path as its workspace artifact so local presence is not
@@ -48,7 +51,12 @@ export class OrgCatalogWorkspace extends Effect.Service<OrgCatalogWorkspace>()('
         }
         return workspaceUris;
       }, new Map<string, URI>());
+      return { namespace, components } as const;
     });
+
+    const scanWorkspace = Effect.fn('OrgCatalogWorkspace.scanWorkspace')((xmlName: string) =>
+      scanWorkspaceInventory(xmlName).pipe(Effect.map(inventory => inventory.components))
+    );
 
     const getWorkspaceMetadataTypes = Effect.fn('OrgCatalogWorkspace.getWorkspaceMetadataTypes')(function* (
       orgId: string
@@ -113,6 +121,6 @@ export class OrgCatalogWorkspace extends Effect.Service<OrgCatalogWorkspace>()('
       return resolutions;
     });
 
-    return { getWorkspaceMetadataTypes, resolveComponents, scanWorkspace } as const;
+    return { getWorkspaceMetadataTypes, resolveComponents, scanWorkspace, scanWorkspaceInventory } as const;
   })
 }) {}

--- a/packages/salesforcedx-vscode-services/src/orgCatalog/orgMetadataCatalogRecorder.ts
+++ b/packages/salesforcedx-vscode-services/src/orgCatalog/orgMetadataCatalogRecorder.ts
@@ -16,7 +16,12 @@ import * as Effect from 'effect/Effect';
 import * as PubSub from 'effect/PubSub';
 import type { URI } from 'vscode-uri';
 import { TransmogrifierService, type DescribeSObjectResult } from '../core/transmogrifierService';
-import { componentIdentity, referencesToAffectedSObjects, typeCacheKey } from './orgCatalogKeys';
+import {
+  componentIdentity,
+  findInventoryComponent,
+  referencesToAffectedSObjects,
+  typeCacheKey
+} from './orgCatalogKeys';
 import { OrgCatalogState } from './orgCatalogState';
 import { OrgMetadataCatalogChangePubSub } from './orgMetadataCatalogChangePubSub';
 import { OrgMetadataReferenceService, type OrgMetadataComponentReference } from './orgMetadataReference';
@@ -100,6 +105,7 @@ export class OrgMetadataCatalogRecorder extends Effect.Service<OrgMetadataCatalo
         components: readonly {
           readonly type: string;
           readonly fullName: string;
+          readonly namespacePrefix?: string;
           readonly lastModifiedDate?: string;
           readonly workspaceUri?: URI;
         }[]
@@ -113,7 +119,9 @@ export class OrgMetadataCatalogRecorder extends Effect.Service<OrgMetadataCatalo
             const reference = { xmlName: component.type, fullName: component.fullName };
             const key = typeCacheKey(orgId, component.type);
             const inventory = next.get(key);
-            const previous = inventory?.components.get(component.fullName);
+            const previous = inventory
+              ? findInventoryComponent(inventory.components, reference, component.namespacePrefix ?? null)
+              : undefined;
             const entry: OrgMetadataCatalogEntry = {
               ...previous,
               orgId,
@@ -126,6 +134,7 @@ export class OrgMetadataCatalogRecorder extends Effect.Service<OrgMetadataCatalo
               documentUri: referenceService.documentUri({ orgId, ...reference }),
               name: previous?.name ?? component.fullName.split('/').at(-1) ?? component.fullName,
               kind: 'component',
+              namespacePrefix: component.namespacePrefix ?? previous?.namespacePrefix,
               inOrg: true,
               inWorkspace: Boolean(component.workspaceUri) || (previous?.inWorkspace ?? false),
               workspaceUri: component.workspaceUri ?? previous?.workspaceUri,
@@ -135,7 +144,10 @@ export class OrgMetadataCatalogRecorder extends Effect.Service<OrgMetadataCatalo
             next.set(key, {
               observedAt,
               complete: inventory?.complete ?? false,
-              components: new Map(inventory?.components).set(component.fullName, entry),
+              components: new Map(inventory?.components).set(
+                componentIdentity(reference, component.namespacePrefix ?? null),
+                entry
+              ),
               folders: inventory?.folders ?? new Map()
             });
           });
@@ -265,7 +277,7 @@ export class OrgMetadataCatalogRecorder extends Effect.Service<OrgMetadataCatalo
         yield* state.ensureHydrated(orgId);
         const revisionByIdentity = new Map(
           remoteChanges.map(change => [
-            `${change.type}\0${change.name}`,
+            componentIdentity({ xmlName: change.type, fullName: change.name }),
             JSON.stringify([
               change.revisionCounter,
               change.lastModifiedDate,
@@ -317,7 +329,7 @@ export class OrgMetadataCatalogRecorder extends Effect.Service<OrgMetadataCatalo
           fullName: change.fullName
         }));
         const affectedTypes = new Set(references.map(reference => reference.xmlName));
-        const identities = new Set(references.map(componentIdentity));
+        const identities = new Set(references.map(reference => componentIdentity(reference)));
         const affectedSObjects = referencesToAffectedSObjects(references);
         yield* state.invalidateTypes(orgId, affectedTypes);
         yield* state.removeTracking(orgId, identities);

--- a/packages/salesforcedx-vscode-services/test/jest/orgCatalog/orgCatalogProjection.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/orgCatalog/orgCatalogProjection.test.ts
@@ -7,6 +7,7 @@
 
 import { URI } from 'vscode-uri';
 import type { TypeInventory } from '../../../src/orgCatalog/orgCatalogInternalTypes';
+import { componentIdentity } from '../../../src/orgCatalog/orgCatalogKeys';
 import { mergeInventory, projectChildren } from '../../../src/orgCatalog/orgCatalogProjection';
 
 const entryUri = (orgId: string, xmlName: string, fullName: string): URI =>
@@ -28,23 +29,69 @@ describe('Org Catalog inventory projection', () => {
       ])
     });
 
-    expect(inventory.get('Both')).toMatchObject({
+    expect(inventory.get(componentIdentity({ xmlName: 'ApexClass', fullName: 'Both' }))).toMatchObject({
       provenance: 'metadata-api+workspace',
       inOrg: true,
       inWorkspace: true,
       workspaceUri,
       remoteLastModifiedDate: '2026-08-03T11:00:00.000Z'
     });
-    expect(inventory.get('RemoteOnly')).toMatchObject({
+    expect(inventory.get(componentIdentity({ xmlName: 'ApexClass', fullName: 'RemoteOnly' }))).toMatchObject({
       provenance: 'metadata-api',
       inOrg: true,
       inWorkspace: false
     });
-    expect(inventory.get('LocalOnly')).toMatchObject({
+    expect(inventory.get(componentIdentity({ xmlName: 'ApexClass', fullName: 'LocalOnly' }))).toMatchObject({
       provenance: 'workspace',
       inOrg: false,
       inWorkspace: true,
       workspaceUri: localOnlyUri
+    });
+  });
+
+  it('keeps a namespaced remote component separate from an ineligible unnamespaced workspace file', () => {
+    const workspaceUri = URI.file('/workspace/classes/MyClass.cls');
+    const inventory = mergeInventory({
+      entryUri,
+      orgId: 'org-one',
+      xmlName: 'ApexClass',
+      observedAt: '2026-08-03T12:00:00.000Z',
+      orgComponents: [{ fullName: 'MyClass', namespacePrefix: 'InstalledPackage' }],
+      workspaceUris: new Map([['MyClass', workspaceUri]]),
+      workspaceNamespace: null
+    });
+
+    expect(inventory.size).toBe(2);
+    expect(
+      inventory.get(componentIdentity({ xmlName: 'ApexClass', fullName: 'MyClass' }, 'InstalledPackage'))
+    ).toMatchObject({ namespacePrefix: 'InstalledPackage', inOrg: true, inWorkspace: false });
+    expect(inventory.get(componentIdentity({ xmlName: 'ApexClass', fullName: 'MyClass' }, null))).toMatchObject({
+      inOrg: false,
+      inWorkspace: true,
+      workspaceUri
+    });
+  });
+
+  it('merges matching project and remote namespaces while preserving provider casing', () => {
+    const workspaceUri = URI.file('/workspace/classes/MyClass.cls');
+    const inventory = mergeInventory({
+      entryUri,
+      orgId: 'org-one',
+      xmlName: 'ApexClass',
+      observedAt: '2026-08-03T12:00:00.000Z',
+      orgComponents: [{ fullName: 'MyClass', namespacePrefix: 'MyPackage' }],
+      workspaceUris: new Map([['myclass', workspaceUri]]),
+      workspaceNamespace: 'mypackage'
+    });
+
+    expect(inventory.size).toBe(1);
+    expect(inventory.values().next().value).toMatchObject({
+      namespacePrefix: 'MyPackage',
+      reference: { xmlName: 'ApexClass', fullName: 'MyClass' },
+      provenance: 'metadata-api+workspace',
+      inOrg: true,
+      inWorkspace: true,
+      workspaceUri
     });
   });
 

--- a/packages/salesforcedx-vscode-services/test/jest/orgCatalog/orgCatalogState.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/orgCatalog/orgCatalogState.test.ts
@@ -10,6 +10,7 @@ import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
 import { URI } from 'vscode-uri';
 import { OrgCatalogState } from '../../../src/orgCatalog/orgCatalogState';
+import { componentIdentity } from '../../../src/orgCatalog/orgCatalogKeys';
 import {
   OrgMetadataCatalogStore,
   type OrgMetadataCatalogSnapshot
@@ -50,7 +51,7 @@ describe('OrgCatalogState', () => {
       folders: new Map(),
       components: new Map([
         [
-          'RemoteAndLocal',
+          componentIdentity({ xmlName: 'ApexClass', fullName: 'RemoteAndLocal' }),
           {
             orgId: 'org-one',
             observedAt: '2026-08-03T12:00:00.000Z',
@@ -65,7 +66,7 @@ describe('OrgCatalogState', () => {
           }
         ],
         [
-          'LocalOnly',
+          componentIdentity({ xmlName: 'ApexClass', fullName: 'LocalOnly' }),
           {
             orgId: 'org-one',
             observedAt: '2026-08-03T12:00:00.000Z',
@@ -130,7 +131,9 @@ describe('OrgCatalogState', () => {
 
     expect(load).toHaveBeenCalledTimes(1);
     expect(result.inventory?.components).toEqual([expect.objectContaining({ fullName: 'RemoteTest' })]);
-    expect(result.tracking.get('ApexClass\0RemoteTest')?.signature).toBe('Changed|7');
+    expect(result.tracking.get(componentIdentity({ xmlName: 'ApexClass', fullName: 'RemoteTest' }))?.signature).toBe(
+      'Changed|7'
+    );
     expect(saved[0]?.generation).toBe(8);
   });
 

--- a/packages/salesforcedx-vscode-services/test/jest/orgCatalog/orgMetadataCatalog.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/orgCatalog/orgMetadataCatalog.test.ts
@@ -315,7 +315,8 @@ const makeHarness = (options: HarnessOptions = {}) => {
       getSfProject: () =>
         Effect.succeed({
           getPackageDirectories: () => [{ fullPath: '/workspace/force-app' }]
-        })
+        }),
+      getProjectNamespace: () => Effect.succeed(null)
     } as unknown as InstanceType<typeof ProjectService>),
     Layer.succeed(TransmogrifierService, {
       toMinimalSObject: (value: SObject) => Effect.succeed(value)

--- a/packages/salesforcedx-vscode-services/test/jest/orgCatalog/orgMetadataCatalogRecorder.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/orgCatalog/orgMetadataCatalogRecorder.test.ts
@@ -13,6 +13,7 @@ import * as Queue from 'effect/Queue';
 import { URI } from 'vscode-uri';
 import { TransmogrifierService } from '../../../src/core/transmogrifierService';
 import { OrgCatalogState } from '../../../src/orgCatalog/orgCatalogState';
+import { componentIdentity, findInventoryComponent } from '../../../src/orgCatalog/orgCatalogKeys';
 import { OrgMetadataCatalogRecorder } from '../../../src/orgCatalog/orgMetadataCatalogRecorder';
 import { OrgMetadataReferenceService } from '../../../src/orgCatalog/orgMetadataReference';
 import {
@@ -111,7 +112,10 @@ describe('OrgMetadataCatalogRecorder', () => {
         yield* recorder.recordRemoteComponents('org-one', 'metadata-api', [
           { type: 'ApexClass', fullName: 'DiscoveredTest', lastModifiedDate: '2026-08-13T00:00:00.000Z' }
         ]);
-        const discovered = (yield* state.getInventory('org-one', 'ApexClass'))?.components.get('DiscoveredTest');
+        const discovered = findInventoryComponent(
+          (yield* state.getInventory('org-one', 'ApexClass'))?.components ?? new Map(),
+          { xmlName: 'ApexClass', fullName: 'DiscoveredTest' }
+        );
         yield* Effect.sleep('350 millis');
         return discovered;
       }).pipe(Effect.provide(layer))
@@ -169,7 +173,7 @@ describe('OrgMetadataCatalogRecorder', () => {
             'org-one',
             new Map([
               [
-                'ApexClass\0Foo',
+                componentIdentity({ xmlName: 'ApexClass', fullName: 'Foo' }),
                 { reference: { xmlName: 'ApexClass', fullName: 'Foo' }, signature: 'modify\0revision-1' }
               ]
             ])


### PR DESCRIPTION
### What does this PR do?

Applies canonical namespace-aware keys to Org Metadata Catalog inventory correlation:

- keys remote and workspace entries by metadata type, namespace, and full name
- obtains `ProjectService` through the Effect context and scans workspace components with the project namespace
- merges local and remote entries only when their normalized namespaces and names match
- keeps installed-package artifacts separate from unrelated unnamespaced workspace files
- preserves canonical remote casing and existing catalog API compatibility
- migrates inventory, tracking, recorder, remote-source, and tree-projection lookups to the new key helper

This is layer 3 of the [W-23971749 stack](https://github.com/forcedotcom/salesforcedx-vscode/stacks/8036). Public `OrgMetadataCatalog.find(...)` behavior remains unchanged.

### What issues does this PR fix or reference?

@W-23971749@

### Functionality Before

Inventory maps keyed only by metadata full name could collapse a remote namespaced artifact and an unrelated local artifact with the same simple name.

### Functionality After

Catalog correlation preserves distinct namespace identities and only reports `metadata-api+workspace` when the project namespace is eligible.

### Validation

- all 68 Org Metadata Catalog Jest tests
- production and test TypeScript compilation
- ESLint, circular dependency, knip, and Effect diagnostics through repository hooks
- repository pre-push workflow

### Stack

1. #8033 — canonical artifact identity
2. #8034 — project namespace access and eligibility
3. This PR — namespace-aware catalog keys and inventory correlation
