### PR TITLE
refactor(services): add canonical Transmogrifier boundary - W-23973850

### DIFF
--- a/packages/salesforcedx-vscode-services/src/core/transmogrifierService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/transmogrifierService.ts
@@ -5,16 +5,32 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import type { SObjectArtifactIdentity } from './artifactIdentity';
 import type { Connection } from '@salesforce/core';
 import * as Effect from 'effect/Effect';
 import * as S from 'effect/Schema';
-import { SObjectSchema, type SObject } from './schemas/sObject';
+import { SObjectSemanticModelSchema, type SObjectSemanticField, type SObjectSemanticModel } from './artifactProjection';
+import { SObjectSchema, type SObject, type SObjectField } from './schemas/sObject';
 
 type RawDescribeSObjectResult = Awaited<ReturnType<Connection['describe']>>;
 
 /** Re-exported raw jsforce describe result for consumer type safety */
 export type DescribeSObjectResult = RawDescribeSObjectResult;
 
+export type RestSObjectDescribeTransmogrifierInput = {
+  readonly source: 'rest-sobject-describe';
+  readonly identity: SObjectArtifactIdentity;
+  readonly value: DescribeSObjectResult;
+};
+
+/** Discriminated provider-native input; the workspace adapter extends this union. */
+export type TransmogrifierInput = RestSObjectDescribeTransmogrifierInput;
+
+export class TransmogrifierError extends S.TaggedError<TransmogrifierError>()('TransmogrifierError', {
+  source: S.Literal('rest-sobject-describe', 'workspace-sobject-metadata'),
+  message: S.String,
+  cause: S.optional(S.Unknown)
+}) {}
 const mapToSObject = (raw: RawDescribeSObjectResult): SObject => ({
   name: raw.name,
   label: raw.label,
@@ -51,6 +67,65 @@ const mapToSObject = (raw: RawDescribeSObjectResult): SObject => ({
   }))
 });
 
+const compareName = (left: { readonly name: string }, right: { readonly name: string }): number =>
+  left.name < right.name ? -1 : left.name > right.name ? 1 : 0;
+
+const mapRestFieldToSemanticField = (field: SObjectField): SObjectSemanticField => ({
+  name: field.name,
+  label: field.label,
+  type: field.type,
+  custom: field.custom,
+  defaultValue: field.defaultValue,
+  ...(field.inlineHelpText === null ? {} : { inlineHelpText: field.inlineHelpText }),
+  ...(field.length === undefined ? {} : { length: field.length }),
+  ...(field.precision === undefined ? {} : { precision: field.precision }),
+  ...(field.scale === undefined ? {} : { scale: field.scale }),
+  referenceTo: field.referenceTo.toSorted(),
+  ...(field.relationshipName === null ? {} : { relationshipName: field.relationshipName }),
+  picklistValues: field.picklistValues
+    .map(value => ({
+      value: value.value,
+      active: value.active,
+      ...(value.label === null ? {} : { label: value.label })
+    }))
+    .toSorted((left, right) => left.value.localeCompare(right.value)),
+  runtimeCapabilities: {
+    aggregatable: field.aggregatable,
+    filterable: field.filterable,
+    groupable: field.groupable,
+    nillable: field.nillable,
+    sortable: field.sortable
+  }
+});
+
+const mapRestDescribeToSemanticModel = (
+  identity: SObjectArtifactIdentity,
+  raw: DescribeSObjectResult
+): SObjectSemanticModel => {
+  const value = mapToSObject(raw);
+  return {
+    kind: 'sobject',
+    value: {
+      identity,
+      label: value.label,
+      custom: value.custom,
+      queryable: value.queryable,
+      fields: value.fields.map(mapRestFieldToSemanticField).toSorted(compareName),
+      childRelationships: value.childRelationships
+        .map(relationship => ({
+          childSObject: relationship.childSObject,
+          field: relationship.field,
+          ...(relationship.relationshipName === null ? {} : { relationshipName: relationship.relationshipName })
+        }))
+        .toSorted((left, right) =>
+          left.childSObject === right.childSObject
+            ? left.field.localeCompare(right.field)
+            : left.childSObject.localeCompare(right.childSObject)
+        )
+    }
+  };
+};
+
 export class TransmogrifierService extends Effect.Service<TransmogrifierService>()('TransmogrifierService', {
   accessors: true,
   dependencies: [],
@@ -65,6 +140,20 @@ export class TransmogrifierService extends Effect.Service<TransmogrifierService>
       return yield* S.decodeUnknown(SObjectSchema)(input);
     });
 
-    return { toMinimalSObject, decodeSObject, SObjectSchema };
+    const toSemanticModel = Effect.fn('TransmogrifierService.toSemanticModel')(function* (input: TransmogrifierInput) {
+      const model = mapRestDescribeToSemanticModel(input.identity, input.value);
+      return yield* S.decodeUnknown(SObjectSemanticModelSchema)(model).pipe(
+        Effect.mapError(
+          cause =>
+            new TransmogrifierError({
+              source: input.source,
+              message: 'Failed to transform REST SObject Describe into the canonical semantic model',
+              cause
+            })
+        )
+      );
+    });
+
+    return { toMinimalSObject, decodeSObject, toSemanticModel, SObjectSchema };
   })
 }) {}

--- a/packages/salesforcedx-vscode-services/src/index.ts
+++ b/packages/salesforcedx-vscode-services/src/index.ts
@@ -311,7 +311,12 @@ export type {
   ListMetadataError,
   SObjectGlobalDescribeItem
 } from './core/metadataDescribeService';
-export type { DescribeSObjectResult, TransmogrifierService } from './core/transmogrifierService';
+export type {
+  DescribeSObjectResult,
+  RestSObjectDescribeTransmogrifierInput,
+  TransmogrifierInput,
+  TransmogrifierService
+} from './core/transmogrifierService';
 export type { SObject, SObjectField, ChildRelationship } from './core/schemas/sObject';
 export {
   SObjectSchema,
@@ -319,6 +324,7 @@ export {
   ChildRelationshipSchema,
   PicklistValueSchema
 } from './core/schemas/sObject';
+export { TransmogrifierError } from './core/transmogrifierService';
 export type { ExecuteAnonymousResult } from './core/executeAnonymousService';
 export type { ExecuteAnonymousError } from './errors/executeAnonymousErrors';
 export type { ApexLogBodyFetchError, ApexLogQueryError } from './errors/apexLogErrors';

--- a/packages/salesforcedx-vscode-services/test/jest/core/transmogrifierService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/transmogrifierService.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Effect from 'effect/Effect';
+import { TransmogrifierService, type DescribeSObjectResult } from '../../../src/core/transmogrifierService';
+
+const describeResult = {
+  name: 'Broker__c',
+  label: 'Broker',
+  custom: true,
+  queryable: true,
+  fields: [
+    {
+      name: 'Zed__c',
+      label: 'Zed',
+      type: 'string',
+      custom: true,
+      aggregatable: true,
+      defaultValue: null,
+      extraTypeInfo: null,
+      filterable: true,
+      groupable: true,
+      inlineHelpText: null,
+      length: 80,
+      nillable: true,
+      picklistValues: [],
+      referenceTo: [],
+      relationshipName: null,
+      sortable: true
+    },
+    {
+      name: 'Account__c',
+      label: 'Account',
+      type: 'reference',
+      custom: true,
+      aggregatable: false,
+      defaultValue: null,
+      extraTypeInfo: null,
+      filterable: true,
+      groupable: false,
+      inlineHelpText: 'Related account',
+      nillable: false,
+      picklistValues: [],
+      referenceTo: ['Account'],
+      relationshipName: 'Account__r',
+      sortable: true
+    }
+  ],
+  childRelationships: [{ childSObject: 'Deal__c', field: 'Broker__c', relationshipName: 'Deals__r' }]
+} as unknown as DescribeSObjectResult;
+
+const run = <A, E>(effect: Effect.Effect<A, E, TransmogrifierService>): Promise<A> =>
+  Effect.runPromise(effect.pipe(Effect.provide(TransmogrifierService.Default)));
+
+describe('TransmogrifierService', () => {
+  it('preserves the existing minimal SObject operation', async () => {
+    const result = await run(
+      TransmogrifierService.pipe(Effect.flatMap(service => service.toMinimalSObject(describeResult)))
+    );
+
+    expect(result.name).toBe('Broker__c');
+    expect(result.fields.map(field => field.name)).toEqual(['Zed__c', 'Account__c']);
+    expect(result.fields[1]).toMatchObject({ referenceTo: ['Account'], relationshipName: 'Account__r' });
+  });
+
+  it('transforms REST Describe through one discriminated canonical boundary', async () => {
+    const result = await run(
+      TransmogrifierService.pipe(
+        Effect.flatMap(service =>
+          service.toSemanticModel({
+            source: 'rest-sobject-describe',
+            identity: { kind: 'sobject', namespace: null, name: 'Broker__c' },
+            value: describeResult
+          })
+        )
+      )
+    );
+
+    expect(result).toMatchObject({
+      kind: 'sobject',
+      value: {
+        identity: { kind: 'sobject', namespace: null, name: 'Broker__c' },
+        label: 'Broker',
+        custom: true,
+        queryable: true
+      }
+    });
+    expect(result.value.fields.map(field => field.name)).toEqual(['Account__c', 'Zed__c']);
+    expect(result.value.fields[0]).toMatchObject({
+      referenceTo: ['Account'],
+      runtimeCapabilities: { filterable: true, nillable: false }
+    });
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Introduces the discriminated `TransmogrifierService.toSemanticModel(...)` boundary for REST SObject Describe input:

- accepts provider-native data plus canonical identity as plain domain input
- produces the canonical SObject semantic projection
- sorts projection collections deterministically
- preserves unknown versus false runtime facts
- retains existing `toMinimalSObject` and `decodeSObject` behavior for current callers

Production consumers continue to resolve `TransmogrifierService` from its Effect tag and provide implementations through Layers; service instances are not passed as parameters.

### What issues does this PR fix or reference?

@W-23973850@

### Functionality Before

The Transmogrifier only exposed the Org Browser-oriented minimal REST SObject model.

### Functionality After

It provides one extensible canonical SObject transformation operation while remaining stateless and free of acquisition, scanning, and persistence responsibilities.

### Validation

- compatibility coverage for the existing minimal operation
- canonical ordering and runtime-capability projection coverage
- production/test TypeScript, lint, knip, Effect diagnostics, and repository hooks

Depends on #8038.
