### PR TITLE
feat(services): add canonical artifact projection schemas - W-23973850

### DIFF
--- a/packages/salesforcedx-vscode-services/src/core/artifactIdentity.ts
+++ b/packages/salesforcedx-vscode-services/src/core/artifactIdentity.ts
@@ -7,7 +7,7 @@
 
 import * as Schema from 'effect/Schema';
 
-export const ArtifactTargetKindSchema = Schema.Literal('metadata-component', 'sobject', 'apex-type');
+export const ArtifactTargetKindSchema = Schema.Literal('metadata-component', 'sobject');
 export type ArtifactTargetKind = typeof ArtifactTargetKindSchema.Type;
 
 export const ArtifactNamespaceSchema = Schema.NullOr(Schema.NonEmptyTrimmedString);
@@ -31,17 +31,10 @@ export const SObjectArtifactIdentitySchema = Schema.Struct({
 });
 export type SObjectArtifactIdentity = typeof SObjectArtifactIdentitySchema.Type;
 
-export const ApexTypeArtifactIdentitySchema = Schema.Struct({
-  kind: Schema.Literal('apex-type'),
-  ...ArtifactIdentityFields
-});
-export type ApexTypeArtifactIdentity = typeof ApexTypeArtifactIdentitySchema.Type;
-
 /** Provider-neutral identity shared by workspace, org, cache, and persistence providers. */
 export const ArtifactIdentitySchema = Schema.Union(
   MetadataComponentArtifactIdentitySchema,
-  SObjectArtifactIdentitySchema,
-  ApexTypeArtifactIdentitySchema
+  SObjectArtifactIdentitySchema
 );
 export type ArtifactIdentity = typeof ArtifactIdentitySchema.Type;
 

--- a/packages/salesforcedx-vscode-services/src/core/artifactProjection.ts
+++ b/packages/salesforcedx-vscode-services/src/core/artifactProjection.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Schema from 'effect/Schema';
+import { URI } from 'vscode-uri';
+import { ArtifactIdentitySchema, SObjectArtifactIdentitySchema } from './artifactIdentity';
+
+const UriTypeSchema = Schema.declare((value): value is URI => value instanceof URI, {
+  identifier: 'URI',
+  description: 'vscode-uri URI'
+});
+
+/** JSON-safe URI schema whose decoded TypeScript value is a vscode-uri URI. */
+export const DocumentUriSchema = Schema.transform(Schema.String, UriTypeSchema, {
+  strict: true,
+  decode: value => URI.parse(value),
+  encode: (_encoded, uri) => uri.toString()
+});
+export type DocumentUri = typeof DocumentUriSchema.Type;
+
+export const ArtifactPresenceSchema = Schema.Literal('workspace', 'org', 'both');
+export type ArtifactPresence = typeof ArtifactPresenceSchema.Type;
+
+export const ArtifactProviderKindSchema = Schema.Literal('workspace', 'metadata-api', 'rest-api', 'tooling-api');
+export type ArtifactProviderKind = typeof ArtifactProviderKindSchema.Type;
+
+/** Provider-neutral catalog information returned alongside any materialized projection. */
+export const CatalogEntryDescriptorSchema = Schema.Struct({
+  kind: Schema.Literal('catalog-entry'),
+  identity: ArtifactIdentitySchema,
+  presence: ArtifactPresenceSchema,
+  providers: Schema.Array(ArtifactProviderKindSchema),
+  workspaceUri: Schema.optional(DocumentUriSchema),
+  orgUri: Schema.optional(DocumentUriSchema)
+});
+export type CatalogEntryDescriptor = typeof CatalogEntryDescriptorSchema.Type;
+
+/** A URI that resolves to actual source. Semantic projections cannot satisfy this contract. */
+export const SourceDocumentSchema = Schema.Struct({
+  kind: Schema.Literal('source-document'),
+  identity: ArtifactIdentitySchema,
+  fidelity: Schema.Literal('actual-source'),
+  uri: DocumentUriSchema,
+  languageId: Schema.optional(Schema.NonEmptyTrimmedString)
+});
+export type SourceDocument = typeof SourceDocumentSchema.Type;
+
+export const SObjectPicklistValueSchema = Schema.Struct({
+  value: Schema.String,
+  label: Schema.optional(Schema.String),
+  active: Schema.optional(Schema.Boolean)
+});
+export type SObjectPicklistValue = typeof SObjectPicklistValueSchema.Type;
+
+/** Runtime capabilities are absent when a provider cannot know them, rather than being invented as false. */
+export const SObjectFieldRuntimeCapabilitiesSchema = Schema.Struct({
+  aggregatable: Schema.Boolean,
+  filterable: Schema.Boolean,
+  groupable: Schema.Boolean,
+  nillable: Schema.Boolean,
+  sortable: Schema.Boolean
+});
+export type SObjectFieldRuntimeCapabilities = typeof SObjectFieldRuntimeCapabilitiesSchema.Type;
+
+export const SObjectSemanticFieldSchema = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  label: Schema.optional(Schema.String),
+  type: Schema.optional(Schema.NonEmptyTrimmedString),
+  custom: Schema.optional(Schema.Boolean),
+  defaultValue: Schema.optional(Schema.Unknown),
+  inlineHelpText: Schema.optional(Schema.String),
+  length: Schema.optional(Schema.Number),
+  precision: Schema.optional(Schema.Number),
+  scale: Schema.optional(Schema.Number),
+  referenceTo: Schema.NonEmptyTrimmedString.pipe(Schema.Array, Schema.optional),
+  relationshipName: Schema.optional(Schema.String),
+  picklistValues: SObjectPicklistValueSchema.pipe(Schema.Array, Schema.optional),
+  runtimeCapabilities: Schema.optional(SObjectFieldRuntimeCapabilitiesSchema),
+  definitionUri: Schema.optional(DocumentUriSchema)
+});
+export type SObjectSemanticField = typeof SObjectSemanticFieldSchema.Type;
+
+export const SObjectChildRelationshipSchema = Schema.Struct({
+  childSObject: Schema.NonEmptyTrimmedString,
+  field: Schema.NonEmptyTrimmedString,
+  relationshipName: Schema.optional(Schema.String)
+});
+export type SObjectChildRelationship = typeof SObjectChildRelationshipSchema.Type;
+
+/**
+ * Canonical SObject facts shared by workspace metadata and org providers. Provider-specific facts are optional so
+ * an incomplete workspace declaration remains truthful and can later be enriched by REST data.
+ */
+export const SObjectSemanticValueSchema = Schema.Struct({
+  identity: SObjectArtifactIdentitySchema,
+  label: Schema.optional(Schema.String),
+  pluralLabel: Schema.optional(Schema.String),
+  custom: Schema.optional(Schema.Boolean),
+  queryable: Schema.optional(Schema.Boolean),
+  fields: Schema.Array(SObjectSemanticFieldSchema),
+  childRelationships: SObjectChildRelationshipSchema.pipe(Schema.Array, Schema.optional),
+  definitionUri: Schema.optional(DocumentUriSchema)
+});
+export type SObjectSemanticValue = typeof SObjectSemanticValueSchema.Type;
+
+export const SObjectSemanticModelSchema = Schema.Struct({
+  kind: Schema.Literal('sobject'),
+  value: SObjectSemanticValueSchema
+});
+export type SObjectSemanticModel = typeof SObjectSemanticModelSchema.Type;
+
+export const CanonicalSemanticModelSchema = SObjectSemanticModelSchema;
+export type CanonicalSemanticModel = typeof CanonicalSemanticModelSchema.Type;
+
+export const CatalogEntryProjectionSchema = Schema.Struct({ kind: Schema.Literal('catalog-entry') });
+export type CatalogEntryProjection = typeof CatalogEntryProjectionSchema.Type;
+
+export const SourceDocumentProjectionSchema = Schema.Struct({ kind: Schema.Literal('source-document') });
+export type SourceDocumentProjection = typeof SourceDocumentProjectionSchema.Type;
+
+export const SObjectSemanticProjectionSchema = Schema.Struct({
+  kind: Schema.Literal('semantic-model'),
+  model: Schema.Literal('sobject')
+});
+export type SObjectSemanticProjection = typeof SObjectSemanticProjectionSchema.Type;
+
+export const ArtifactProjectionSchema = Schema.Union(
+  CatalogEntryProjectionSchema,
+  SourceDocumentProjectionSchema,
+  SObjectSemanticProjectionSchema
+);
+export type ArtifactProjection = typeof ArtifactProjectionSchema.Type;
+
+export const ProjectionUnavailableReasonSchema = Schema.Literal('protected-source');
+export type ProjectionUnavailableReason = typeof ProjectionUnavailableReasonSchema.Type;
+
+export const ProjectionUnavailableSchema = Schema.Struct({
+  kind: Schema.Literal('projection-unavailable'),
+  reason: ProjectionUnavailableReasonSchema,
+  availableProjections: Schema.Array(ArtifactProjectionSchema)
+});
+export type ProjectionUnavailable = typeof ProjectionUnavailableSchema.Type;
+
+/** Runtime schemas exposed through the VS Code Services extension API. */
+export const ArtifactProjectionSchemas = {
+  DocumentUri: DocumentUriSchema,
+  CatalogEntryDescriptor: CatalogEntryDescriptorSchema,
+  SourceDocument: SourceDocumentSchema,
+  SObjectSemanticModel: SObjectSemanticModelSchema,
+  CanonicalSemanticModel: CanonicalSemanticModelSchema,
+  ArtifactProjection: ArtifactProjectionSchema,
+  ProjectionUnavailable: ProjectionUnavailableSchema
+} as const;

--- a/packages/salesforcedx-vscode-services/src/index.ts
+++ b/packages/salesforcedx-vscode-services/src/index.ts
@@ -19,6 +19,7 @@ import { getActiveMetadataOperationRef } from './core/activeMetadataOperationRef
 import { AliasService } from './core/alias';
 import { watchAliasFile } from './core/aliasFileWatcher';
 import { ApexLogService } from './core/apexLogService';
+import { ArtifactProjectionSchemas } from './core/artifactProjection';
 import { ComponentSetService } from './core/componentSetService';
 import { watchConfigFiles } from './core/configFileWatcher';
 import { ConfigService } from './core/configService';
@@ -120,6 +121,7 @@ export type SalesforceVSCodeServicesApi = {
     >;
     ApexLogService: typeof ApexLogService;
     AliasService: typeof AliasService;
+    ArtifactProjectionSchemas: typeof ArtifactProjectionSchemas;
     TemplateService: typeof TemplateService;
     TemplateType: typeof TemplateType;
     ChannelService: typeof ChannelService;
@@ -176,7 +178,6 @@ type PublicSdkLayerFor = (
 export type { AliasService } from './core/alias';
 export type { TelemetryIdentitySnapshot } from './core/defaultOrgRef';
 export {
-  ApexTypeArtifactIdentitySchema,
   ArtifactIdentitySchema,
   ArtifactNamespaceSchema,
   ArtifactTargetKindSchema,
@@ -188,13 +189,51 @@ export {
   normalizeArtifactIdentity,
   normalizeArtifactIdentityPart,
   normalizeArtifactNamespace,
-  type ApexTypeArtifactIdentity,
   type ArtifactIdentity,
   type ArtifactNamespace,
   type ArtifactTargetKind,
   type MetadataComponentArtifactIdentity,
   type SObjectArtifactIdentity
 } from './core/artifactIdentity';
+export {
+  ArtifactPresenceSchema,
+  ArtifactProjectionSchema,
+  ArtifactProjectionSchemas,
+  ArtifactProviderKindSchema,
+  CanonicalSemanticModelSchema,
+  CatalogEntryDescriptorSchema,
+  CatalogEntryProjectionSchema,
+  DocumentUriSchema,
+  ProjectionUnavailableReasonSchema,
+  ProjectionUnavailableSchema,
+  SObjectChildRelationshipSchema,
+  SObjectFieldRuntimeCapabilitiesSchema,
+  SObjectPicklistValueSchema,
+  SObjectSemanticFieldSchema,
+  SObjectSemanticModelSchema,
+  SObjectSemanticProjectionSchema,
+  SObjectSemanticValueSchema,
+  SourceDocumentProjectionSchema,
+  SourceDocumentSchema,
+  type ArtifactPresence,
+  type ArtifactProjection,
+  type ArtifactProviderKind,
+  type CanonicalSemanticModel,
+  type CatalogEntryDescriptor,
+  type CatalogEntryProjection,
+  type DocumentUri,
+  type ProjectionUnavailable,
+  type ProjectionUnavailableReason,
+  type SObjectChildRelationship,
+  type SObjectFieldRuntimeCapabilities,
+  type SObjectPicklistValue,
+  type SObjectSemanticField,
+  type SObjectSemanticModel,
+  type SObjectSemanticProjection,
+  type SObjectSemanticValue,
+  type SourceDocument,
+  type SourceDocumentProjection
+} from './core/artifactProjection';
 export {
   TemplateService,
   type ApexClassCreateOptions,
@@ -488,6 +527,7 @@ export const activate = async (context: vscode.ExtensionContext): Promise<Salesf
         prebuiltServicesDependencies: builtContext,
         ApexLogService,
         AliasService,
+        ArtifactProjectionSchemas,
         TemplateService,
         TemplateType,
         ChannelService,

--- a/packages/salesforcedx-vscode-services/test/jest/core/artifactIdentity.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/artifactIdentity.test.ts
@@ -7,8 +7,8 @@
 
 import * as Schema from 'effect/Schema';
 import {
-  ApexTypeArtifactIdentitySchema,
   ArtifactIdentitySchema,
+  SObjectArtifactIdentitySchema,
   artifactIdentitiesEqual,
   artifactIdentityKey,
   artifactNamespacesEqual,
@@ -17,10 +17,8 @@ import {
 
 describe('artifact identity', () => {
   it.each([
-    { kind: 'apex-type', namespace: null, name: 'GlobalType' },
-    { kind: 'apex-type', namespace: 'System', name: 'String' },
-    { kind: 'apex-type', namespace: 'MyPackage', name: 'Outer.Inner' },
     { kind: 'sobject', namespace: null, name: 'Widget__c' },
+    { kind: 'sobject', namespace: 'MyPackage', name: 'Widget__c' },
     { kind: 'metadata-component', metadataType: 'ApexClass', namespace: null, name: 'Example' }
   ] as const)('decodes a canonical $kind identity for $name', identity => {
     expect(Schema.decodeUnknownSync(ArtifactIdentitySchema)(identity)).toEqual(identity);
@@ -28,10 +26,10 @@ describe('artifact identity', () => {
 
   it('requires an explicit null namespace for a global identity', () => {
     expect(() =>
-      Schema.decodeUnknownSync(ApexTypeArtifactIdentitySchema)({ kind: 'apex-type', name: 'String' })
+      Schema.decodeUnknownSync(SObjectArtifactIdentitySchema)({ kind: 'sobject', name: 'Widget__c' })
     ).toThrow('namespace');
     expect(() =>
-      Schema.decodeUnknownSync(ApexTypeArtifactIdentitySchema)({ kind: 'apex-type', namespace: '', name: 'String' })
+      Schema.decodeUnknownSync(SObjectArtifactIdentitySchema)({ kind: 'sobject', namespace: '', name: 'Widget__c' })
     ).toThrow('namespace');
   });
 
@@ -60,25 +58,35 @@ describe('artifact identity', () => {
   it('matches namespace and name case-insensitively', () => {
     expect(
       artifactIdentitiesEqual(
-        { kind: 'apex-type', namespace: 'System', name: 'String' },
-        { kind: 'apex-type', namespace: 'SYSTEM', name: 'string' }
+        { kind: 'sobject', namespace: 'MyPackage', name: 'Widget__c' },
+        { kind: 'sobject', namespace: 'MYPACKAGE', name: 'widget__c' }
       )
     ).toBe(true);
     expect(artifactNamespacesEqual('MyPackage', 'mypackage')).toBe(true);
   });
 
-  it('does not conflate namespace with inner-type qualification', () => {
-    const namespacedInner = { kind: 'apex-type', namespace: 'MyPackage', name: 'Outer.Inner' } as const;
-    const dottedName = { kind: 'apex-type', namespace: null, name: 'MyPackage.Outer.Inner' } as const;
+  it('does not conflate namespace with dotted names', () => {
+    const namespaced = {
+      kind: 'metadata-component',
+      metadataType: 'ApexClass',
+      namespace: 'MyPackage',
+      name: 'Example'
+    } as const;
+    const dottedName = {
+      kind: 'metadata-component',
+      metadataType: 'ApexClass',
+      namespace: null,
+      name: 'MyPackage.Example'
+    } as const;
 
-    expect(artifactIdentitiesEqual(namespacedInner, dottedName)).toBe(false);
-    expect(artifactIdentityKey(namespacedInner)).not.toBe(artifactIdentityKey(dottedName));
+    expect(artifactIdentitiesEqual(namespaced, dottedName)).toBe(false);
+    expect(artifactIdentityKey(namespaced)).not.toBe(artifactIdentityKey(dottedName));
   });
 
   it('distinguishes target kind and metadata type', () => {
     expect(
       artifactIdentitiesEqual(
-        { kind: 'apex-type', namespace: null, name: 'Widget__c' },
+        { kind: 'metadata-component', metadataType: 'CustomObject', namespace: null, name: 'Widget__c' },
         { kind: 'sobject', namespace: null, name: 'Widget__c' }
       )
     ).toBe(false);

--- a/packages/salesforcedx-vscode-services/test/jest/core/artifactProjection.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/artifactProjection.test.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Schema from 'effect/Schema';
+import {
+  ArtifactProjectionSchema,
+  CatalogEntryDescriptorSchema,
+  ProjectionUnavailableSchema,
+  SObjectSemanticModelSchema,
+  SourceDocumentSchema,
+  type SObjectSemanticModel
+} from '../../../src/core/artifactProjection';
+
+describe('canonical artifact projections', () => {
+  it('decodes an actual source URI and encodes it back to a JSON-safe string', () => {
+    const input = {
+      kind: 'source-document',
+      identity: {
+        kind: 'metadata-component',
+        metadataType: 'ApexClass',
+        namespace: null,
+        name: 'WorkspaceClass'
+      },
+      fidelity: 'actual-source',
+      uri: 'file:///workspace/classes/WorkspaceClass.cls',
+      languageId: 'apex'
+    } as const;
+
+    const decoded = Schema.decodeUnknownSync(SourceDocumentSchema)(input);
+
+    expect(decoded.uri.toString()).toBe(input.uri);
+    expect(Schema.encodeSync(SourceDocumentSchema)(decoded)).toEqual(input);
+    expect(() => Schema.decodeUnknownSync(SourceDocumentSchema)({ ...input, fidelity: 'stub-source' })).toThrow(
+      'actual-source'
+    );
+  });
+
+  it('represents truthful partial workspace SObject semantics without fabricated REST capabilities', () => {
+    const decoded: SObjectSemanticModel = Schema.decodeUnknownSync(SObjectSemanticModelSchema)({
+      kind: 'sobject',
+      value: {
+        identity: { kind: 'sobject', namespace: null, name: 'Broker__c' },
+        label: 'Broker',
+        fields: [
+          {
+            name: 'Email__c',
+            type: 'Email',
+            definitionUri: 'file:///workspace/objects/Broker__c/fields/Email__c.field-meta.xml'
+          }
+        ],
+        definitionUri: 'file:///workspace/objects/Broker__c/Broker__c.object-meta.xml'
+      }
+    });
+
+    expect(decoded.value.queryable).toBeUndefined();
+    expect(decoded.value.fields[0].runtimeCapabilities).toBeUndefined();
+    expect(decoded.value.definitionUri?.scheme).toBe('file');
+    expect(decoded.value.fields[0].definitionUri?.path).toContain('Email__c.field-meta.xml');
+  });
+
+  it('accepts REST-known runtime SObject capabilities when they are available', () => {
+    const decoded = Schema.decodeUnknownSync(SObjectSemanticModelSchema)({
+      kind: 'sobject',
+      value: {
+        identity: { kind: 'sobject', namespace: null, name: 'Account' },
+        custom: false,
+        queryable: true,
+        fields: [
+          {
+            name: 'Name',
+            type: 'string',
+            runtimeCapabilities: {
+              aggregatable: true,
+              filterable: true,
+              groupable: true,
+              nillable: false,
+              sortable: true
+            }
+          }
+        ],
+        childRelationships: []
+      }
+    });
+
+    expect(decoded.value.queryable).toBe(true);
+    expect(decoded.value.fields[0].runtimeCapabilities?.nillable).toBe(false);
+  });
+
+  it('decodes catalog descriptors without conflating workspace and org locations', () => {
+    const decoded = Schema.decodeUnknownSync(CatalogEntryDescriptorSchema)({
+      kind: 'catalog-entry',
+      identity: { kind: 'metadata-component', metadataType: 'ApexClass', namespace: null, name: 'Example' },
+      presence: 'both',
+      providers: ['workspace', 'metadata-api'],
+      workspaceUri: 'file:///workspace/classes/Example.cls',
+      orgUri: 'sf-org-metadata:/orgs/00D/ApexClass/Example.cls'
+    });
+
+    expect(decoded.workspaceUri?.scheme).toBe('file');
+    expect(decoded.orgUri?.scheme).toBe('sf-org-metadata');
+  });
+
+  it.each([
+    { kind: 'catalog-entry' },
+    { kind: 'source-document' },
+    { kind: 'semantic-model', model: 'sobject' }
+  ] as const)('publishes the $kind projection descriptor', projection => {
+    expect(Schema.decodeUnknownSync(ArtifactProjectionSchema)(projection)).toEqual(projection);
+  });
+
+  it('reports projection unavailability separately from not-found', () => {
+    const unavailable = {
+      kind: 'projection-unavailable',
+      reason: 'protected-source',
+      availableProjections: [{ kind: 'catalog-entry' }]
+    } as const;
+
+    expect(Schema.decodeUnknownSync(ProjectionUnavailableSchema)(unavailable)).toEqual(unavailable);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Defines the provider-neutral projection contracts required by W-23973850:

- actual-source document handles with JSON-safe URI encoding
- truthful partial SObject semantic models with optional runtime-only facts
- catalog-entry descriptors, projection selectors, and unavailable reasons
- named Effect Schemas, inferred TypeScript types, and a runtime `ArtifactProjectionSchemas` API bundle

No finder behavior or provider acquisition is introduced. Apex source is represented by the actual-source projection and is acquired through the metadata source path.

### What issues does this PR fix or reference?

@W-23973850@

### Functionality Before

Services had identity primitives but no shared runtime/TypeScript contract for consumer-selected artifact projections.

### Functionality After

Consumers can select and validate catalog-entry, actual-source, and SObject semantic projections without inventing unavailable workspace runtime facts.

### Validation

- 16 focused schema encode/decode tests
- production and test TypeScript compilation
- generated declaration-package compilation
- repository pre-commit workflow

This is the first PR in the active W-23973850/W-23973887 stack.
