### PR TITLE
feat(services): add Apex Symbol Table response schemas - W-23973850

### DIFF
--- a/packages/salesforcedx-vscode-services/src/core/apexSymbolTableSchema.ts
+++ b/packages/salesforcedx-vscode-services/src/core/apexSymbolTableSchema.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Schema from 'effect/Schema';
+import { ApexTypeKindSchema, type ApexTypeKind } from './artifactProjection';
+
+type RawApexTypeReferenceValue = {
+  readonly namespacePrefix?: string | null;
+  readonly name: string;
+  readonly typeParameters?: readonly RawApexTypeReferenceValue[] | null;
+};
+
+/** Provider-native TypeReference. The service currently emits both omitted and explicit-null optional fields. */
+export const RawApexTypeReferenceSchema: Schema.Schema<RawApexTypeReferenceValue> = Schema.Struct({
+  namespacePrefix: Schema.String.pipe(Schema.NullOr, Schema.optional),
+  name: Schema.NonEmptyTrimmedString,
+  typeParameters: Schema.suspend(() => RawApexTypeReferenceSchema).pipe(Schema.Array, Schema.NullOr, Schema.optional)
+});
+export type RawApexTypeReference = typeof RawApexTypeReferenceSchema.Type;
+
+export const RawApexAnnotationParameterStubSchema = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  type: RawApexTypeReferenceSchema,
+  value: Schema.String
+});
+export type RawApexAnnotationParameterStub = typeof RawApexAnnotationParameterStubSchema.Type;
+
+export const RawApexAnnotationStubSchema = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  parameters: RawApexAnnotationParameterStubSchema.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  documentation: Schema.String.pipe(Schema.NullOr, Schema.optional)
+});
+export type RawApexAnnotationStub = typeof RawApexAnnotationStubSchema.Type;
+
+export const RawApexAccessorStubSchema = Schema.Struct({
+  modifiers: Schema.String.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  documentation: Schema.String.pipe(Schema.NullOr, Schema.optional)
+});
+export type RawApexAccessorStub = typeof RawApexAccessorStubSchema.Type;
+
+export const RawApexParameterStubSchema = Schema.Struct({
+  name: Schema.String.pipe(Schema.NullOr, Schema.optional),
+  type: RawApexTypeReferenceSchema.pipe(Schema.NullOr, Schema.optional),
+  annotations: RawApexAnnotationStubSchema.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  documentation: Schema.String.pipe(Schema.NullOr, Schema.optional)
+});
+export type RawApexParameterStub = typeof RawApexParameterStubSchema.Type;
+
+export const RawApexMethodStubSchema = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  isConstructor: Schema.Boolean.pipe(Schema.NullOr, Schema.optional),
+  returnType: RawApexTypeReferenceSchema.pipe(Schema.NullOr, Schema.optional),
+  modifiers: Schema.String.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  annotations: RawApexAnnotationStubSchema.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  parameters: RawApexParameterStubSchema.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  documentation: Schema.String.pipe(Schema.NullOr, Schema.optional),
+  definingType: RawApexTypeReferenceSchema.pipe(Schema.NullOr, Schema.optional)
+});
+export type RawApexMethodStub = typeof RawApexMethodStubSchema.Type;
+
+export const RawApexFieldStubSchema = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  type: RawApexTypeReferenceSchema.pipe(Schema.NullOr, Schema.optional),
+  modifiers: Schema.String.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  annotations: RawApexAnnotationStubSchema.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  documentation: Schema.String.pipe(Schema.NullOr, Schema.optional),
+  definingType: RawApexTypeReferenceSchema.pipe(Schema.NullOr, Schema.optional)
+});
+export type RawApexFieldStub = typeof RawApexFieldStubSchema.Type;
+
+export const RawApexPropertyStubSchema = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  type: RawApexTypeReferenceSchema.pipe(Schema.NullOr, Schema.optional),
+  modifiers: Schema.String.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  annotations: RawApexAnnotationStubSchema.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  getter: RawApexAccessorStubSchema.pipe(Schema.NullOr, Schema.optional),
+  setter: RawApexAccessorStubSchema.pipe(Schema.NullOr, Schema.optional),
+  documentation: Schema.String.pipe(Schema.NullOr, Schema.optional),
+  definingType: RawApexTypeReferenceSchema.pipe(Schema.NullOr, Schema.optional)
+});
+export type RawApexPropertyStub = typeof RawApexPropertyStubSchema.Type;
+
+type RawApexTypeStubValue = {
+  readonly name: string;
+  readonly namespacePrefix?: string | null;
+  readonly kind: ApexTypeKind;
+  readonly modifiers?: readonly string[] | null;
+  readonly annotations?: readonly RawApexAnnotationStub[] | null;
+  readonly superClass?: RawApexTypeReference | null;
+  readonly interfaces?: readonly RawApexTypeReference[] | null;
+  readonly fields?: readonly RawApexFieldStub[] | null;
+  readonly properties?: readonly RawApexPropertyStub[] | null;
+  readonly methods?: readonly RawApexMethodStub[] | null;
+  readonly innerTypes?: readonly RawApexTypeStubValue[] | null;
+  readonly triggerOperations?: readonly string[] | null;
+  readonly triggerObjectType?: RawApexTypeReference | null;
+  readonly documentation?: string | null;
+  readonly compileError?: string | null;
+};
+
+/** Raw TYPE_STUB payload. Canonical completeness and ordering are enforced by TransmogrifierService. */
+export const RawApexTypeStubSchema: Schema.Schema<RawApexTypeStubValue> = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  namespacePrefix: Schema.String.pipe(Schema.NullOr, Schema.optional),
+  kind: ApexTypeKindSchema,
+  modifiers: Schema.String.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  annotations: RawApexAnnotationStubSchema.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  superClass: RawApexTypeReferenceSchema.pipe(Schema.NullOr, Schema.optional),
+  interfaces: RawApexTypeReferenceSchema.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  fields: RawApexFieldStubSchema.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  properties: RawApexPropertyStubSchema.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  methods: RawApexMethodStubSchema.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  innerTypes: Schema.suspend(() => RawApexTypeStubSchema).pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  triggerOperations: Schema.String.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  triggerObjectType: RawApexTypeReferenceSchema.pipe(Schema.NullOr, Schema.optional),
+  documentation: Schema.String.pipe(Schema.NullOr, Schema.optional),
+  compileError: Schema.String.pipe(Schema.NullOr, Schema.optional)
+});
+export type RawApexTypeStub = typeof RawApexTypeStubSchema.Type;
+
+export const RawApexTypeStubResponseSchema = Schema.Struct({
+  typeStubs: Schema.Array(RawApexTypeStubSchema)
+});
+export type RawApexTypeStubResponse = typeof RawApexTypeStubResponseSchema.Type;
+
+export const ApexSymbolTableSchemas = {
+  TypeReference: RawApexTypeReferenceSchema,
+  AnnotationParameterStub: RawApexAnnotationParameterStubSchema,
+  AnnotationStub: RawApexAnnotationStubSchema,
+  AccessorStub: RawApexAccessorStubSchema,
+  ParameterStub: RawApexParameterStubSchema,
+  MethodStub: RawApexMethodStubSchema,
+  FieldStub: RawApexFieldStubSchema,
+  PropertyStub: RawApexPropertyStubSchema,
+  TypeStub: RawApexTypeStubSchema,
+  TypeStubResponse: RawApexTypeStubResponseSchema
+} as const;

--- a/packages/salesforcedx-vscode-services/src/core/artifactProjection.ts
+++ b/packages/salesforcedx-vscode-services/src/core/artifactProjection.ts
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Schema from 'effect/Schema';
+import { URI } from 'vscode-uri';
+import {
+  ApexTypeArtifactIdentitySchema,
+  ArtifactIdentitySchema,
+  ArtifactNamespaceSchema,
+  SObjectArtifactIdentitySchema,
+  type ArtifactNamespace
+} from './artifactIdentity';
+
+const UriTypeSchema = Schema.declare((value): value is URI => value instanceof URI, {
+  identifier: 'URI',
+  description: 'vscode-uri URI'
+});
+
+/** JSON-safe URI schema whose decoded TypeScript value is a vscode-uri URI. */
+export const DocumentUriSchema = Schema.transform(Schema.String, UriTypeSchema, {
+  strict: true,
+  decode: value => URI.parse(value),
+  encode: (_encoded, uri) => uri.toString()
+});
+export type DocumentUri = typeof DocumentUriSchema.Type;
+
+export const ArtifactPresenceSchema = Schema.Literal('workspace', 'org', 'both');
+export type ArtifactPresence = typeof ArtifactPresenceSchema.Type;
+
+export const ArtifactProviderKindSchema = Schema.Literal(
+  'workspace',
+  'metadata-api',
+  'rest-api',
+  'tooling-api',
+  'symbol-table'
+);
+export type ArtifactProviderKind = typeof ArtifactProviderKindSchema.Type;
+
+/** Provider-neutral catalog information returned alongside any materialized projection. */
+export const CatalogEntryDescriptorSchema = Schema.Struct({
+  kind: Schema.Literal('catalog-entry'),
+  identity: ArtifactIdentitySchema,
+  presence: ArtifactPresenceSchema,
+  providers: Schema.Array(ArtifactProviderKindSchema),
+  workspaceUri: Schema.optional(DocumentUriSchema),
+  orgUri: Schema.optional(DocumentUriSchema)
+});
+export type CatalogEntryDescriptor = typeof CatalogEntryDescriptorSchema.Type;
+
+/** A URI that resolves to actual source. Symbol stubs cannot satisfy this contract. */
+export const SourceDocumentSchema = Schema.Struct({
+  kind: Schema.Literal('source-document'),
+  identity: ArtifactIdentitySchema,
+  fidelity: Schema.Literal('actual-source'),
+  uri: DocumentUriSchema,
+  languageId: Schema.optional(Schema.NonEmptyTrimmedString)
+});
+export type SourceDocument = typeof SourceDocumentSchema.Type;
+
+export const SObjectPicklistValueSchema = Schema.Struct({
+  value: Schema.String,
+  label: Schema.optional(Schema.String),
+  active: Schema.optional(Schema.Boolean)
+});
+export type SObjectPicklistValue = typeof SObjectPicklistValueSchema.Type;
+
+/** Runtime capabilities are absent when a provider cannot know them, rather than being invented as false. */
+export const SObjectFieldRuntimeCapabilitiesSchema = Schema.Struct({
+  aggregatable: Schema.Boolean,
+  filterable: Schema.Boolean,
+  groupable: Schema.Boolean,
+  nillable: Schema.Boolean,
+  sortable: Schema.Boolean
+});
+export type SObjectFieldRuntimeCapabilities = typeof SObjectFieldRuntimeCapabilitiesSchema.Type;
+
+export const SObjectSemanticFieldSchema = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  label: Schema.optional(Schema.String),
+  type: Schema.optional(Schema.NonEmptyTrimmedString),
+  custom: Schema.optional(Schema.Boolean),
+  defaultValue: Schema.optional(Schema.Unknown),
+  inlineHelpText: Schema.optional(Schema.String),
+  length: Schema.optional(Schema.Number),
+  precision: Schema.optional(Schema.Number),
+  scale: Schema.optional(Schema.Number),
+  referenceTo: Schema.NonEmptyTrimmedString.pipe(Schema.Array, Schema.optional),
+  relationshipName: Schema.optional(Schema.String),
+  picklistValues: SObjectPicklistValueSchema.pipe(Schema.Array, Schema.optional),
+  runtimeCapabilities: Schema.optional(SObjectFieldRuntimeCapabilitiesSchema),
+  definitionUri: Schema.optional(DocumentUriSchema)
+});
+export type SObjectSemanticField = typeof SObjectSemanticFieldSchema.Type;
+
+export const SObjectChildRelationshipSchema = Schema.Struct({
+  childSObject: Schema.NonEmptyTrimmedString,
+  field: Schema.NonEmptyTrimmedString,
+  relationshipName: Schema.optional(Schema.String)
+});
+export type SObjectChildRelationship = typeof SObjectChildRelationshipSchema.Type;
+
+/**
+ * Canonical SObject facts shared by workspace metadata and org providers. Provider-specific facts are optional so
+ * an incomplete workspace declaration remains truthful and can later be enriched by REST or Symbol Table data.
+ */
+export const SObjectSemanticValueSchema = Schema.Struct({
+  identity: SObjectArtifactIdentitySchema,
+  label: Schema.optional(Schema.String),
+  pluralLabel: Schema.optional(Schema.String),
+  custom: Schema.optional(Schema.Boolean),
+  queryable: Schema.optional(Schema.Boolean),
+  fields: Schema.Array(SObjectSemanticFieldSchema),
+  childRelationships: SObjectChildRelationshipSchema.pipe(Schema.Array, Schema.optional),
+  definitionUri: Schema.optional(DocumentUriSchema)
+});
+export type SObjectSemanticValue = typeof SObjectSemanticValueSchema.Type;
+
+export const SObjectSemanticModelSchema = Schema.Struct({
+  kind: Schema.Literal('sobject'),
+  value: SObjectSemanticValueSchema
+});
+export type SObjectSemanticModel = typeof SObjectSemanticModelSchema.Type;
+
+type ApexTypeReferenceValue = {
+  readonly namespacePrefix: ArtifactNamespace;
+  readonly name: string;
+  readonly typeParameters: readonly ApexTypeReferenceValue[] | null;
+};
+
+/** Canonical recursive Apex type reference: nullable provider fields are explicit rather than omitted. */
+export const ApexTypeReferenceSchema: Schema.Schema<ApexTypeReferenceValue> = Schema.Struct({
+  namespacePrefix: ArtifactNamespaceSchema,
+  name: Schema.NonEmptyTrimmedString,
+  typeParameters: Schema.suspend(() => ApexTypeReferenceSchema).pipe(Schema.Array, Schema.NullOr)
+});
+export type ApexTypeReference = typeof ApexTypeReferenceSchema.Type;
+
+const NullableDocumentationSchema = Schema.NullOr(Schema.String);
+
+export const ApexAnnotationParameterStubSchema = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  type: ApexTypeReferenceSchema,
+  value: Schema.String
+});
+export type ApexAnnotationParameterStub = typeof ApexAnnotationParameterStubSchema.Type;
+
+export const ApexAnnotationStubSchema = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  parameters: Schema.Array(ApexAnnotationParameterStubSchema),
+  documentation: NullableDocumentationSchema
+});
+export type ApexAnnotationStub = typeof ApexAnnotationStubSchema.Type;
+
+export const ApexAccessorStubSchema = Schema.Struct({
+  modifiers: Schema.Array(Schema.String),
+  documentation: NullableDocumentationSchema
+});
+export type ApexAccessorStub = typeof ApexAccessorStubSchema.Type;
+
+export const ApexParameterStubSchema = Schema.Struct({
+  name: Schema.NullOr(Schema.String),
+  type: Schema.NullOr(ApexTypeReferenceSchema),
+  annotations: Schema.Array(ApexAnnotationStubSchema),
+  documentation: NullableDocumentationSchema
+});
+export type ApexParameterStub = typeof ApexParameterStubSchema.Type;
+
+export const ApexMethodStubSchema = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  isConstructor: Schema.NullOr(Schema.Boolean),
+  returnType: Schema.NullOr(ApexTypeReferenceSchema),
+  modifiers: Schema.Array(Schema.String),
+  annotations: Schema.Array(ApexAnnotationStubSchema),
+  parameters: Schema.Array(ApexParameterStubSchema),
+  documentation: NullableDocumentationSchema,
+  definingType: Schema.NullOr(ApexTypeReferenceSchema)
+});
+export type ApexMethodStub = typeof ApexMethodStubSchema.Type;
+
+export const ApexFieldStubSchema = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  type: Schema.NullOr(ApexTypeReferenceSchema),
+  modifiers: Schema.Array(Schema.String),
+  annotations: Schema.Array(ApexAnnotationStubSchema),
+  documentation: NullableDocumentationSchema,
+  definingType: Schema.NullOr(ApexTypeReferenceSchema)
+});
+export type ApexFieldStub = typeof ApexFieldStubSchema.Type;
+
+export const ApexPropertyStubSchema = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  type: Schema.NullOr(ApexTypeReferenceSchema),
+  modifiers: Schema.Array(Schema.String),
+  annotations: Schema.Array(ApexAnnotationStubSchema),
+  getter: Schema.NullOr(ApexAccessorStubSchema),
+  setter: Schema.NullOr(ApexAccessorStubSchema),
+  documentation: NullableDocumentationSchema,
+  definingType: Schema.NullOr(ApexTypeReferenceSchema)
+});
+export type ApexPropertyStub = typeof ApexPropertyStubSchema.Type;
+
+export const ApexTypeKindSchema = Schema.Literal('CLASS', 'INTERFACE', 'ENUM', 'TRIGGER');
+export type ApexTypeKind = typeof ApexTypeKindSchema.Type;
+
+type ApexTypeStubValue = {
+  readonly name: string;
+  readonly namespacePrefix: ArtifactNamespace;
+  readonly kind: ApexTypeKind;
+  readonly modifiers: readonly string[];
+  readonly annotations: readonly ApexAnnotationStub[];
+  readonly superClass: ApexTypeReference | null;
+  readonly interfaces: readonly ApexTypeReference[];
+  readonly fields: readonly ApexFieldStub[];
+  readonly properties: readonly ApexPropertyStub[];
+  readonly methods: readonly ApexMethodStub[];
+  readonly innerTypes: readonly ApexTypeStubValue[];
+  readonly triggerOperations: readonly string[] | null;
+  readonly triggerObjectType: ApexTypeReference | null;
+  readonly documentation: string | null;
+  readonly compileError: string | null;
+};
+
+export const ApexTypeStubSchema: Schema.Schema<ApexTypeStubValue> = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  namespacePrefix: ArtifactNamespaceSchema,
+  kind: ApexTypeKindSchema,
+  modifiers: Schema.Array(Schema.String),
+  annotations: Schema.Array(ApexAnnotationStubSchema),
+  superClass: Schema.NullOr(ApexTypeReferenceSchema),
+  interfaces: Schema.Array(ApexTypeReferenceSchema),
+  fields: Schema.Array(ApexFieldStubSchema),
+  properties: Schema.Array(ApexPropertyStubSchema),
+  methods: Schema.Array(ApexMethodStubSchema),
+  innerTypes: Schema.Array(Schema.suspend(() => ApexTypeStubSchema)),
+  triggerOperations: Schema.String.pipe(Schema.Array, Schema.NullOr),
+  triggerObjectType: Schema.NullOr(ApexTypeReferenceSchema),
+  documentation: NullableDocumentationSchema,
+  compileError: Schema.NullOr(Schema.String)
+});
+export type ApexTypeStub = typeof ApexTypeStubSchema.Type;
+
+export const ApexTypeStubSemanticModelSchema = Schema.Struct({
+  kind: Schema.Literal('apex-type-stub'),
+  identity: ApexTypeArtifactIdentitySchema,
+  value: ApexTypeStubSchema
+});
+export type ApexTypeStubSemanticModel = typeof ApexTypeStubSemanticModelSchema.Type;
+
+export const CanonicalSemanticModelSchema = Schema.Union(SObjectSemanticModelSchema, ApexTypeStubSemanticModelSchema);
+export type CanonicalSemanticModel = typeof CanonicalSemanticModelSchema.Type;
+
+export const CatalogEntryProjectionSchema = Schema.Struct({ kind: Schema.Literal('catalog-entry') });
+export type CatalogEntryProjection = typeof CatalogEntryProjectionSchema.Type;
+
+export const SourceDocumentProjectionSchema = Schema.Struct({ kind: Schema.Literal('source-document') });
+export type SourceDocumentProjection = typeof SourceDocumentProjectionSchema.Type;
+
+export const SObjectSemanticProjectionSchema = Schema.Struct({
+  kind: Schema.Literal('semantic-model'),
+  model: Schema.Literal('sobject')
+});
+export type SObjectSemanticProjection = typeof SObjectSemanticProjectionSchema.Type;
+
+export const ApexTypeStubSemanticProjectionSchema = Schema.Struct({
+  kind: Schema.Literal('semantic-model'),
+  model: Schema.Literal('apex-type-stub')
+});
+export type ApexTypeStubSemanticProjection = typeof ApexTypeStubSemanticProjectionSchema.Type;
+
+export const ArtifactProjectionSchema = Schema.Union(
+  CatalogEntryProjectionSchema,
+  SourceDocumentProjectionSchema,
+  SObjectSemanticProjectionSchema,
+  ApexTypeStubSemanticProjectionSchema
+);
+export type ArtifactProjection = typeof ArtifactProjectionSchema.Type;
+
+export const ProjectionUnavailableReasonSchema = Schema.Literal(
+  'projection-unavailable',
+  'protected-source',
+  'compile-error',
+  'unsupported-org-capability'
+);
+export type ProjectionUnavailableReason = typeof ProjectionUnavailableReasonSchema.Type;
+
+export const ProjectionUnavailableSchema = Schema.Struct({
+  kind: Schema.Literal('projection-unavailable'),
+  reason: ProjectionUnavailableReasonSchema,
+  availableProjections: Schema.Array(ArtifactProjectionSchema)
+});
+export type ProjectionUnavailable = typeof ProjectionUnavailableSchema.Type;
+
+/** Runtime schemas exposed through the VS Code Services extension API. */
+export const ArtifactProjectionSchemas = {
+  DocumentUri: DocumentUriSchema,
+  CatalogEntryDescriptor: CatalogEntryDescriptorSchema,
+  SourceDocument: SourceDocumentSchema,
+  SObjectSemanticModel: SObjectSemanticModelSchema,
+  ApexTypeReference: ApexTypeReferenceSchema,
+  ApexTypeStub: ApexTypeStubSchema,
+  ApexTypeStubSemanticModel: ApexTypeStubSemanticModelSchema,
+  CanonicalSemanticModel: CanonicalSemanticModelSchema,
+  ArtifactProjection: ArtifactProjectionSchema,
+  ProjectionUnavailable: ProjectionUnavailableSchema
+} as const;

--- a/packages/salesforcedx-vscode-services/src/index.ts
+++ b/packages/salesforcedx-vscode-services/src/index.ts
@@ -19,6 +19,7 @@ import { getActiveMetadataOperationRef } from './core/activeMetadataOperationRef
 import { AliasService } from './core/alias';
 import { watchAliasFile } from './core/aliasFileWatcher';
 import { ApexLogService } from './core/apexLogService';
+import { ArtifactProjectionSchemas } from './core/artifactProjection';
 import { ComponentSetService } from './core/componentSetService';
 import { watchConfigFiles } from './core/configFileWatcher';
 import { ConfigService } from './core/configService';
@@ -120,6 +121,7 @@ export type SalesforceVSCodeServicesApi = {
     >;
     ApexLogService: typeof ApexLogService;
     AliasService: typeof AliasService;
+    ArtifactProjectionSchemas: typeof ArtifactProjectionSchemas;
     TemplateService: typeof TemplateService;
     TemplateType: typeof TemplateType;
     ChannelService: typeof ChannelService;
@@ -195,6 +197,69 @@ export {
   type MetadataComponentArtifactIdentity,
   type SObjectArtifactIdentity
 } from './core/artifactIdentity';
+export {
+  ApexAccessorStubSchema,
+  ApexAnnotationParameterStubSchema,
+  ApexAnnotationStubSchema,
+  ApexFieldStubSchema,
+  ApexMethodStubSchema,
+  ApexParameterStubSchema,
+  ApexPropertyStubSchema,
+  ApexTypeKindSchema,
+  ApexTypeReferenceSchema,
+  ApexTypeStubSchema,
+  ApexTypeStubSemanticModelSchema,
+  ApexTypeStubSemanticProjectionSchema,
+  ArtifactPresenceSchema,
+  ArtifactProjectionSchema,
+  ArtifactProjectionSchemas,
+  ArtifactProviderKindSchema,
+  CanonicalSemanticModelSchema,
+  CatalogEntryDescriptorSchema,
+  CatalogEntryProjectionSchema,
+  DocumentUriSchema,
+  ProjectionUnavailableReasonSchema,
+  ProjectionUnavailableSchema,
+  SObjectChildRelationshipSchema,
+  SObjectFieldRuntimeCapabilitiesSchema,
+  SObjectPicklistValueSchema,
+  SObjectSemanticFieldSchema,
+  SObjectSemanticModelSchema,
+  SObjectSemanticProjectionSchema,
+  SObjectSemanticValueSchema,
+  SourceDocumentProjectionSchema,
+  SourceDocumentSchema,
+  type ApexAccessorStub,
+  type ApexAnnotationParameterStub,
+  type ApexAnnotationStub,
+  type ApexFieldStub,
+  type ApexMethodStub,
+  type ApexParameterStub,
+  type ApexPropertyStub,
+  type ApexTypeKind,
+  type ApexTypeReference,
+  type ApexTypeStub,
+  type ApexTypeStubSemanticModel,
+  type ApexTypeStubSemanticProjection,
+  type ArtifactPresence,
+  type ArtifactProjection,
+  type ArtifactProviderKind,
+  type CanonicalSemanticModel,
+  type CatalogEntryDescriptor,
+  type CatalogEntryProjection,
+  type DocumentUri,
+  type ProjectionUnavailable,
+  type ProjectionUnavailableReason,
+  type SObjectChildRelationship,
+  type SObjectFieldRuntimeCapabilities,
+  type SObjectPicklistValue,
+  type SObjectSemanticField,
+  type SObjectSemanticModel,
+  type SObjectSemanticProjection,
+  type SObjectSemanticValue,
+  type SourceDocument,
+  type SourceDocumentProjection
+} from './core/artifactProjection';
 export {
   TemplateService,
   type ApexClassCreateOptions,
@@ -488,6 +553,7 @@ export const activate = async (context: vscode.ExtensionContext): Promise<Salesf
         prebuiltServicesDependencies: builtContext,
         ApexLogService,
         AliasService,
+        ArtifactProjectionSchemas,
         TemplateService,
         TemplateType,
         ChannelService,

--- a/packages/salesforcedx-vscode-services/src/index.ts
+++ b/packages/salesforcedx-vscode-services/src/index.ts
@@ -19,6 +19,7 @@ import { getActiveMetadataOperationRef } from './core/activeMetadataOperationRef
 import { AliasService } from './core/alias';
 import { watchAliasFile } from './core/aliasFileWatcher';
 import { ApexLogService } from './core/apexLogService';
+import { ApexSymbolTableSchemas } from './core/apexSymbolTableSchema';
 import { ArtifactProjectionSchemas } from './core/artifactProjection';
 import { ComponentSetService } from './core/componentSetService';
 import { watchConfigFiles } from './core/configFileWatcher';
@@ -120,6 +121,7 @@ export type SalesforceVSCodeServicesApi = {
       | WorkspaceService
     >;
     ApexLogService: typeof ApexLogService;
+    ApexSymbolTableSchemas: typeof ApexSymbolTableSchemas;
     AliasService: typeof AliasService;
     ArtifactProjectionSchemas: typeof ArtifactProjectionSchemas;
     TemplateService: typeof TemplateService;
@@ -176,6 +178,29 @@ type PublicSdkLayerFor = (
   Layer.Layer.Error<ReturnType<typeof SdkLayerFor>>
 >;
 export type { AliasService } from './core/alias';
+export {
+  ApexSymbolTableSchemas,
+  RawApexAccessorStubSchema,
+  RawApexAnnotationParameterStubSchema,
+  RawApexAnnotationStubSchema,
+  RawApexFieldStubSchema,
+  RawApexMethodStubSchema,
+  RawApexParameterStubSchema,
+  RawApexPropertyStubSchema,
+  RawApexTypeReferenceSchema,
+  RawApexTypeStubResponseSchema,
+  RawApexTypeStubSchema,
+  type RawApexAccessorStub,
+  type RawApexAnnotationParameterStub,
+  type RawApexAnnotationStub,
+  type RawApexFieldStub,
+  type RawApexMethodStub,
+  type RawApexParameterStub,
+  type RawApexPropertyStub,
+  type RawApexTypeReference,
+  type RawApexTypeStub,
+  type RawApexTypeStubResponse
+} from './core/apexSymbolTableSchema';
 export type { TelemetryIdentitySnapshot } from './core/defaultOrgRef';
 export {
   ApexTypeArtifactIdentitySchema,
@@ -552,6 +577,7 @@ export const activate = async (context: vscode.ExtensionContext): Promise<Salesf
       services: {
         prebuiltServicesDependencies: builtContext,
         ApexLogService,
+        ApexSymbolTableSchemas,
         AliasService,
         ArtifactProjectionSchemas,
         TemplateService,

--- a/packages/salesforcedx-vscode-services/test/jest/core/apexSymbolTableSchema.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/apexSymbolTableSchema.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Schema from 'effect/Schema';
+import {
+  ApexSymbolTableSchemas,
+  RawApexTypeReferenceSchema,
+  RawApexTypeStubResponseSchema
+} from '../../../src/core/apexSymbolTableSchema';
+import * as responseFixture from './fixtures/apexSymbolTableResponse.json';
+
+describe('Apex Symbol Table raw response schemas', () => {
+  it('decodes representative class, interface, enum, trigger, managed-package, and compile-error stubs', () => {
+    const response = Schema.decodeUnknownSync(RawApexTypeStubResponseSchema)(responseFixture);
+
+    expect(response.typeStubs.map(stub => stub.kind)).toEqual(['CLASS', 'INTERFACE', 'ENUM', 'TRIGGER', 'CLASS']);
+    expect(response.typeStubs[0]).toMatchObject({
+      name: 'ManagedOuter',
+      namespacePrefix: 'ExamplePkg',
+      documentation: 'Managed class documentation.'
+    });
+    expect(response.typeStubs[0].innerTypes?.[0].name).toBe('ManagedOuter.Inner');
+    expect(response.typeStubs[3]).toMatchObject({
+      triggerOperations: ['AFTER INSERT', 'BEFORE UPDATE'],
+      triggerObjectType: { namespacePrefix: 'Schema', name: 'Account' }
+    });
+    expect(response.typeStubs[4]).toMatchObject({
+      compileError: 'Unexpected token near line 4',
+      fields: null,
+      methods: null
+    });
+  });
+
+  it('preserves recursive nested generic arguments', () => {
+    const reference = Schema.decodeUnknownSync(RawApexTypeReferenceSchema)({
+      namespacePrefix: 'System',
+      name: 'List',
+      typeParameters: [
+        {
+          name: 'Set',
+          typeParameters: [
+            {
+              name: 'Map',
+              typeParameters: [{ name: 'String' }, { name: 'Object', typeParameters: null }]
+            }
+          ]
+        }
+      ]
+    });
+
+    expect(reference.typeParameters?.[0].typeParameters?.[0].typeParameters?.map(type => type.name)).toEqual([
+      'String',
+      'Object'
+    ]);
+  });
+
+  it('accepts omitted and explicit-null optional provider fields without normalizing them yet', () => {
+    expect(
+      Schema.decodeUnknownSync(ApexSymbolTableSchemas.TypeStub)({
+        name: 'Minimal',
+        kind: 'CLASS'
+      })
+    ).toEqual({ name: 'Minimal', kind: 'CLASS' });
+    expect(
+      Schema.decodeUnknownSync(ApexSymbolTableSchemas.TypeStub)({
+        name: 'NullHeavy',
+        namespacePrefix: null,
+        kind: 'CLASS',
+        modifiers: null,
+        annotations: null,
+        compileError: null
+      })
+    ).toEqual({
+      name: 'NullHeavy',
+      namespacePrefix: null,
+      kind: 'CLASS',
+      modifiers: null,
+      annotations: null,
+      compileError: null
+    });
+  });
+
+  it('rejects malformed type kinds and type references', () => {
+    expect(() =>
+      Schema.decodeUnknownSync(RawApexTypeStubResponseSchema)({
+        typeStubs: [{ name: 'BadKind', kind: 'STRUCT' }]
+      })
+    ).toThrow('CLASS');
+    expect(() => Schema.decodeUnknownSync(RawApexTypeReferenceSchema)({ namespacePrefix: 'System' })).toThrow('name');
+  });
+});

--- a/packages/salesforcedx-vscode-services/test/jest/core/artifactProjection.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/artifactProjection.test.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Schema from 'effect/Schema';
+import {
+  ApexTypeStubSchema,
+  ArtifactProjectionSchema,
+  CatalogEntryDescriptorSchema,
+  ProjectionUnavailableSchema,
+  SObjectSemanticModelSchema,
+  SourceDocumentSchema,
+  type SObjectSemanticModel
+} from '../../../src/core/artifactProjection';
+
+const emptyApexStub = (overrides: Record<string, unknown> = {}) => ({
+  name: 'Example',
+  namespacePrefix: null,
+  kind: 'CLASS',
+  modifiers: ['public'],
+  annotations: [],
+  superClass: null,
+  interfaces: [],
+  fields: [],
+  properties: [],
+  methods: [],
+  innerTypes: [],
+  triggerOperations: null,
+  triggerObjectType: null,
+  documentation: null,
+  compileError: null,
+  ...overrides
+});
+
+describe('canonical artifact projections', () => {
+  it('decodes an actual source URI and encodes it back to a JSON-safe string', () => {
+    const input = {
+      kind: 'source-document',
+      identity: { kind: 'apex-type', namespace: null, name: 'WorkspaceClass' },
+      fidelity: 'actual-source',
+      uri: 'file:///workspace/classes/WorkspaceClass.cls',
+      languageId: 'apex'
+    } as const;
+
+    const decoded = Schema.decodeUnknownSync(SourceDocumentSchema)(input);
+
+    expect(decoded.uri.toString()).toBe(input.uri);
+    expect(Schema.encodeSync(SourceDocumentSchema)(decoded)).toEqual(input);
+    expect(() => Schema.decodeUnknownSync(SourceDocumentSchema)({ ...input, fidelity: 'stub-source' })).toThrow(
+      'actual-source'
+    );
+  });
+
+  it('represents truthful partial workspace SObject semantics without fabricated REST capabilities', () => {
+    const decoded: SObjectSemanticModel = Schema.decodeUnknownSync(SObjectSemanticModelSchema)({
+      kind: 'sobject',
+      value: {
+        identity: { kind: 'sobject', namespace: null, name: 'Broker__c' },
+        label: 'Broker',
+        fields: [
+          {
+            name: 'Email__c',
+            type: 'Email',
+            definitionUri: 'file:///workspace/objects/Broker__c/fields/Email__c.field-meta.xml'
+          }
+        ],
+        definitionUri: 'file:///workspace/objects/Broker__c/Broker__c.object-meta.xml'
+      }
+    });
+
+    expect(decoded.value.queryable).toBeUndefined();
+    expect(decoded.value.fields[0].runtimeCapabilities).toBeUndefined();
+    expect(decoded.value.definitionUri?.scheme).toBe('file');
+    expect(decoded.value.fields[0].definitionUri?.path).toContain('Email__c.field-meta.xml');
+  });
+
+  it('accepts REST-known runtime SObject capabilities when they are available', () => {
+    const decoded = Schema.decodeUnknownSync(SObjectSemanticModelSchema)({
+      kind: 'sobject',
+      value: {
+        identity: { kind: 'sobject', namespace: null, name: 'Account' },
+        custom: false,
+        queryable: true,
+        fields: [
+          {
+            name: 'Name',
+            type: 'string',
+            runtimeCapabilities: {
+              aggregatable: true,
+              filterable: true,
+              groupable: true,
+              nillable: false,
+              sortable: true
+            }
+          }
+        ],
+        childRelationships: []
+      }
+    });
+
+    expect(decoded.value.queryable).toBe(true);
+    expect(decoded.value.fields[0].runtimeCapabilities?.nillable).toBe(false);
+  });
+
+  it('decodes recursive Apex inner types and nested generic references', () => {
+    const decoded = Schema.decodeUnknownSync(ApexTypeStubSchema)(
+      emptyApexStub({
+        namespacePrefix: 'MyPackage',
+        name: 'Outer',
+        interfaces: [
+          {
+            namespacePrefix: 'System',
+            name: 'Iterator',
+            typeParameters: [
+              {
+                namespacePrefix: null,
+                name: 'List',
+                typeParameters: [{ namespacePrefix: null, name: 'String', typeParameters: null }]
+              }
+            ]
+          }
+        ],
+        innerTypes: [emptyApexStub({ name: 'Outer.Inner', namespacePrefix: 'MyPackage' })]
+      })
+    );
+
+    expect(decoded.interfaces[0].typeParameters?.[0].typeParameters?.[0].name).toBe('String');
+    expect(decoded.innerTypes[0]).toMatchObject({ name: 'Outer.Inner', namespacePrefix: 'MyPackage' });
+  });
+
+  it('requires explicit canonical nulls that the raw endpoint adapter will normalize', () => {
+    const incomplete: Record<string, unknown> = emptyApexStub();
+    delete incomplete.documentation;
+
+    expect(() => Schema.decodeUnknownSync(ApexTypeStubSchema)(incomplete)).toThrow('documentation');
+  });
+
+  it('decodes catalog descriptors without conflating workspace and org locations', () => {
+    const decoded = Schema.decodeUnknownSync(CatalogEntryDescriptorSchema)({
+      kind: 'catalog-entry',
+      identity: { kind: 'metadata-component', metadataType: 'ApexClass', namespace: null, name: 'Example' },
+      presence: 'both',
+      providers: ['workspace', 'metadata-api'],
+      workspaceUri: 'file:///workspace/classes/Example.cls',
+      orgUri: 'sf-org-metadata:/orgs/00D/ApexClass/Example.cls'
+    });
+
+    expect(decoded.workspaceUri?.scheme).toBe('file');
+    expect(decoded.orgUri?.scheme).toBe('sf-org-metadata');
+  });
+
+  it.each([
+    { kind: 'catalog-entry' },
+    { kind: 'source-document' },
+    { kind: 'semantic-model', model: 'sobject' },
+    { kind: 'semantic-model', model: 'apex-type-stub' }
+  ] as const)('publishes the $kind projection descriptor', projection => {
+    expect(Schema.decodeUnknownSync(ArtifactProjectionSchema)(projection)).toEqual(projection);
+  });
+
+  it('reports projection unavailability separately from not-found', () => {
+    const unavailable = {
+      kind: 'projection-unavailable',
+      reason: 'protected-source',
+      availableProjections: [{ kind: 'catalog-entry' }, { kind: 'semantic-model', model: 'apex-type-stub' }]
+    } as const;
+
+    expect(Schema.decodeUnknownSync(ProjectionUnavailableSchema)(unavailable)).toEqual(unavailable);
+  });
+});

--- a/packages/salesforcedx-vscode-services/test/jest/core/fixtures/apexSymbolTableResponse.json
+++ b/packages/salesforcedx-vscode-services/test/jest/core/fixtures/apexSymbolTableResponse.json
@@ -1,0 +1,115 @@
+{
+  "typeStubs": [
+    {
+      "name": "ManagedOuter",
+      "namespacePrefix": "ExamplePkg",
+      "kind": "CLASS",
+      "modifiers": ["global"],
+      "annotations": [{ "name": "AuraEnabled", "parameters": [], "documentation": null }],
+      "interfaces": [
+        {
+          "namespacePrefix": "System",
+          "name": "Iterator",
+          "typeParameters": [
+            {
+              "name": "List",
+              "typeParameters": [{ "name": "String" }]
+            }
+          ]
+        }
+      ],
+      "fields": [
+        {
+          "name": "items",
+          "type": { "name": "List", "typeParameters": [{ "name": "String" }] },
+          "modifiers": ["global"],
+          "annotations": [],
+          "definingType": { "namespacePrefix": "ExamplePkg", "name": "ManagedBase" }
+        }
+      ],
+      "properties": [
+        {
+          "name": "value",
+          "type": { "name": "String" },
+          "modifiers": ["global"],
+          "annotations": [],
+          "getter": { "modifiers": ["global"], "documentation": "Reads the value." },
+          "setter": null
+        }
+      ],
+      "methods": [
+        {
+          "name": "convert",
+          "returnType": { "name": "String" },
+          "modifiers": ["global"],
+          "annotations": [],
+          "parameters": [
+            {
+              "name": "input",
+              "type": { "name": "Object" },
+              "annotations": [],
+              "documentation": null
+            }
+          ],
+          "documentation": "Converts an input value."
+        }
+      ],
+      "innerTypes": [
+        {
+          "name": "ManagedOuter.Inner",
+          "namespacePrefix": "ExamplePkg",
+          "kind": "CLASS",
+          "modifiers": ["global"],
+          "annotations": [],
+          "interfaces": [],
+          "fields": [],
+          "properties": [],
+          "methods": [],
+          "innerTypes": []
+        }
+      ],
+      "documentation": "Managed class documentation.",
+      "compileError": null
+    },
+    {
+      "name": "RunnableContract",
+      "kind": "INTERFACE",
+      "modifiers": ["public"],
+      "annotations": [],
+      "interfaces": [],
+      "fields": [],
+      "properties": [],
+      "methods": [],
+      "innerTypes": []
+    },
+    {
+      "name": "State",
+      "namespacePrefix": null,
+      "kind": "ENUM",
+      "modifiers": ["public"],
+      "fields": [
+        {
+          "name": "OPEN",
+          "type": { "name": "State" },
+          "modifiers": ["final", "public", "static"],
+          "annotations": []
+        }
+      ]
+    },
+    {
+      "name": "AccountTrigger",
+      "kind": "TRIGGER",
+      "modifiers": ["public"],
+      "triggerOperations": ["AFTER INSERT", "BEFORE UPDATE"],
+      "triggerObjectType": { "namespacePrefix": "Schema", "name": "Account" }
+    },
+    {
+      "name": "BrokenType",
+      "kind": "CLASS",
+      "compileError": "Unexpected token near line 4",
+      "fields": null,
+      "methods": null,
+      "innerTypes": null
+    }
+  ]
+}


### PR DESCRIPTION
### What does this PR do?

Adds provider-native Effect Schemas for the planned Apex Symbol Table `TYPE_STUB` response:

- recursive type references and inner types
- fields, properties, accessors, methods, parameters, and annotations
- generic arguments, documentation, defining types, trigger data, namespaces, and compile errors
- tolerant omitted/null handling matching the supplied endpoint contract and examples
- named exports and a runtime `ApexSymbolTableSchemas` API bundle

This slice performs no Connection or network operation.

### What issues does this PR fix or reference?

@W-23973850@

### Functionality Before

Services had no runtime boundary for validating Symbol Table Apex payloads.

### Functionality After

Provider responses can be decoded without prematurely normalizing their wire representation; canonical normalization remains the Transmogrifier's responsibility.

### Validation

- representative class, interface, enum, trigger, managed-package, inner-type, generic, inherited-member, documentation, and compile-error fixture coverage
- production/test TypeScript and generated declaration compilation
- repository pre-commit and pre-push workflows

This is PR 5 in [stack #8036](https://github.com/forcedotcom/salesforcedx-vscode/stacks/8036).
