### PR TITLE
feat(services): transform workspace SObject metadata - W-23973850

### DIFF
--- a/packages/salesforcedx-vscode-services/src/core/transmogrifierService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/transmogrifierService.ts
@@ -9,6 +9,7 @@ import type { SObjectArtifactIdentity } from './artifactIdentity';
 import type { Connection } from '@salesforce/core';
 import * as Effect from 'effect/Effect';
 import * as S from 'effect/Schema';
+import type { URI } from 'vscode-uri';
 import { SObjectSemanticModelSchema, type SObjectSemanticField, type SObjectSemanticModel } from './artifactProjection';
 import { SObjectSchema, type SObject, type SObjectField } from './schemas/sObject';
 
@@ -23,8 +24,26 @@ export type RestSObjectDescribeTransmogrifierInput = {
   readonly value: DescribeSObjectResult;
 };
 
-/** Discriminated provider-native input; the workspace adapter extends this union. */
-export type TransmogrifierInput = RestSObjectDescribeTransmogrifierInput;
+export type WorkspaceSObjectMetadataDocument = {
+  readonly fullName: string;
+  readonly metadata: Readonly<Record<string, unknown>>;
+  readonly definitionUri: URI;
+};
+
+/** Structured metadata parsed by SDR. Raw XML is never interpreted by the Transmogrifier. */
+export type WorkspaceSObjectMetadata = {
+  readonly object: WorkspaceSObjectMetadataDocument;
+  readonly fields: readonly WorkspaceSObjectMetadataDocument[];
+};
+
+export type WorkspaceSObjectMetadataTransmogrifierInput = {
+  readonly source: 'workspace-sobject-metadata';
+  readonly identity: SObjectArtifactIdentity;
+  readonly value: WorkspaceSObjectMetadata;
+};
+
+/** Provider-native SObject inputs accepted by the canonical transformation boundary. */
+export type TransmogrifierInput = RestSObjectDescribeTransmogrifierInput | WorkspaceSObjectMetadataTransmogrifierInput;
 
 export class TransmogrifierError extends S.TaggedError<TransmogrifierError>()('TransmogrifierError', {
   source: S.Literal('rest-sobject-describe', 'workspace-sobject-metadata'),
@@ -69,6 +88,163 @@ const mapToSObject = (raw: RawDescribeSObjectResult): SObject => ({
 
 const compareName = (left: { readonly name: string }, right: { readonly name: string }): number =>
   left.name < right.name ? -1 : left.name > right.name ? 1 : 0;
+
+const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const metadataValue = (
+  metadata: Readonly<Record<string, unknown>>,
+  metadataType: 'CustomObject' | 'CustomField'
+): Readonly<Record<string, unknown>> => {
+  const wrapped = metadata[metadataType];
+  return isRecord(wrapped) ? wrapped : metadata;
+};
+
+const asArray = (value: unknown): readonly unknown[] =>
+  Array.isArray(value) ? value : value === undefined ? [] : [value];
+
+const optionalString = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+
+const optionalNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value !== 'string' || value.trim().length === 0) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const optionalBoolean = (value: unknown): boolean | undefined => {
+  if (typeof value === 'boolean') return value;
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  return undefined;
+};
+
+const workspaceFieldType = (value: unknown): string | undefined => {
+  const metadataType = optionalString(value);
+  if (!metadataType) return undefined;
+  const normalized = metadataType.toLowerCase();
+  const typeMap: Readonly<Record<string, string>> = {
+    autonumber: 'string',
+    checkbox: 'boolean',
+    encryptedtext: 'string',
+    externallookup: 'reference',
+    hierarchy: 'reference',
+    html: 'textarea',
+    indirectlookup: 'reference',
+    longtextarea: 'textarea',
+    lookup: 'reference',
+    masterdetail: 'reference',
+    metadatarelationship: 'reference',
+    multiselectpicklist: 'multipicklist',
+    number: 'double',
+    text: 'string'
+  };
+  return typeMap[normalized] ?? normalized;
+};
+
+const simpleFieldName = (objectName: string, fullName: string): string => {
+  const prefix = `${objectName}.`;
+  return fullName.toLowerCase().startsWith(prefix.toLowerCase()) ? fullName.slice(prefix.length) : fullName;
+};
+
+const workspacePicklistValues = (field: Readonly<Record<string, unknown>>) => {
+  const valueSet = isRecord(field.valueSet) ? field.valueSet : undefined;
+  const definition = valueSet && isRecord(valueSet.valueSetDefinition) ? valueSet.valueSetDefinition : undefined;
+  return asArray(definition?.value)
+    .filter(isRecord)
+    .flatMap(value => {
+      const name = optionalString(value.fullName);
+      if (!name) return [];
+      const label = optionalString(value.label);
+      const active = optionalBoolean(value.isActive);
+      return [
+        {
+          value: name,
+          ...(label === undefined ? {} : { label }),
+          ...(active === undefined ? {} : { active })
+        }
+      ];
+    })
+    .toSorted((left, right) => left.value.localeCompare(right.value));
+};
+
+const mapWorkspaceField = (
+  identity: SObjectArtifactIdentity,
+  document: WorkspaceSObjectMetadataDocument,
+  rawField?: Readonly<Record<string, unknown>>
+): SObjectSemanticField | undefined => {
+  const field = rawField ?? metadataValue(document.metadata, 'CustomField');
+  const fullName = optionalString(field.fullName) ?? optionalString(document.fullName);
+  if (!fullName) return undefined;
+  const name = simpleFieldName(identity.name, fullName);
+  const label = optionalString(field.label);
+  const type = workspaceFieldType(field.type);
+  const defaultValue = field.defaultValue;
+  const inlineHelpText = optionalString(field.inlineHelpText);
+  const length = optionalNumber(field.length);
+  const precision = optionalNumber(field.precision);
+  const scale = optionalNumber(field.scale);
+  const referenceTo = asArray(field.referenceTo)
+    .flatMap(value => optionalString(value) ?? [])
+    .toSorted();
+  const relationshipName = optionalString(field.relationshipName);
+  const picklistValues = workspacePicklistValues(field);
+  return {
+    name,
+    ...(label === undefined ? {} : { label }),
+    ...(type === undefined ? {} : { type }),
+    custom: /__(?:c|mdt|e|b|x)$/i.test(name),
+    ...(defaultValue === undefined ? {} : { defaultValue }),
+    ...(inlineHelpText === undefined ? {} : { inlineHelpText }),
+    ...(length === undefined ? {} : { length }),
+    ...(precision === undefined ? {} : { precision }),
+    ...(scale === undefined ? {} : { scale }),
+    ...(referenceTo.length === 0 ? {} : { referenceTo }),
+    ...(relationshipName === undefined ? {} : { relationshipName }),
+    ...(picklistValues.length === 0 ? {} : { picklistValues }),
+    definitionUri: document.definitionUri
+  };
+};
+
+const mapWorkspaceSObjectToSemanticModel = (
+  identity: SObjectArtifactIdentity,
+  workspace: WorkspaceSObjectMetadata
+): SObjectSemanticModel => {
+  const object = metadataValue(workspace.object.metadata, 'CustomObject');
+  const nameField = isRecord(object.nameField) ? object.nameField : undefined;
+  const fields = [
+    ...asArray(object.fields)
+      .filter(isRecord)
+      .map(field => mapWorkspaceField(identity, workspace.object, field)),
+    ...(nameField
+      ? [
+          mapWorkspaceField(identity, workspace.object, {
+            ...nameField,
+            fullName: 'Name'
+          })
+        ]
+      : []),
+    ...workspace.fields.map(document => mapWorkspaceField(identity, document))
+  ].reduce(
+    (byName, field) => (field ? new Map(byName).set(field.name.toLowerCase(), field) : byName),
+    new Map<string, SObjectSemanticField>()
+  );
+
+  const label = optionalString(object.label);
+  const pluralLabel = optionalString(object.pluralLabel);
+  return {
+    kind: 'sobject',
+    value: {
+      identity,
+      ...(label === undefined ? {} : { label }),
+      ...(pluralLabel === undefined ? {} : { pluralLabel }),
+      custom: /__(?:c|mdt|e|b|x)$/i.test(identity.name),
+      fields: [...fields.values()].toSorted(compareName),
+      definitionUri: workspace.object.definitionUri
+    }
+  };
+};
 
 const mapRestFieldToSemanticField = (field: SObjectField): SObjectSemanticField => ({
   name: field.name,
@@ -141,13 +317,16 @@ export class TransmogrifierService extends Effect.Service<TransmogrifierService>
     });
 
     const toSemanticModel = Effect.fn('TransmogrifierService.toSemanticModel')(function* (input: TransmogrifierInput) {
-      const model = mapRestDescribeToSemanticModel(input.identity, input.value);
-      return yield* S.decodeUnknown(SObjectSemanticModelSchema)(model).pipe(
+      const model =
+        input.source === 'rest-sobject-describe'
+          ? mapRestDescribeToSemanticModel(input.identity, input.value)
+          : mapWorkspaceSObjectToSemanticModel(input.identity, input.value);
+      return yield* S.validate(SObjectSemanticModelSchema)(model).pipe(
         Effect.mapError(
           cause =>
             new TransmogrifierError({
               source: input.source,
-              message: 'Failed to transform REST SObject Describe into the canonical semantic model',
+              message: `Failed to transform ${input.source} into the canonical semantic model`,
               cause
             })
         )

--- a/packages/salesforcedx-vscode-services/src/index.ts
+++ b/packages/salesforcedx-vscode-services/src/index.ts
@@ -315,7 +315,10 @@ export type {
   DescribeSObjectResult,
   RestSObjectDescribeTransmogrifierInput,
   TransmogrifierInput,
-  TransmogrifierService
+  TransmogrifierService,
+  WorkspaceSObjectMetadata,
+  WorkspaceSObjectMetadataDocument,
+  WorkspaceSObjectMetadataTransmogrifierInput
 } from './core/transmogrifierService';
 export type { SObject, SObjectField, ChildRelationship } from './core/schemas/sObject';
 export {

--- a/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogWorkspace.ts
+++ b/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogWorkspace.ts
@@ -5,7 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import type { SObjectArtifactIdentity } from '../core/artifactIdentity';
+import type { WorkspaceSObjectMetadata, WorkspaceSObjectMetadataDocument } from '../core/transmogrifierService';
 import * as Arr from 'effect/Array';
+import * as Data from 'effect/Data';
 import * as Effect from 'effect/Effect';
 import { URI } from 'vscode-uri';
 import { MetadataRetrieveService } from '../core/metadataRetrieveService';
@@ -13,6 +16,11 @@ import { ProjectService } from '../core/projectService';
 import { toUri } from '../vscode/uriUtils';
 import { OrgCatalogState } from './orgCatalogState';
 import { OrgMetadataReferenceService, type OrgMetadataComponentReference } from './orgMetadataReference';
+
+class WorkspaceSObjectMetadataReadError extends Data.TaggedError('WorkspaceSObjectMetadataReadError')<{
+  readonly identity: SObjectArtifactIdentity;
+  readonly cause: unknown;
+}> {}
 
 export class OrgCatalogWorkspace extends Effect.Service<OrgCatalogWorkspace>()('OrgCatalogWorkspace', {
   accessors: true,
@@ -58,6 +66,60 @@ export class OrgCatalogWorkspace extends Effect.Service<OrgCatalogWorkspace>()('
     const scanWorkspace = Effect.fn('OrgCatalogWorkspace.scanWorkspace')((xmlName: string) =>
       scanWorkspaceInventory(xmlName).pipe(Effect.map(inventory => inventory.components))
     );
+
+    const loadSObjectMetadata = Effect.fn('OrgCatalogWorkspace.loadSObjectMetadata')(function* (
+      identity: SObjectArtifactIdentity
+    ) {
+      if (!(yield* projectService.isArtifactNamespaceWorkspaceEligible(identity.namespace))) return null;
+      const project = yield* projectService.getSfProject();
+      const packageDirectories = project.getPackageDirectories().map(directory => directory.fullPath);
+      const componentSet = yield* metadataRetrieveService.buildComponentSetFromSource(packageDirectories, [
+        { type: 'CustomObject', fullName: identity.name }
+      ]);
+      const sourceComponents = [...componentSet.getSourceComponents()];
+      const objectComponent = sourceComponents.find(
+        component =>
+          component.type.name === 'CustomObject' && component.fullName.toLowerCase() === identity.name.toLowerCase()
+      );
+      const objectXml = objectComponent?.xml;
+      if (!objectComponent || !objectXml) return null;
+
+      return yield* Effect.tryPromise({
+        try: async (): Promise<WorkspaceSObjectMetadata> => {
+          const childComponents = [...sourceComponents, ...objectComponent.getChildren()].filter(
+            (component, index, components) =>
+              component.type.name === 'CustomField' &&
+              component.fullName.toLowerCase().startsWith(`${identity.name.toLowerCase()}.`) &&
+              components.findIndex(
+                candidate => candidate.fullName.toLowerCase() === component.fullName.toLowerCase()
+              ) === index
+          );
+          const object: WorkspaceSObjectMetadataDocument = {
+            fullName: objectComponent.fullName,
+            metadata: await objectComponent.parseXml(),
+            definitionUri: toUri(objectXml)
+          };
+          const fields = await Promise.all(
+            childComponents.flatMap(component => {
+              const sourcePath = component.xml ?? component.content;
+              if (!sourcePath) return [];
+              const definitionUri = toUri(sourcePath);
+              return [
+                component.parseXml().then(
+                  (metadata): WorkspaceSObjectMetadataDocument => ({
+                    fullName: component.fullName,
+                    metadata,
+                    definitionUri
+                  })
+                )
+              ];
+            })
+          );
+          return { object, fields };
+        },
+        catch: cause => new WorkspaceSObjectMetadataReadError({ identity, cause })
+      });
+    });
 
     const getWorkspaceMetadataTypes = Effect.fn('OrgCatalogWorkspace.getWorkspaceMetadataTypes')(function* (
       orgId: string
@@ -124,6 +186,12 @@ export class OrgCatalogWorkspace extends Effect.Service<OrgCatalogWorkspace>()('
       return resolutions;
     });
 
-    return { getWorkspaceMetadataTypes, resolveComponents, scanWorkspace, scanWorkspaceInventory } as const;
+    return {
+      getWorkspaceMetadataTypes,
+      loadSObjectMetadata,
+      resolveComponents,
+      scanWorkspace,
+      scanWorkspaceInventory
+    } as const;
   })
 }) {}

--- a/packages/salesforcedx-vscode-services/test/jest/core/transmogrifierService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/transmogrifierService.test.ts
@@ -6,6 +6,7 @@
  */
 
 import * as Effect from 'effect/Effect';
+import { URI } from 'vscode-uri';
 import { TransmogrifierService, type DescribeSObjectResult } from '../../../src/core/transmogrifierService';
 
 const describeResult = {
@@ -94,5 +95,91 @@ describe('TransmogrifierService', () => {
       referenceTo: ['Account'],
       runtimeCapabilities: { filterable: true, nillable: false }
     });
+  });
+
+  it('transforms SDR-parsed workspace metadata without inventing runtime capabilities', async () => {
+    const objectUri = URI.file('/workspace/force-app/main/default/objects/Broker__c/Broker__c.object-meta.xml');
+    const accountFieldUri = URI.file(
+      '/workspace/force-app/main/default/objects/Broker__c/fields/Account__c.field-meta.xml'
+    );
+    const incompleteFieldUri = URI.file(
+      '/workspace/force-app/main/default/objects/Broker__c/fields/Incomplete__c.field-meta.xml'
+    );
+    const result = await run(
+      TransmogrifierService.pipe(
+        Effect.flatMap(service =>
+          service.toSemanticModel({
+            source: 'workspace-sobject-metadata',
+            identity: { kind: 'sobject', namespace: null, name: 'Broker__c' },
+            value: {
+              object: {
+                fullName: 'Broker__c',
+                definitionUri: objectUri,
+                metadata: {
+                  CustomObject: {
+                    label: 'Broker',
+                    pluralLabel: 'Brokers',
+                    nameField: { label: 'Broker Number', type: 'AutoNumber' },
+                    fields: {
+                      fullName: 'Legacy__c',
+                      label: 'Legacy',
+                      type: 'Checkbox',
+                      defaultValue: 'false'
+                    }
+                  }
+                }
+              },
+              fields: [
+                {
+                  fullName: 'Broker__c.Account__c',
+                  definitionUri: accountFieldUri,
+                  metadata: {
+                    CustomField: {
+                      fullName: 'Account__c',
+                      label: 'Account',
+                      type: 'Lookup',
+                      referenceTo: 'Account',
+                      relationshipName: 'Account__r',
+                      inlineHelpText: 'Related account'
+                    }
+                  }
+                },
+                {
+                  fullName: 'Broker__c.Incomplete__c',
+                  definitionUri: incompleteFieldUri,
+                  metadata: { CustomField: { label: 'Incomplete' } }
+                }
+              ]
+            }
+          })
+        )
+      )
+    );
+
+    expect(result).toMatchObject({
+      kind: 'sobject',
+      value: {
+        identity: { kind: 'sobject', namespace: null, name: 'Broker__c' },
+        label: 'Broker',
+        pluralLabel: 'Brokers',
+        custom: true,
+        definitionUri: objectUri
+      }
+    });
+    expect(result.value.fields.map(field => field.name)).toEqual(['Account__c', 'Incomplete__c', 'Legacy__c', 'Name']);
+    expect(result.value.fields[0]).toMatchObject({
+      type: 'reference',
+      referenceTo: ['Account'],
+      relationshipName: 'Account__r',
+      definitionUri: accountFieldUri
+    });
+    expect(result.value.fields[0]).not.toHaveProperty('runtimeCapabilities');
+    expect(result.value.fields[1]).toEqual({
+      name: 'Incomplete__c',
+      label: 'Incomplete',
+      custom: true,
+      definitionUri: incompleteFieldUri
+    });
+    expect(result.value.fields[3]).toMatchObject({ name: 'Name', type: 'string', custom: false });
   });
 });

--- a/packages/salesforcedx-vscode-services/test/jest/orgCatalog/orgCatalogWorkspace.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/orgCatalog/orgCatalogWorkspace.test.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+import { MetadataRetrieveService } from '../../../src/core/metadataRetrieveService';
+import { ProjectService } from '../../../src/core/projectService';
+import { OrgCatalogState } from '../../../src/orgCatalog/orgCatalogState';
+import { OrgCatalogWorkspace } from '../../../src/orgCatalog/orgCatalogWorkspace';
+import { OrgMetadataReferenceService } from '../../../src/orgCatalog/orgMetadataReference';
+
+const objectMetadata = {
+  CustomObject: {
+    label: 'Broker',
+    pluralLabel: 'Brokers'
+  }
+};
+
+const fieldMetadata = {
+  CustomField: {
+    fullName: 'Account__c',
+    label: 'Account',
+    type: 'Lookup',
+    referenceTo: 'Account'
+  }
+};
+
+const createFixture = (eligible = true) => {
+  const parseObject = jest.fn(async () => objectMetadata);
+  const parseField = jest.fn(async () => fieldMetadata);
+  const fieldComponent = {
+    type: { name: 'CustomField' },
+    fullName: 'Broker__c.Account__c',
+    xml: '/workspace/force-app/main/default/objects/Broker__c/fields/Account__c.field-meta.xml',
+    parseXml: parseField
+  };
+  const objectComponent = {
+    type: { name: 'CustomObject' },
+    fullName: 'Broker__c',
+    xml: '/workspace/force-app/main/default/objects/Broker__c/Broker__c.object-meta.xml',
+    parseXml: parseObject,
+    getChildren: jest.fn(() => [fieldComponent])
+  };
+  const buildComponentSetFromSource = jest.fn(() =>
+    Effect.succeed({ getSourceComponents: () => [objectComponent, fieldComponent] })
+  );
+  const dependencies = Layer.mergeAll(
+    Layer.succeed(OrgCatalogState, {} as unknown as InstanceType<typeof OrgCatalogState>),
+    Layer.succeed(OrgMetadataReferenceService, {} as unknown as InstanceType<typeof OrgMetadataReferenceService>),
+    Layer.succeed(MetadataRetrieveService, {
+      buildComponentSetFromSource
+    } as unknown as InstanceType<typeof MetadataRetrieveService>),
+    Layer.succeed(ProjectService, {
+      getSfProject: () => Effect.succeed({ getPackageDirectories: () => [{ fullPath: '/workspace/force-app' }] }),
+      isArtifactNamespaceWorkspaceEligible: () => Effect.succeed(eligible)
+    } as unknown as InstanceType<typeof ProjectService>)
+  );
+  const layer = OrgCatalogWorkspace.DefaultWithoutDependencies.pipe(Layer.provide(dependencies));
+  return { buildComponentSetFromSource, layer, parseField, parseObject };
+};
+
+describe('OrgCatalogWorkspace', () => {
+  it('loads structured SObject metadata through SDR SourceComponent parsing', async () => {
+    const fixture = createFixture();
+    const result = await Effect.runPromise(
+      OrgCatalogWorkspace.pipe(
+        Effect.flatMap(service => service.loadSObjectMetadata({ kind: 'sobject', namespace: null, name: 'Broker__c' })),
+        Effect.provide(fixture.layer)
+      )
+    );
+
+    expect(result).toMatchObject({
+      object: {
+        fullName: 'Broker__c',
+        metadata: objectMetadata
+      },
+      fields: [
+        {
+          fullName: 'Broker__c.Account__c',
+          metadata: fieldMetadata
+        }
+      ]
+    });
+    expect(result?.object.definitionUri.toString()).toBe(
+      'file:///workspace/force-app/main/default/objects/Broker__c/Broker__c.object-meta.xml'
+    );
+    expect(fixture.buildComponentSetFromSource).toHaveBeenCalledWith(
+      ['/workspace/force-app'],
+      [{ type: 'CustomObject', fullName: 'Broker__c' }]
+    );
+    expect(fixture.parseObject).toHaveBeenCalledTimes(1);
+    expect(fixture.parseField).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not attribute a mismatched namespace to the workspace', async () => {
+    const fixture = createFixture(false);
+    const result = await Effect.runPromise(
+      OrgCatalogWorkspace.pipe(
+        Effect.flatMap(service =>
+          service.loadSObjectMetadata({ kind: 'sobject', namespace: 'OtherPackage', name: 'Broker__c' })
+        ),
+        Effect.provide(fixture.layer)
+      )
+    );
+
+    expect(result).toBeNull();
+    expect(fixture.buildComponentSetFromSource).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Adds the workspace SObject transformation slice for W-23973850:

- extends the internal OrgCatalogWorkspace provider with namespace-eligible CustomObject loading
- parses object and decomposed CustomField metadata through SDR SourceComponent APIs
- passes only structured metadata and definition URIs to TransmogrifierService
- maps workspace object, name-field, relationship, picklist, and incomplete field facts into the canonical SObject projection
- preserves unknown org-only runtime capabilities rather than inventing false values

Services are obtained through Effect tags and provided through Layers; service instances are not passed as parameters. This slice does not call REST Describe or bind catalog find behavior.

### What issues does this PR fix or reference?

@W-23973850@

### Functionality Before

TransmogrifierService could normalize REST SObject Describe values, but workspace CustomObject metadata had no structured provider-to-projection path.

### Functionality After

The workspace provider can load SDR-parsed SObject metadata and TransmogrifierService can produce the same canonical SObject semantic model shape with local definition URIs.

### Validation

- focused workspace provider and Transmogrifier Jest tests
- production and test TypeScript checks
- focused ESLint
- complete repository pre-commit workflow

Depends on #8040.
