### PR TITLE
feat(services): transform Symbol Table Apex stubs - W-23973850

### DIFF
--- a/packages/salesforcedx-vscode-services/src/core/apexSymbolTableSchema.ts
+++ b/packages/salesforcedx-vscode-services/src/core/apexSymbolTableSchema.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Schema from 'effect/Schema';
+import { ApexTypeKindSchema, type ApexTypeKind } from './artifactProjection';
+
+type RawApexTypeReferenceValue = {
+  readonly namespacePrefix?: string | null;
+  readonly name: string;
+  readonly typeParameters?: readonly RawApexTypeReferenceValue[] | null;
+};
+
+/** Provider-native TypeReference. The service currently emits both omitted and explicit-null optional fields. */
+export const RawApexTypeReferenceSchema: Schema.Schema<RawApexTypeReferenceValue> = Schema.Struct({
+  namespacePrefix: Schema.String.pipe(Schema.NullOr, Schema.optional),
+  name: Schema.NonEmptyTrimmedString,
+  typeParameters: Schema.suspend(() => RawApexTypeReferenceSchema).pipe(Schema.Array, Schema.NullOr, Schema.optional)
+});
+export type RawApexTypeReference = typeof RawApexTypeReferenceSchema.Type;
+
+export const RawApexAnnotationParameterStubSchema = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  type: RawApexTypeReferenceSchema,
+  value: Schema.String
+});
+export type RawApexAnnotationParameterStub = typeof RawApexAnnotationParameterStubSchema.Type;
+
+export const RawApexAnnotationStubSchema = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  parameters: RawApexAnnotationParameterStubSchema.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  documentation: Schema.String.pipe(Schema.NullOr, Schema.optional)
+});
+export type RawApexAnnotationStub = typeof RawApexAnnotationStubSchema.Type;
+
+export const RawApexAccessorStubSchema = Schema.Struct({
+  modifiers: Schema.String.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  documentation: Schema.String.pipe(Schema.NullOr, Schema.optional)
+});
+export type RawApexAccessorStub = typeof RawApexAccessorStubSchema.Type;
+
+export const RawApexParameterStubSchema = Schema.Struct({
+  name: Schema.String.pipe(Schema.NullOr, Schema.optional),
+  type: RawApexTypeReferenceSchema.pipe(Schema.NullOr, Schema.optional),
+  annotations: RawApexAnnotationStubSchema.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  documentation: Schema.String.pipe(Schema.NullOr, Schema.optional)
+});
+export type RawApexParameterStub = typeof RawApexParameterStubSchema.Type;
+
+export const RawApexMethodStubSchema = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  isConstructor: Schema.Boolean.pipe(Schema.NullOr, Schema.optional),
+  returnType: RawApexTypeReferenceSchema.pipe(Schema.NullOr, Schema.optional),
+  modifiers: Schema.String.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  annotations: RawApexAnnotationStubSchema.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  parameters: RawApexParameterStubSchema.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  documentation: Schema.String.pipe(Schema.NullOr, Schema.optional),
+  definingType: RawApexTypeReferenceSchema.pipe(Schema.NullOr, Schema.optional)
+});
+export type RawApexMethodStub = typeof RawApexMethodStubSchema.Type;
+
+export const RawApexFieldStubSchema = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  type: RawApexTypeReferenceSchema.pipe(Schema.NullOr, Schema.optional),
+  modifiers: Schema.String.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  annotations: RawApexAnnotationStubSchema.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  documentation: Schema.String.pipe(Schema.NullOr, Schema.optional),
+  definingType: RawApexTypeReferenceSchema.pipe(Schema.NullOr, Schema.optional)
+});
+export type RawApexFieldStub = typeof RawApexFieldStubSchema.Type;
+
+export const RawApexPropertyStubSchema = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  type: RawApexTypeReferenceSchema.pipe(Schema.NullOr, Schema.optional),
+  modifiers: Schema.String.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  annotations: RawApexAnnotationStubSchema.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  getter: RawApexAccessorStubSchema.pipe(Schema.NullOr, Schema.optional),
+  setter: RawApexAccessorStubSchema.pipe(Schema.NullOr, Schema.optional),
+  documentation: Schema.String.pipe(Schema.NullOr, Schema.optional),
+  definingType: RawApexTypeReferenceSchema.pipe(Schema.NullOr, Schema.optional)
+});
+export type RawApexPropertyStub = typeof RawApexPropertyStubSchema.Type;
+
+type RawApexTypeStubValue = {
+  readonly name: string;
+  readonly namespacePrefix?: string | null;
+  readonly kind: ApexTypeKind;
+  readonly modifiers?: readonly string[] | null;
+  readonly annotations?: readonly RawApexAnnotationStub[] | null;
+  readonly superClass?: RawApexTypeReference | null;
+  readonly interfaces?: readonly RawApexTypeReference[] | null;
+  readonly fields?: readonly RawApexFieldStub[] | null;
+  readonly properties?: readonly RawApexPropertyStub[] | null;
+  readonly methods?: readonly RawApexMethodStub[] | null;
+  readonly innerTypes?: readonly RawApexTypeStubValue[] | null;
+  readonly triggerOperations?: readonly string[] | null;
+  readonly triggerObjectType?: RawApexTypeReference | null;
+  readonly documentation?: string | null;
+  readonly compileError?: string | null;
+};
+
+/** Raw TYPE_STUB payload. Canonical completeness and ordering are enforced by TransmogrifierService. */
+export const RawApexTypeStubSchema: Schema.Schema<RawApexTypeStubValue> = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  namespacePrefix: Schema.String.pipe(Schema.NullOr, Schema.optional),
+  kind: ApexTypeKindSchema,
+  modifiers: Schema.String.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  annotations: RawApexAnnotationStubSchema.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  superClass: RawApexTypeReferenceSchema.pipe(Schema.NullOr, Schema.optional),
+  interfaces: RawApexTypeReferenceSchema.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  fields: RawApexFieldStubSchema.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  properties: RawApexPropertyStubSchema.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  methods: RawApexMethodStubSchema.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  innerTypes: Schema.suspend(() => RawApexTypeStubSchema).pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  triggerOperations: Schema.String.pipe(Schema.Array, Schema.NullOr, Schema.optional),
+  triggerObjectType: RawApexTypeReferenceSchema.pipe(Schema.NullOr, Schema.optional),
+  documentation: Schema.String.pipe(Schema.NullOr, Schema.optional),
+  compileError: Schema.String.pipe(Schema.NullOr, Schema.optional)
+});
+export type RawApexTypeStub = typeof RawApexTypeStubSchema.Type;
+
+export const RawApexTypeStubResponseSchema = Schema.Struct({
+  typeStubs: Schema.Array(RawApexTypeStubSchema)
+});
+export type RawApexTypeStubResponse = typeof RawApexTypeStubResponseSchema.Type;
+
+export const ApexSymbolTableSchemas = {
+  TypeReference: RawApexTypeReferenceSchema,
+  AnnotationParameterStub: RawApexAnnotationParameterStubSchema,
+  AnnotationStub: RawApexAnnotationStubSchema,
+  AccessorStub: RawApexAccessorStubSchema,
+  ParameterStub: RawApexParameterStubSchema,
+  MethodStub: RawApexMethodStubSchema,
+  FieldStub: RawApexFieldStubSchema,
+  PropertyStub: RawApexPropertyStubSchema,
+  TypeStub: RawApexTypeStubSchema,
+  TypeStubResponse: RawApexTypeStubResponseSchema
+} as const;

--- a/packages/salesforcedx-vscode-services/src/core/artifactIdentity.ts
+++ b/packages/salesforcedx-vscode-services/src/core/artifactIdentity.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Schema from 'effect/Schema';
+
+export const ArtifactTargetKindSchema = Schema.Literal('metadata-component', 'sobject', 'apex-type');
+export type ArtifactTargetKind = typeof ArtifactTargetKindSchema.Type;
+
+export const ArtifactNamespaceSchema = Schema.NullOr(Schema.NonEmptyTrimmedString);
+export type ArtifactNamespace = typeof ArtifactNamespaceSchema.Type;
+
+const ArtifactIdentityFields = {
+  namespace: ArtifactNamespaceSchema,
+  name: Schema.NonEmptyTrimmedString
+} as const;
+
+export const MetadataComponentArtifactIdentitySchema = Schema.Struct({
+  kind: Schema.Literal('metadata-component'),
+  metadataType: Schema.NonEmptyTrimmedString,
+  ...ArtifactIdentityFields
+});
+export type MetadataComponentArtifactIdentity = typeof MetadataComponentArtifactIdentitySchema.Type;
+
+export const SObjectArtifactIdentitySchema = Schema.Struct({
+  kind: Schema.Literal('sobject'),
+  ...ArtifactIdentityFields
+});
+export type SObjectArtifactIdentity = typeof SObjectArtifactIdentitySchema.Type;
+
+export const ApexTypeArtifactIdentitySchema = Schema.Struct({
+  kind: Schema.Literal('apex-type'),
+  ...ArtifactIdentityFields
+});
+export type ApexTypeArtifactIdentity = typeof ApexTypeArtifactIdentitySchema.Type;
+
+/** Provider-neutral identity shared by workspace, org, cache, and persistence providers. */
+export const ArtifactIdentitySchema = Schema.Union(
+  MetadataComponentArtifactIdentitySchema,
+  SObjectArtifactIdentitySchema,
+  ApexTypeArtifactIdentitySchema
+);
+export type ArtifactIdentity = typeof ArtifactIdentitySchema.Type;
+
+/** Locale-independent comparison normalization. Canonical provider casing remains on the identity itself. */
+export const normalizeArtifactIdentityPart = (value: string): string => value.toLowerCase();
+
+export const normalizeArtifactNamespace = (namespace: ArtifactNamespace): ArtifactNamespace =>
+  namespace === null ? null : normalizeArtifactIdentityPart(namespace);
+
+export const normalizeArtifactIdentity = (identity: ArtifactIdentity): ArtifactIdentity => ({
+  ...identity,
+  ...(identity.kind === 'metadata-component'
+    ? { metadataType: normalizeArtifactIdentityPart(identity.metadataType) }
+    : {}),
+  namespace: normalizeArtifactNamespace(identity.namespace),
+  name: normalizeArtifactIdentityPart(identity.name)
+});
+
+/** Stable comparison/cache key. Namespace remains a distinct tuple member rather than being added to the name. */
+export const artifactIdentityKey = (identity: ArtifactIdentity): string => {
+  const normalized = normalizeArtifactIdentity(identity);
+  return JSON.stringify([
+    normalized.kind,
+    normalized.kind === 'metadata-component' ? normalized.metadataType : null,
+    normalized.namespace,
+    normalized.name
+  ]);
+};
+
+export const artifactIdentitiesEqual = (left: ArtifactIdentity, right: ArtifactIdentity): boolean =>
+  artifactIdentityKey(left) === artifactIdentityKey(right);
+
+export const artifactNamespacesEqual = (left: ArtifactNamespace, right: ArtifactNamespace): boolean =>
+  normalizeArtifactNamespace(left) === normalizeArtifactNamespace(right);

--- a/packages/salesforcedx-vscode-services/src/core/artifactProjection.ts
+++ b/packages/salesforcedx-vscode-services/src/core/artifactProjection.ts
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Schema from 'effect/Schema';
+import { URI } from 'vscode-uri';
+import {
+  ApexTypeArtifactIdentitySchema,
+  ArtifactIdentitySchema,
+  ArtifactNamespaceSchema,
+  SObjectArtifactIdentitySchema,
+  type ArtifactNamespace
+} from './artifactIdentity';
+
+const UriTypeSchema = Schema.declare((value): value is URI => value instanceof URI, {
+  identifier: 'URI',
+  description: 'vscode-uri URI'
+});
+
+/** JSON-safe URI schema whose decoded TypeScript value is a vscode-uri URI. */
+export const DocumentUriSchema = Schema.transform(Schema.String, UriTypeSchema, {
+  strict: true,
+  decode: value => URI.parse(value),
+  encode: (_encoded, uri) => uri.toString()
+});
+export type DocumentUri = typeof DocumentUriSchema.Type;
+
+export const ArtifactPresenceSchema = Schema.Literal('workspace', 'org', 'both');
+export type ArtifactPresence = typeof ArtifactPresenceSchema.Type;
+
+export const ArtifactProviderKindSchema = Schema.Literal(
+  'workspace',
+  'metadata-api',
+  'rest-api',
+  'tooling-api',
+  'symbol-table'
+);
+export type ArtifactProviderKind = typeof ArtifactProviderKindSchema.Type;
+
+/** Provider-neutral catalog information returned alongside any materialized projection. */
+export const CatalogEntryDescriptorSchema = Schema.Struct({
+  kind: Schema.Literal('catalog-entry'),
+  identity: ArtifactIdentitySchema,
+  presence: ArtifactPresenceSchema,
+  providers: Schema.Array(ArtifactProviderKindSchema),
+  workspaceUri: Schema.optional(DocumentUriSchema),
+  orgUri: Schema.optional(DocumentUriSchema)
+});
+export type CatalogEntryDescriptor = typeof CatalogEntryDescriptorSchema.Type;
+
+/** A URI that resolves to actual source. Symbol stubs cannot satisfy this contract. */
+export const SourceDocumentSchema = Schema.Struct({
+  kind: Schema.Literal('source-document'),
+  identity: ArtifactIdentitySchema,
+  fidelity: Schema.Literal('actual-source'),
+  uri: DocumentUriSchema,
+  languageId: Schema.optional(Schema.NonEmptyTrimmedString)
+});
+export type SourceDocument = typeof SourceDocumentSchema.Type;
+
+export const SObjectPicklistValueSchema = Schema.Struct({
+  value: Schema.String,
+  label: Schema.optional(Schema.String),
+  active: Schema.optional(Schema.Boolean)
+});
+export type SObjectPicklistValue = typeof SObjectPicklistValueSchema.Type;
+
+/** Runtime capabilities are absent when a provider cannot know them, rather than being invented as false. */
+export const SObjectFieldRuntimeCapabilitiesSchema = Schema.Struct({
+  aggregatable: Schema.Boolean,
+  filterable: Schema.Boolean,
+  groupable: Schema.Boolean,
+  nillable: Schema.Boolean,
+  sortable: Schema.Boolean
+});
+export type SObjectFieldRuntimeCapabilities = typeof SObjectFieldRuntimeCapabilitiesSchema.Type;
+
+export const SObjectSemanticFieldSchema = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  label: Schema.optional(Schema.String),
+  type: Schema.optional(Schema.NonEmptyTrimmedString),
+  custom: Schema.optional(Schema.Boolean),
+  defaultValue: Schema.optional(Schema.Unknown),
+  inlineHelpText: Schema.optional(Schema.String),
+  length: Schema.optional(Schema.Number),
+  precision: Schema.optional(Schema.Number),
+  scale: Schema.optional(Schema.Number),
+  referenceTo: Schema.NonEmptyTrimmedString.pipe(Schema.Array, Schema.optional),
+  relationshipName: Schema.optional(Schema.String),
+  picklistValues: SObjectPicklistValueSchema.pipe(Schema.Array, Schema.optional),
+  runtimeCapabilities: Schema.optional(SObjectFieldRuntimeCapabilitiesSchema),
+  definitionUri: Schema.optional(DocumentUriSchema)
+});
+export type SObjectSemanticField = typeof SObjectSemanticFieldSchema.Type;
+
+export const SObjectChildRelationshipSchema = Schema.Struct({
+  childSObject: Schema.NonEmptyTrimmedString,
+  field: Schema.NonEmptyTrimmedString,
+  relationshipName: Schema.optional(Schema.String)
+});
+export type SObjectChildRelationship = typeof SObjectChildRelationshipSchema.Type;
+
+/**
+ * Canonical SObject facts shared by workspace metadata and org providers. Provider-specific facts are optional so
+ * an incomplete workspace declaration remains truthful and can later be enriched by REST or Symbol Table data.
+ */
+export const SObjectSemanticValueSchema = Schema.Struct({
+  identity: SObjectArtifactIdentitySchema,
+  label: Schema.optional(Schema.String),
+  pluralLabel: Schema.optional(Schema.String),
+  custom: Schema.optional(Schema.Boolean),
+  queryable: Schema.optional(Schema.Boolean),
+  fields: Schema.Array(SObjectSemanticFieldSchema),
+  childRelationships: SObjectChildRelationshipSchema.pipe(Schema.Array, Schema.optional),
+  definitionUri: Schema.optional(DocumentUriSchema)
+});
+export type SObjectSemanticValue = typeof SObjectSemanticValueSchema.Type;
+
+export const SObjectSemanticModelSchema = Schema.Struct({
+  kind: Schema.Literal('sobject'),
+  value: SObjectSemanticValueSchema
+});
+export type SObjectSemanticModel = typeof SObjectSemanticModelSchema.Type;
+
+type ApexTypeReferenceValue = {
+  readonly namespacePrefix: ArtifactNamespace;
+  readonly name: string;
+  readonly typeParameters: readonly ApexTypeReferenceValue[] | null;
+};
+
+/** Canonical recursive Apex type reference: nullable provider fields are explicit rather than omitted. */
+export const ApexTypeReferenceSchema: Schema.Schema<ApexTypeReferenceValue> = Schema.Struct({
+  namespacePrefix: ArtifactNamespaceSchema,
+  name: Schema.NonEmptyTrimmedString,
+  typeParameters: Schema.suspend(() => ApexTypeReferenceSchema).pipe(Schema.Array, Schema.NullOr)
+});
+export type ApexTypeReference = typeof ApexTypeReferenceSchema.Type;
+
+const NullableDocumentationSchema = Schema.NullOr(Schema.String);
+
+export const ApexAnnotationParameterStubSchema = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  type: ApexTypeReferenceSchema,
+  value: Schema.String
+});
+export type ApexAnnotationParameterStub = typeof ApexAnnotationParameterStubSchema.Type;
+
+export const ApexAnnotationStubSchema = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  parameters: Schema.Array(ApexAnnotationParameterStubSchema),
+  documentation: NullableDocumentationSchema
+});
+export type ApexAnnotationStub = typeof ApexAnnotationStubSchema.Type;
+
+export const ApexAccessorStubSchema = Schema.Struct({
+  modifiers: Schema.Array(Schema.String),
+  documentation: NullableDocumentationSchema
+});
+export type ApexAccessorStub = typeof ApexAccessorStubSchema.Type;
+
+export const ApexParameterStubSchema = Schema.Struct({
+  name: Schema.NullOr(Schema.String),
+  type: Schema.NullOr(ApexTypeReferenceSchema),
+  annotations: Schema.Array(ApexAnnotationStubSchema),
+  documentation: NullableDocumentationSchema
+});
+export type ApexParameterStub = typeof ApexParameterStubSchema.Type;
+
+export const ApexMethodStubSchema = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  isConstructor: Schema.NullOr(Schema.Boolean),
+  returnType: Schema.NullOr(ApexTypeReferenceSchema),
+  modifiers: Schema.Array(Schema.String),
+  annotations: Schema.Array(ApexAnnotationStubSchema),
+  parameters: Schema.Array(ApexParameterStubSchema),
+  documentation: NullableDocumentationSchema,
+  definingType: Schema.NullOr(ApexTypeReferenceSchema)
+});
+export type ApexMethodStub = typeof ApexMethodStubSchema.Type;
+
+export const ApexFieldStubSchema = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  type: Schema.NullOr(ApexTypeReferenceSchema),
+  modifiers: Schema.Array(Schema.String),
+  annotations: Schema.Array(ApexAnnotationStubSchema),
+  documentation: NullableDocumentationSchema,
+  definingType: Schema.NullOr(ApexTypeReferenceSchema)
+});
+export type ApexFieldStub = typeof ApexFieldStubSchema.Type;
+
+export const ApexPropertyStubSchema = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  type: Schema.NullOr(ApexTypeReferenceSchema),
+  modifiers: Schema.Array(Schema.String),
+  annotations: Schema.Array(ApexAnnotationStubSchema),
+  getter: Schema.NullOr(ApexAccessorStubSchema),
+  setter: Schema.NullOr(ApexAccessorStubSchema),
+  documentation: NullableDocumentationSchema,
+  definingType: Schema.NullOr(ApexTypeReferenceSchema)
+});
+export type ApexPropertyStub = typeof ApexPropertyStubSchema.Type;
+
+export const ApexTypeKindSchema = Schema.Literal('CLASS', 'INTERFACE', 'ENUM', 'TRIGGER');
+export type ApexTypeKind = typeof ApexTypeKindSchema.Type;
+
+type ApexTypeStubValue = {
+  readonly name: string;
+  readonly namespacePrefix: ArtifactNamespace;
+  readonly kind: ApexTypeKind;
+  readonly modifiers: readonly string[];
+  readonly annotations: readonly ApexAnnotationStub[];
+  readonly superClass: ApexTypeReference | null;
+  readonly interfaces: readonly ApexTypeReference[];
+  readonly fields: readonly ApexFieldStub[];
+  readonly properties: readonly ApexPropertyStub[];
+  readonly methods: readonly ApexMethodStub[];
+  readonly innerTypes: readonly ApexTypeStubValue[];
+  readonly triggerOperations: readonly string[] | null;
+  readonly triggerObjectType: ApexTypeReference | null;
+  readonly documentation: string | null;
+  readonly compileError: string | null;
+};
+
+export const ApexTypeStubSchema: Schema.Schema<ApexTypeStubValue> = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  namespacePrefix: ArtifactNamespaceSchema,
+  kind: ApexTypeKindSchema,
+  modifiers: Schema.Array(Schema.String),
+  annotations: Schema.Array(ApexAnnotationStubSchema),
+  superClass: Schema.NullOr(ApexTypeReferenceSchema),
+  interfaces: Schema.Array(ApexTypeReferenceSchema),
+  fields: Schema.Array(ApexFieldStubSchema),
+  properties: Schema.Array(ApexPropertyStubSchema),
+  methods: Schema.Array(ApexMethodStubSchema),
+  innerTypes: Schema.Array(Schema.suspend(() => ApexTypeStubSchema)),
+  triggerOperations: Schema.String.pipe(Schema.Array, Schema.NullOr),
+  triggerObjectType: Schema.NullOr(ApexTypeReferenceSchema),
+  documentation: NullableDocumentationSchema,
+  compileError: Schema.NullOr(Schema.String)
+});
+export type ApexTypeStub = typeof ApexTypeStubSchema.Type;
+
+export const ApexTypeStubSemanticModelSchema = Schema.Struct({
+  kind: Schema.Literal('apex-type-stub'),
+  identity: ApexTypeArtifactIdentitySchema,
+  value: ApexTypeStubSchema
+});
+export type ApexTypeStubSemanticModel = typeof ApexTypeStubSemanticModelSchema.Type;
+
+export const CanonicalSemanticModelSchema = Schema.Union(SObjectSemanticModelSchema, ApexTypeStubSemanticModelSchema);
+export type CanonicalSemanticModel = typeof CanonicalSemanticModelSchema.Type;
+
+export const CatalogEntryProjectionSchema = Schema.Struct({ kind: Schema.Literal('catalog-entry') });
+export type CatalogEntryProjection = typeof CatalogEntryProjectionSchema.Type;
+
+export const SourceDocumentProjectionSchema = Schema.Struct({ kind: Schema.Literal('source-document') });
+export type SourceDocumentProjection = typeof SourceDocumentProjectionSchema.Type;
+
+export const SObjectSemanticProjectionSchema = Schema.Struct({
+  kind: Schema.Literal('semantic-model'),
+  model: Schema.Literal('sobject')
+});
+export type SObjectSemanticProjection = typeof SObjectSemanticProjectionSchema.Type;
+
+export const ApexTypeStubSemanticProjectionSchema = Schema.Struct({
+  kind: Schema.Literal('semantic-model'),
+  model: Schema.Literal('apex-type-stub')
+});
+export type ApexTypeStubSemanticProjection = typeof ApexTypeStubSemanticProjectionSchema.Type;
+
+export const ArtifactProjectionSchema = Schema.Union(
+  CatalogEntryProjectionSchema,
+  SourceDocumentProjectionSchema,
+  SObjectSemanticProjectionSchema,
+  ApexTypeStubSemanticProjectionSchema
+);
+export type ArtifactProjection = typeof ArtifactProjectionSchema.Type;
+
+export const ProjectionUnavailableReasonSchema = Schema.Literal(
+  'projection-unavailable',
+  'protected-source',
+  'compile-error',
+  'unsupported-org-capability'
+);
+export type ProjectionUnavailableReason = typeof ProjectionUnavailableReasonSchema.Type;
+
+export const ProjectionUnavailableSchema = Schema.Struct({
+  kind: Schema.Literal('projection-unavailable'),
+  reason: ProjectionUnavailableReasonSchema,
+  availableProjections: Schema.Array(ArtifactProjectionSchema)
+});
+export type ProjectionUnavailable = typeof ProjectionUnavailableSchema.Type;
+
+/** Runtime schemas exposed through the VS Code Services extension API. */
+export const ArtifactProjectionSchemas = {
+  DocumentUri: DocumentUriSchema,
+  CatalogEntryDescriptor: CatalogEntryDescriptorSchema,
+  SourceDocument: SourceDocumentSchema,
+  SObjectSemanticModel: SObjectSemanticModelSchema,
+  ApexTypeReference: ApexTypeReferenceSchema,
+  ApexTypeStub: ApexTypeStubSchema,
+  ApexTypeStubSemanticModel: ApexTypeStubSemanticModelSchema,
+  CanonicalSemanticModel: CanonicalSemanticModelSchema,
+  ArtifactProjection: ArtifactProjectionSchema,
+  ProjectionUnavailable: ProjectionUnavailableSchema
+} as const;

--- a/packages/salesforcedx-vscode-services/src/core/projectService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/projectService.ts
@@ -21,6 +21,7 @@ import * as vscode from 'vscode';
 import { URI, Utils } from 'vscode-uri';
 import { toUri } from '../vscode/uriUtils';
 import { WorkspaceService } from '../vscode/workspaceService';
+import { artifactNamespacesEqual, type ArtifactNamespace } from './artifactIdentity';
 import { unknownToErrorCause } from './shared';
 
 export class FailedToResolveSfProjectError extends Schema.TaggedError<FailedToResolveSfProjectError>()(
@@ -128,6 +129,14 @@ const readVsCodeTestWebDiskRootMarker = Effect.promise(async (): Promise<string 
 export const sfProjectCacheKey = (workspaceDirFsPath: string) =>
   Effect.map(readVsCodeTestWebDiskRootMarker, markerPath => markerPath ?? normalize(workspaceDirFsPath));
 
+export const canonicalProjectNamespace = (value: unknown): ArtifactNamespace =>
+  typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+
+export const isWorkspaceNamespaceEligible = (
+  requestedNamespace: ArtifactNamespace,
+  projectNamespace: ArtifactNamespace
+): boolean => artifactNamespacesEqual(requestedNamespace, projectNamespace);
+
 /** VS Code Web test mounts are not readable by Node `SfProject.resolve`; used when resolve fails on the disk key. */
 const workspaceRootSalesforceManifestExistsViaVscodeFs = Effect.promise(async (): Promise<boolean> => {
   const folders = vscode.workspace.workspaceFolders;
@@ -187,6 +196,19 @@ export class ProjectService extends Effect.Service<ProjectService>()('ProjectSer
       yield* setProjectOpenedContext(projectOpenedContext, true, 'workspace_non_empty');
       return project;
     });
+
+    /** Return the canonical project namespace, or null for an explicitly unnamespaced project. */
+    const getProjectNamespace = Effect.fn('ProjectService.getProjectNamespace')(function* () {
+      const project = yield* getSfProject();
+      return canonicalProjectNamespace(project.getSfProjectJson().getContents().namespace);
+    });
+
+    /** Determine whether an exact artifact namespace is eligible for attribution to this workspace. */
+    const isArtifactNamespaceWorkspaceEligible = Effect.fn('ProjectService.isArtifactNamespaceWorkspaceEligible')(
+      function* (requestedNamespace: ArtifactNamespace) {
+        return isWorkspaceNamespaceEligible(requestedNamespace, yield* getProjectNamespace());
+      }
+    );
 
     /** Check if a URI is within any package directory */
     const isInPackageDirectories = Effect.fn('ProjectService.isInPackageDirectories')(function* (uri: URI) {
@@ -271,6 +293,8 @@ export class ProjectService extends Effect.Service<ProjectService>()('ProjectSer
     return {
       isSalesforceProject,
       getSfProject,
+      getProjectNamespace,
+      isArtifactNamespaceWorkspaceEligible,
       isInPackageDirectories,
       ensureInPackageDirectories,
       getSoqlMetadataPath,

--- a/packages/salesforcedx-vscode-services/src/core/transmogrifierService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/transmogrifierService.ts
@@ -9,6 +9,7 @@ import type { SObjectArtifactIdentity } from './artifactIdentity';
 import type { Connection } from '@salesforce/core';
 import * as Effect from 'effect/Effect';
 import * as S from 'effect/Schema';
+import type { URI } from 'vscode-uri';
 import { SObjectSemanticModelSchema, type SObjectSemanticField, type SObjectSemanticModel } from './artifactProjection';
 
 type RawDescribeSObjectResult = Awaited<ReturnType<Connection['describe']>>;
@@ -68,8 +69,26 @@ export type RestSObjectDescribeTransmogrifierInput = {
   readonly value: DescribeSObjectResult;
 };
 
-/** Discriminated provider-native input; later workspace and Symbol Table adapters extend this union. */
-export type TransmogrifierInput = RestSObjectDescribeTransmogrifierInput;
+export type WorkspaceSObjectMetadataDocument = {
+  readonly fullName: string;
+  readonly metadata: Readonly<Record<string, unknown>>;
+  readonly definitionUri: URI;
+};
+
+/** Structured metadata parsed by SDR. Raw XML is never interpreted by the Transmogrifier. */
+export type WorkspaceSObjectMetadata = {
+  readonly object: WorkspaceSObjectMetadataDocument;
+  readonly fields: readonly WorkspaceSObjectMetadataDocument[];
+};
+
+export type WorkspaceSObjectMetadataTransmogrifierInput = {
+  readonly source: 'workspace-sobject-metadata';
+  readonly identity: SObjectArtifactIdentity;
+  readonly value: WorkspaceSObjectMetadata;
+};
+
+/** Discriminated provider-native input; later Symbol Table adapters extend this union. */
+export type TransmogrifierInput = RestSObjectDescribeTransmogrifierInput | WorkspaceSObjectMetadataTransmogrifierInput;
 
 export class TransmogrifierError extends S.TaggedError<TransmogrifierError>()('TransmogrifierError', {
   source: S.Literal('rest-sobject-describe', 'workspace-sobject-metadata', 'symbol-table-apex'),
@@ -115,6 +134,163 @@ const mapToSObject = (raw: RawDescribeSObjectResult): SObject => ({
 
 const compareName = (left: { readonly name: string }, right: { readonly name: string }): number =>
   left.name < right.name ? -1 : left.name > right.name ? 1 : 0;
+
+const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const metadataValue = (
+  metadata: Readonly<Record<string, unknown>>,
+  metadataType: 'CustomObject' | 'CustomField'
+): Readonly<Record<string, unknown>> => {
+  const wrapped = metadata[metadataType];
+  return isRecord(wrapped) ? wrapped : metadata;
+};
+
+const asArray = (value: unknown): readonly unknown[] =>
+  Array.isArray(value) ? value : value === undefined ? [] : [value];
+
+const optionalString = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+
+const optionalNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value !== 'string' || value.trim().length === 0) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const optionalBoolean = (value: unknown): boolean | undefined => {
+  if (typeof value === 'boolean') return value;
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  return undefined;
+};
+
+const workspaceFieldType = (value: unknown): string | undefined => {
+  const metadataType = optionalString(value);
+  if (!metadataType) return undefined;
+  const normalized = metadataType.toLowerCase();
+  const typeMap: Readonly<Record<string, string>> = {
+    autonumber: 'string',
+    checkbox: 'boolean',
+    encryptedtext: 'string',
+    externallookup: 'reference',
+    hierarchy: 'reference',
+    html: 'textarea',
+    indirectlookup: 'reference',
+    longtextarea: 'textarea',
+    lookup: 'reference',
+    masterdetail: 'reference',
+    metadatarelationship: 'reference',
+    multiselectpicklist: 'multipicklist',
+    number: 'double',
+    text: 'string'
+  };
+  return typeMap[normalized] ?? normalized;
+};
+
+const simpleFieldName = (objectName: string, fullName: string): string => {
+  const prefix = `${objectName}.`;
+  return fullName.toLowerCase().startsWith(prefix.toLowerCase()) ? fullName.slice(prefix.length) : fullName;
+};
+
+const workspacePicklistValues = (field: Readonly<Record<string, unknown>>) => {
+  const valueSet = isRecord(field.valueSet) ? field.valueSet : undefined;
+  const definition = valueSet && isRecord(valueSet.valueSetDefinition) ? valueSet.valueSetDefinition : undefined;
+  return asArray(definition?.value)
+    .filter(isRecord)
+    .flatMap(value => {
+      const name = optionalString(value.fullName);
+      if (!name) return [];
+      const label = optionalString(value.label);
+      const active = optionalBoolean(value.isActive);
+      return [
+        {
+          value: name,
+          ...(label === undefined ? {} : { label }),
+          ...(active === undefined ? {} : { active })
+        }
+      ];
+    })
+    .toSorted((left, right) => left.value.localeCompare(right.value));
+};
+
+const mapWorkspaceField = (
+  identity: SObjectArtifactIdentity,
+  document: WorkspaceSObjectMetadataDocument,
+  rawField?: Readonly<Record<string, unknown>>
+): SObjectSemanticField | undefined => {
+  const field = rawField ?? metadataValue(document.metadata, 'CustomField');
+  const fullName = optionalString(field.fullName) ?? optionalString(document.fullName);
+  if (!fullName) return undefined;
+  const name = simpleFieldName(identity.name, fullName);
+  const label = optionalString(field.label);
+  const type = workspaceFieldType(field.type);
+  const defaultValue = field.defaultValue;
+  const inlineHelpText = optionalString(field.inlineHelpText);
+  const length = optionalNumber(field.length);
+  const precision = optionalNumber(field.precision);
+  const scale = optionalNumber(field.scale);
+  const referenceTo = asArray(field.referenceTo)
+    .flatMap(value => optionalString(value) ?? [])
+    .toSorted();
+  const relationshipName = optionalString(field.relationshipName);
+  const picklistValues = workspacePicklistValues(field);
+  return {
+    name,
+    ...(label === undefined ? {} : { label }),
+    ...(type === undefined ? {} : { type }),
+    custom: /__(?:c|mdt|e|b|x)$/i.test(name),
+    ...(defaultValue === undefined ? {} : { defaultValue }),
+    ...(inlineHelpText === undefined ? {} : { inlineHelpText }),
+    ...(length === undefined ? {} : { length }),
+    ...(precision === undefined ? {} : { precision }),
+    ...(scale === undefined ? {} : { scale }),
+    ...(referenceTo.length === 0 ? {} : { referenceTo }),
+    ...(relationshipName === undefined ? {} : { relationshipName }),
+    ...(picklistValues.length === 0 ? {} : { picklistValues }),
+    definitionUri: document.definitionUri
+  };
+};
+
+const mapWorkspaceSObjectToSemanticModel = (
+  identity: SObjectArtifactIdentity,
+  workspace: WorkspaceSObjectMetadata
+): SObjectSemanticModel => {
+  const object = metadataValue(workspace.object.metadata, 'CustomObject');
+  const nameField = isRecord(object.nameField) ? object.nameField : undefined;
+  const fields = [
+    ...asArray(object.fields)
+      .filter(isRecord)
+      .map(field => mapWorkspaceField(identity, workspace.object, field)),
+    ...(nameField
+      ? [
+          mapWorkspaceField(identity, workspace.object, {
+            ...nameField,
+            fullName: 'Name'
+          })
+        ]
+      : []),
+    ...workspace.fields.map(document => mapWorkspaceField(identity, document))
+  ].reduce(
+    (byName, field) => (field ? new Map(byName).set(field.name.toLowerCase(), field) : byName),
+    new Map<string, SObjectSemanticField>()
+  );
+
+  const label = optionalString(object.label);
+  const pluralLabel = optionalString(object.pluralLabel);
+  return {
+    kind: 'sobject',
+    value: {
+      identity,
+      ...(label === undefined ? {} : { label }),
+      ...(pluralLabel === undefined ? {} : { pluralLabel }),
+      custom: /__(?:c|mdt|e|b|x)$/i.test(identity.name),
+      fields: [...fields.values()].toSorted(compareName),
+      definitionUri: workspace.object.definitionUri
+    }
+  };
+};
 
 const mapRestFieldToSemanticField = (field: SObjectField): SObjectSemanticField => ({
   name: field.name,
@@ -187,13 +363,16 @@ export class TransmogrifierService extends Effect.Service<TransmogrifierService>
     });
 
     const toSemanticModel = Effect.fn('TransmogrifierService.toSemanticModel')(function* (input: TransmogrifierInput) {
-      const model = mapRestDescribeToSemanticModel(input.identity, input.value);
-      return yield* S.decodeUnknown(SObjectSemanticModelSchema)(model).pipe(
+      const model =
+        input.source === 'rest-sobject-describe'
+          ? mapRestDescribeToSemanticModel(input.identity, input.value)
+          : mapWorkspaceSObjectToSemanticModel(input.identity, input.value);
+      return yield* S.validate(SObjectSemanticModelSchema)(model).pipe(
         Effect.mapError(
           cause =>
             new TransmogrifierError({
               source: input.source,
-              message: 'Failed to transform REST SObject Describe into the canonical semantic model',
+              message: `Failed to transform ${input.source} into the canonical semantic model`,
               cause
             })
         )

--- a/packages/salesforcedx-vscode-services/src/core/transmogrifierService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/transmogrifierService.ts
@@ -5,12 +5,40 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import type { SObjectArtifactIdentity } from './artifactIdentity';
 import type { Connection } from '@salesforce/core';
 import * as Effect from 'effect/Effect';
 import * as S from 'effect/Schema';
 import type { URI } from 'vscode-uri';
-import { SObjectSemanticModelSchema, type SObjectSemanticField, type SObjectSemanticModel } from './artifactProjection';
+import {
+  RawApexTypeStubSchema,
+  type RawApexAnnotationStub,
+  type RawApexFieldStub,
+  type RawApexMethodStub,
+  type RawApexParameterStub,
+  type RawApexPropertyStub,
+  type RawApexTypeReference,
+  type RawApexTypeStub
+} from './apexSymbolTableSchema';
+import {
+  artifactIdentitiesEqual,
+  type ApexTypeArtifactIdentity,
+  type SObjectArtifactIdentity
+} from './artifactIdentity';
+import {
+  ApexTypeStubSemanticModelSchema,
+  SObjectSemanticModelSchema,
+  type ApexAnnotationStub,
+  type ApexFieldStub,
+  type ApexMethodStub,
+  type ApexParameterStub,
+  type ApexPropertyStub,
+  type ApexTypeReference,
+  type ApexTypeStub,
+  type ApexTypeStubSemanticModel,
+  type CanonicalSemanticModel,
+  type SObjectSemanticField,
+  type SObjectSemanticModel
+} from './artifactProjection';
 
 type RawDescribeSObjectResult = Awaited<ReturnType<Connection['describe']>>;
 
@@ -87,8 +115,17 @@ export type WorkspaceSObjectMetadataTransmogrifierInput = {
   readonly value: WorkspaceSObjectMetadata;
 };
 
-/** Discriminated provider-native input; later Symbol Table adapters extend this union. */
-export type TransmogrifierInput = RestSObjectDescribeTransmogrifierInput | WorkspaceSObjectMetadataTransmogrifierInput;
+export type SymbolTableApexTransmogrifierInput = {
+  readonly source: 'symbol-table-apex';
+  readonly identity: ApexTypeArtifactIdentity;
+  readonly value: unknown;
+};
+
+/** Discriminated provider-native inputs normalized into canonical semantic models. */
+export type TransmogrifierInput =
+  | RestSObjectDescribeTransmogrifierInput
+  | WorkspaceSObjectMetadataTransmogrifierInput
+  | SymbolTableApexTransmogrifierInput;
 
 export class TransmogrifierError extends S.TaggedError<TransmogrifierError>()('TransmogrifierError', {
   source: S.Literal('rest-sobject-describe', 'workspace-sobject-metadata', 'symbol-table-apex'),
@@ -292,6 +329,109 @@ const mapWorkspaceSObjectToSemanticModel = (
   };
 };
 
+const compareString = (left: string, right: string): number => left.localeCompare(right);
+
+const compareNamedCanonicalValue = (left: { readonly name: string }, right: { readonly name: string }): number => {
+  const byName = left.name.localeCompare(right.name);
+  return byName === 0 ? JSON.stringify(left).localeCompare(JSON.stringify(right)) : byName;
+};
+
+const mapRawApexTypeReference = (raw: RawApexTypeReference): ApexTypeReference => ({
+  namespacePrefix: raw.namespacePrefix ?? null,
+  name: raw.name,
+  typeParameters: raw.typeParameters?.map(mapRawApexTypeReference) ?? null
+});
+
+const mapRawApexAnnotation = (raw: RawApexAnnotationStub): ApexAnnotationStub => ({
+  name: raw.name,
+  parameters: (raw.parameters ?? [])
+    .map(parameter => ({
+      name: parameter.name,
+      type: mapRawApexTypeReference(parameter.type),
+      value: parameter.value
+    }))
+    .toSorted(compareNamedCanonicalValue),
+  documentation: raw.documentation ?? null
+});
+
+const mapRawApexAnnotations = (raw: readonly RawApexAnnotationStub[] | null | undefined) =>
+  (raw ?? []).map(mapRawApexAnnotation).toSorted(compareNamedCanonicalValue);
+
+const mapRawApexParameter = (raw: RawApexParameterStub): ApexParameterStub => ({
+  name: raw.name ?? null,
+  type: raw.type ? mapRawApexTypeReference(raw.type) : null,
+  annotations: mapRawApexAnnotations(raw.annotations),
+  documentation: raw.documentation ?? null
+});
+
+const mapRawApexField = (raw: RawApexFieldStub): ApexFieldStub => ({
+  name: raw.name,
+  type: raw.type ? mapRawApexTypeReference(raw.type) : null,
+  modifiers: (raw.modifiers ?? []).toSorted(compareString),
+  annotations: mapRawApexAnnotations(raw.annotations),
+  documentation: raw.documentation ?? null,
+  definingType: raw.definingType ? mapRawApexTypeReference(raw.definingType) : null
+});
+
+const mapRawApexProperty = (raw: RawApexPropertyStub): ApexPropertyStub => ({
+  name: raw.name,
+  type: raw.type ? mapRawApexTypeReference(raw.type) : null,
+  modifiers: (raw.modifiers ?? []).toSorted(compareString),
+  annotations: mapRawApexAnnotations(raw.annotations),
+  getter: raw.getter
+    ? {
+        modifiers: (raw.getter.modifiers ?? []).toSorted(compareString),
+        documentation: raw.getter.documentation ?? null
+      }
+    : null,
+  setter: raw.setter
+    ? {
+        modifiers: (raw.setter.modifiers ?? []).toSorted(compareString),
+        documentation: raw.setter.documentation ?? null
+      }
+    : null,
+  documentation: raw.documentation ?? null,
+  definingType: raw.definingType ? mapRawApexTypeReference(raw.definingType) : null
+});
+
+const mapRawApexMethod = (raw: RawApexMethodStub): ApexMethodStub => ({
+  name: raw.name,
+  isConstructor: raw.isConstructor ?? null,
+  returnType: raw.returnType ? mapRawApexTypeReference(raw.returnType) : null,
+  modifiers: (raw.modifiers ?? []).toSorted(compareString),
+  annotations: mapRawApexAnnotations(raw.annotations),
+  parameters: (raw.parameters ?? []).map(mapRawApexParameter),
+  documentation: raw.documentation ?? null,
+  definingType: raw.definingType ? mapRawApexTypeReference(raw.definingType) : null
+});
+
+const mapRawApexTypeStub = (raw: RawApexTypeStub): ApexTypeStub => ({
+  name: raw.name,
+  namespacePrefix: raw.namespacePrefix ?? null,
+  kind: raw.kind,
+  modifiers: (raw.modifiers ?? []).toSorted(compareString),
+  annotations: mapRawApexAnnotations(raw.annotations),
+  superClass: raw.superClass ? mapRawApexTypeReference(raw.superClass) : null,
+  interfaces: (raw.interfaces ?? []).map(mapRawApexTypeReference).toSorted(compareNamedCanonicalValue),
+  fields: (raw.fields ?? []).map(mapRawApexField).toSorted(compareNamedCanonicalValue),
+  properties: (raw.properties ?? []).map(mapRawApexProperty).toSorted(compareNamedCanonicalValue),
+  methods: (raw.methods ?? []).map(mapRawApexMethod).toSorted(compareNamedCanonicalValue),
+  innerTypes: (raw.innerTypes ?? []).map(mapRawApexTypeStub).toSorted(compareNamedCanonicalValue),
+  triggerOperations: raw.triggerOperations?.toSorted(compareString) ?? null,
+  triggerObjectType: raw.triggerObjectType ? mapRawApexTypeReference(raw.triggerObjectType) : null,
+  documentation: raw.documentation ?? null,
+  compileError: raw.compileError ?? null
+});
+
+const mapSymbolTableApexToSemanticModel = (
+  identity: ApexTypeArtifactIdentity,
+  raw: RawApexTypeStub
+): ApexTypeStubSemanticModel => ({
+  kind: 'apex-type-stub',
+  identity,
+  value: mapRawApexTypeStub(raw)
+});
+
 const mapRestFieldToSemanticField = (field: SObjectField): SObjectSemanticField => ({
   name: field.name,
   label: field.label,
@@ -362,22 +502,59 @@ export class TransmogrifierService extends Effect.Service<TransmogrifierService>
       return yield* S.decodeUnknown(SObjectSchema)(input);
     });
 
-    const toSemanticModel = Effect.fn('TransmogrifierService.toSemanticModel')(function* (input: TransmogrifierInput) {
-      const model =
-        input.source === 'rest-sobject-describe'
-          ? mapRestDescribeToSemanticModel(input.identity, input.value)
-          : mapWorkspaceSObjectToSemanticModel(input.identity, input.value);
-      return yield* S.validate(SObjectSemanticModelSchema)(model).pipe(
-        Effect.mapError(
-          cause =>
-            new TransmogrifierError({
+    const toSemanticModel: (input: TransmogrifierInput) => Effect.Effect<CanonicalSemanticModel, TransmogrifierError> =
+      Effect.fn('TransmogrifierService.toSemanticModel')(function* (input: TransmogrifierInput) {
+        if (input.source === 'symbol-table-apex') {
+          const raw = yield* S.decodeUnknown(RawApexTypeStubSchema)(input.value).pipe(
+            Effect.mapError(
+              cause =>
+                new TransmogrifierError({
+                  source: input.source,
+                  message: 'Failed to validate the Symbol Table Apex payload',
+                  cause
+                })
+            )
+          );
+          const providerIdentity: ApexTypeArtifactIdentity = {
+            kind: 'apex-type',
+            namespace: raw.namespacePrefix ?? null,
+            name: raw.name
+          };
+          if (!artifactIdentitiesEqual(input.identity, providerIdentity)) {
+            return yield* new TransmogrifierError({
               source: input.source,
-              message: `Failed to transform ${input.source} into the canonical semantic model`,
-              cause
-            })
-        )
-      );
-    });
+              message: 'Symbol Table Apex payload identity does not match the requested artifact identity',
+              cause: { requested: input.identity, received: providerIdentity }
+            });
+          }
+          return yield* S.validate(ApexTypeStubSemanticModelSchema)(
+            mapSymbolTableApexToSemanticModel(providerIdentity, raw)
+          ).pipe(
+            Effect.mapError(
+              cause =>
+                new TransmogrifierError({
+                  source: input.source,
+                  message: 'Failed to transform Symbol Table Apex into the canonical semantic model',
+                  cause
+                })
+            )
+          );
+        }
+        const model =
+          input.source === 'rest-sobject-describe'
+            ? mapRestDescribeToSemanticModel(input.identity, input.value)
+            : mapWorkspaceSObjectToSemanticModel(input.identity, input.value);
+        return yield* S.validate(SObjectSemanticModelSchema)(model).pipe(
+          Effect.mapError(
+            cause =>
+              new TransmogrifierError({
+                source: input.source,
+                message: `Failed to transform ${input.source} into the canonical semantic model`,
+                cause
+              })
+          )
+        );
+      });
 
     return { toMinimalSObject, decodeSObject, toSemanticModel, SObjectSchema };
   })

--- a/packages/salesforcedx-vscode-services/src/core/transmogrifierService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/transmogrifierService.ts
@@ -5,9 +5,11 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import type { SObjectArtifactIdentity } from './artifactIdentity';
 import type { Connection } from '@salesforce/core';
 import * as Effect from 'effect/Effect';
 import * as S from 'effect/Schema';
+import { SObjectSemanticModelSchema, type SObjectSemanticField, type SObjectSemanticModel } from './artifactProjection';
 
 type RawDescribeSObjectResult = Awaited<ReturnType<Connection['describe']>>;
 
@@ -60,6 +62,21 @@ export type SObject = S.Schema.Type<typeof SObjectSchema>;
 export type SObjectField = S.Schema.Type<typeof SObjectFieldSchema>;
 export type ChildRelationship = S.Schema.Type<typeof ChildRelationshipSchema>;
 
+export type RestSObjectDescribeTransmogrifierInput = {
+  readonly source: 'rest-sobject-describe';
+  readonly identity: SObjectArtifactIdentity;
+  readonly value: DescribeSObjectResult;
+};
+
+/** Discriminated provider-native input; later workspace and Symbol Table adapters extend this union. */
+export type TransmogrifierInput = RestSObjectDescribeTransmogrifierInput;
+
+export class TransmogrifierError extends S.TaggedError<TransmogrifierError>()('TransmogrifierError', {
+  source: S.Literal('rest-sobject-describe', 'workspace-sobject-metadata', 'symbol-table-apex'),
+  message: S.String,
+  cause: S.optional(S.Unknown)
+}) {}
+
 const mapToSObject = (raw: RawDescribeSObjectResult): SObject => ({
   name: raw.name,
   label: raw.label,
@@ -96,6 +113,65 @@ const mapToSObject = (raw: RawDescribeSObjectResult): SObject => ({
   }))
 });
 
+const compareName = (left: { readonly name: string }, right: { readonly name: string }): number =>
+  left.name < right.name ? -1 : left.name > right.name ? 1 : 0;
+
+const mapRestFieldToSemanticField = (field: SObjectField): SObjectSemanticField => ({
+  name: field.name,
+  label: field.label,
+  type: field.type,
+  custom: field.custom,
+  defaultValue: field.defaultValue,
+  ...(field.inlineHelpText === null ? {} : { inlineHelpText: field.inlineHelpText }),
+  ...(field.length === undefined ? {} : { length: field.length }),
+  ...(field.precision === undefined ? {} : { precision: field.precision }),
+  ...(field.scale === undefined ? {} : { scale: field.scale }),
+  referenceTo: field.referenceTo.toSorted(),
+  ...(field.relationshipName === null ? {} : { relationshipName: field.relationshipName }),
+  picklistValues: field.picklistValues
+    .map(value => ({
+      value: value.value,
+      active: value.active,
+      ...(value.label === null ? {} : { label: value.label })
+    }))
+    .toSorted((left, right) => left.value.localeCompare(right.value)),
+  runtimeCapabilities: {
+    aggregatable: field.aggregatable,
+    filterable: field.filterable,
+    groupable: field.groupable,
+    nillable: field.nillable,
+    sortable: field.sortable
+  }
+});
+
+const mapRestDescribeToSemanticModel = (
+  identity: SObjectArtifactIdentity,
+  raw: DescribeSObjectResult
+): SObjectSemanticModel => {
+  const value = mapToSObject(raw);
+  return {
+    kind: 'sobject',
+    value: {
+      identity,
+      label: value.label,
+      custom: value.custom,
+      queryable: value.queryable,
+      fields: value.fields.map(mapRestFieldToSemanticField).toSorted(compareName),
+      childRelationships: value.childRelationships
+        .map(relationship => ({
+          childSObject: relationship.childSObject,
+          field: relationship.field,
+          ...(relationship.relationshipName === null ? {} : { relationshipName: relationship.relationshipName })
+        }))
+        .toSorted((left, right) =>
+          left.childSObject === right.childSObject
+            ? left.field.localeCompare(right.field)
+            : left.childSObject.localeCompare(right.childSObject)
+        )
+    }
+  };
+};
+
 export class TransmogrifierService extends Effect.Service<TransmogrifierService>()('TransmogrifierService', {
   accessors: true,
   dependencies: [],
@@ -110,6 +186,20 @@ export class TransmogrifierService extends Effect.Service<TransmogrifierService>
       return yield* S.decodeUnknown(SObjectSchema)(input);
     });
 
-    return { toMinimalSObject, decodeSObject, SObjectSchema };
+    const toSemanticModel = Effect.fn('TransmogrifierService.toSemanticModel')(function* (input: TransmogrifierInput) {
+      const model = mapRestDescribeToSemanticModel(input.identity, input.value);
+      return yield* S.decodeUnknown(SObjectSemanticModelSchema)(model).pipe(
+        Effect.mapError(
+          cause =>
+            new TransmogrifierError({
+              source: input.source,
+              message: 'Failed to transform REST SObject Describe into the canonical semantic model',
+              cause
+            })
+        )
+      );
+    });
+
+    return { toMinimalSObject, decodeSObject, toSemanticModel, SObjectSchema };
   })
 }) {}

--- a/packages/salesforcedx-vscode-services/src/index.ts
+++ b/packages/salesforcedx-vscode-services/src/index.ts
@@ -19,6 +19,7 @@ import { getActiveMetadataOperationRef } from './core/activeMetadataOperationRef
 import { AliasService } from './core/alias';
 import { watchAliasFile } from './core/aliasFileWatcher';
 import { ApexLogService } from './core/apexLogService';
+import { ApexSymbolTableSchemas } from './core/apexSymbolTableSchema';
 import { ArtifactProjectionSchemas } from './core/artifactProjection';
 import { ComponentSetService } from './core/componentSetService';
 import { watchConfigFiles } from './core/configFileWatcher';
@@ -120,6 +121,7 @@ export type SalesforceVSCodeServicesApi = {
       | WorkspaceService
     >;
     ApexLogService: typeof ApexLogService;
+    ApexSymbolTableSchemas: typeof ApexSymbolTableSchemas;
     AliasService: typeof AliasService;
     ArtifactProjectionSchemas: typeof ArtifactProjectionSchemas;
     TemplateService: typeof TemplateService;
@@ -176,6 +178,29 @@ type PublicSdkLayerFor = (
   Layer.Layer.Error<ReturnType<typeof SdkLayerFor>>
 >;
 export type { AliasService } from './core/alias';
+export {
+  ApexSymbolTableSchemas,
+  RawApexAccessorStubSchema,
+  RawApexAnnotationParameterStubSchema,
+  RawApexAnnotationStubSchema,
+  RawApexFieldStubSchema,
+  RawApexMethodStubSchema,
+  RawApexParameterStubSchema,
+  RawApexPropertyStubSchema,
+  RawApexTypeReferenceSchema,
+  RawApexTypeStubResponseSchema,
+  RawApexTypeStubSchema,
+  type RawApexAccessorStub,
+  type RawApexAnnotationParameterStub,
+  type RawApexAnnotationStub,
+  type RawApexFieldStub,
+  type RawApexMethodStub,
+  type RawApexParameterStub,
+  type RawApexPropertyStub,
+  type RawApexTypeReference,
+  type RawApexTypeStub,
+  type RawApexTypeStubResponse
+} from './core/apexSymbolTableSchema';
 export type { TelemetryIdentitySnapshot } from './core/defaultOrgRef';
 export {
   ApexTypeArtifactIdentitySchema,
@@ -557,6 +582,7 @@ export const activate = async (context: vscode.ExtensionContext): Promise<Salesf
       services: {
         prebuiltServicesDependencies: builtContext,
         ApexLogService,
+        ApexSymbolTableSchemas,
         AliasService,
         ArtifactProjectionSchemas,
         TemplateService,

--- a/packages/salesforcedx-vscode-services/src/index.ts
+++ b/packages/salesforcedx-vscode-services/src/index.ts
@@ -368,7 +368,10 @@ export type {
   SObjectField,
   ChildRelationship,
   TransmogrifierInput,
-  TransmogrifierService
+  TransmogrifierService,
+  WorkspaceSObjectMetadata,
+  WorkspaceSObjectMetadataDocument,
+  WorkspaceSObjectMetadataTransmogrifierInput
 } from './core/transmogrifierService';
 export {
   SObjectSchema,

--- a/packages/salesforcedx-vscode-services/src/index.ts
+++ b/packages/salesforcedx-vscode-services/src/index.ts
@@ -176,6 +176,26 @@ type PublicSdkLayerFor = (
 export type { AliasService } from './core/alias';
 export type { TelemetryIdentitySnapshot } from './core/defaultOrgRef';
 export {
+  ApexTypeArtifactIdentitySchema,
+  ArtifactIdentitySchema,
+  ArtifactNamespaceSchema,
+  ArtifactTargetKindSchema,
+  MetadataComponentArtifactIdentitySchema,
+  SObjectArtifactIdentitySchema,
+  artifactIdentitiesEqual,
+  artifactIdentityKey,
+  artifactNamespacesEqual,
+  normalizeArtifactIdentity,
+  normalizeArtifactIdentityPart,
+  normalizeArtifactNamespace,
+  type ApexTypeArtifactIdentity,
+  type ArtifactIdentity,
+  type ArtifactNamespace,
+  type ArtifactTargetKind,
+  type MetadataComponentArtifactIdentity,
+  type SObjectArtifactIdentity
+} from './core/artifactIdentity';
+export {
   TemplateService,
   type ApexClassCreateOptions,
   type ApexTriggerCreateOptions,

--- a/packages/salesforcedx-vscode-services/src/index.ts
+++ b/packages/salesforcedx-vscode-services/src/index.ts
@@ -366,6 +366,7 @@ export type {
   RestSObjectDescribeTransmogrifierInput,
   SObject,
   SObjectField,
+  SymbolTableApexTransmogrifierInput,
   ChildRelationship,
   TransmogrifierInput,
   TransmogrifierService,

--- a/packages/salesforcedx-vscode-services/src/index.ts
+++ b/packages/salesforcedx-vscode-services/src/index.ts
@@ -19,6 +19,7 @@ import { getActiveMetadataOperationRef } from './core/activeMetadataOperationRef
 import { AliasService } from './core/alias';
 import { watchAliasFile } from './core/aliasFileWatcher';
 import { ApexLogService } from './core/apexLogService';
+import { ArtifactProjectionSchemas } from './core/artifactProjection';
 import { ComponentSetService } from './core/componentSetService';
 import { watchConfigFiles } from './core/configFileWatcher';
 import { ConfigService } from './core/configService';
@@ -120,6 +121,7 @@ export type SalesforceVSCodeServicesApi = {
     >;
     ApexLogService: typeof ApexLogService;
     AliasService: typeof AliasService;
+    ArtifactProjectionSchemas: typeof ArtifactProjectionSchemas;
     TemplateService: typeof TemplateService;
     TemplateType: typeof TemplateType;
     ChannelService: typeof ChannelService;
@@ -195,6 +197,69 @@ export {
   type MetadataComponentArtifactIdentity,
   type SObjectArtifactIdentity
 } from './core/artifactIdentity';
+export {
+  ApexAccessorStubSchema,
+  ApexAnnotationParameterStubSchema,
+  ApexAnnotationStubSchema,
+  ApexFieldStubSchema,
+  ApexMethodStubSchema,
+  ApexParameterStubSchema,
+  ApexPropertyStubSchema,
+  ApexTypeKindSchema,
+  ApexTypeReferenceSchema,
+  ApexTypeStubSchema,
+  ApexTypeStubSemanticModelSchema,
+  ApexTypeStubSemanticProjectionSchema,
+  ArtifactPresenceSchema,
+  ArtifactProjectionSchema,
+  ArtifactProjectionSchemas,
+  ArtifactProviderKindSchema,
+  CanonicalSemanticModelSchema,
+  CatalogEntryDescriptorSchema,
+  CatalogEntryProjectionSchema,
+  DocumentUriSchema,
+  ProjectionUnavailableReasonSchema,
+  ProjectionUnavailableSchema,
+  SObjectChildRelationshipSchema,
+  SObjectFieldRuntimeCapabilitiesSchema,
+  SObjectPicklistValueSchema,
+  SObjectSemanticFieldSchema,
+  SObjectSemanticModelSchema,
+  SObjectSemanticProjectionSchema,
+  SObjectSemanticValueSchema,
+  SourceDocumentProjectionSchema,
+  SourceDocumentSchema,
+  type ApexAccessorStub,
+  type ApexAnnotationParameterStub,
+  type ApexAnnotationStub,
+  type ApexFieldStub,
+  type ApexMethodStub,
+  type ApexParameterStub,
+  type ApexPropertyStub,
+  type ApexTypeKind,
+  type ApexTypeReference,
+  type ApexTypeStub,
+  type ApexTypeStubSemanticModel,
+  type ApexTypeStubSemanticProjection,
+  type ArtifactPresence,
+  type ArtifactProjection,
+  type ArtifactProviderKind,
+  type CanonicalSemanticModel,
+  type CatalogEntryDescriptor,
+  type CatalogEntryProjection,
+  type DocumentUri,
+  type ProjectionUnavailable,
+  type ProjectionUnavailableReason,
+  type SObjectChildRelationship,
+  type SObjectFieldRuntimeCapabilities,
+  type SObjectPicklistValue,
+  type SObjectSemanticField,
+  type SObjectSemanticModel,
+  type SObjectSemanticProjection,
+  type SObjectSemanticValue,
+  type SourceDocument,
+  type SourceDocumentProjection
+} from './core/artifactProjection';
 export {
   TemplateService,
   type ApexClassCreateOptions,
@@ -493,6 +558,7 @@ export const activate = async (context: vscode.ExtensionContext): Promise<Salesf
         prebuiltServicesDependencies: builtContext,
         ApexLogService,
         AliasService,
+        ArtifactProjectionSchemas,
         TemplateService,
         TemplateType,
         ChannelService,

--- a/packages/salesforcedx-vscode-services/src/index.ts
+++ b/packages/salesforcedx-vscode-services/src/index.ts
@@ -363,16 +363,19 @@ export type {
 } from './core/metadataDescribeService';
 export type {
   DescribeSObjectResult,
+  RestSObjectDescribeTransmogrifierInput,
   SObject,
   SObjectField,
   ChildRelationship,
+  TransmogrifierInput,
   TransmogrifierService
 } from './core/transmogrifierService';
 export {
   SObjectSchema,
   SObjectFieldSchema,
   ChildRelationshipSchema,
-  PicklistValueSchema
+  PicklistValueSchema,
+  TransmogrifierError
 } from './core/transmogrifierService';
 export type { ExecuteAnonymousResult } from './core/executeAnonymousService';
 export type { ExecuteAnonymousError } from './errors/executeAnonymousErrors';

--- a/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogInventory.ts
+++ b/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogInventory.ts
@@ -10,7 +10,7 @@ import type { OrgMetadataPresence } from './orgMetadataCatalogTypes';
 import * as Effect from 'effect/Effect';
 import { URI } from 'vscode-uri';
 import { FOLDERED_METADATA_TYPES, MetadataDescribeService } from '../core/metadataDescribeService';
-import { emptyPresence, typeCacheKey } from './orgCatalogKeys';
+import { emptyPresence, findInventoryComponent, typeCacheKey } from './orgCatalogKeys';
 import { mergeInventory, projectChildren } from './orgCatalogProjection';
 import { OrgCatalogState } from './orgCatalogState';
 import { OrgCatalogWorkspace } from './orgCatalogWorkspace';
@@ -62,10 +62,14 @@ export class OrgCatalogInventory extends Effect.Service<OrgCatalogInventory>()('
               : metadataDescribeService
                   .listMetadata(xmlName, undefined, orgId)
                   .pipe(Effect.map(components => ({ components, folders: [] })));
-        const [orgListing, workspaceUris] = yield* Effect.all(
+        const [orgListing, workspaceInventory] = yield* Effect.all(
           [
             listOrgComponents,
-            workspace.scanWorkspace(xmlName).pipe(Effect.catchAll(() => Effect.succeed(new Map<string, URI>())))
+            workspace
+              .scanWorkspaceInventory(xmlName)
+              .pipe(
+                Effect.catchAll(() => Effect.succeed({ namespace: null, components: new Map<string, URI>() } as const))
+              )
           ],
           { concurrency: 'unbounded' }
         );
@@ -78,7 +82,8 @@ export class OrgCatalogInventory extends Effect.Service<OrgCatalogInventory>()('
             orgId,
             xmlName,
             orgComponents: orgListing.components,
-            workspaceUris,
+            workspaceUris: workspaceInventory.components,
+            workspaceNamespace: workspaceInventory.namespace,
             observedAt
           }),
           folders: new Map(orgListing.folders.map(folder => [folder.fullName, folder]))
@@ -93,8 +98,12 @@ export class OrgCatalogInventory extends Effect.Service<OrgCatalogInventory>()('
       orgId: string,
       reference: OrgMetadataComponentReference
     ) {
-      const cachedEntry = (yield* state.getInventory(orgId, reference.xmlName))?.components.get(reference.fullName);
-      const entry = cachedEntry ?? (yield* loadType(orgId, reference.xmlName)).components.get(reference.fullName);
+      const cachedEntry = findInventoryComponent(
+        (yield* state.getInventory(orgId, reference.xmlName))?.components ?? new Map(),
+        reference
+      );
+      const entry =
+        cachedEntry ?? findInventoryComponent((yield* loadType(orgId, reference.xmlName)).components, reference);
       return entry
         ? ({
             inOrg: entry.inOrg,
@@ -109,9 +118,12 @@ export class OrgCatalogInventory extends Effect.Service<OrgCatalogInventory>()('
       reference: OrgMetadataComponentReference
     ) {
       const cached = yield* state.getInventory(orgId, reference.xmlName);
-      const inventory = cached?.components.has(reference.fullName) ? cached : yield* loadType(orgId, reference.xmlName);
+      const inventory =
+        cached && findInventoryComponent(cached.components, reference)
+          ? cached
+          : yield* loadType(orgId, reference.xmlName);
       return (
-        inventory.components.get(reference.fullName) ??
+        findInventoryComponent(inventory.components, reference) ??
         projectChildren(
           entryUri,
           orgId,

--- a/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogKeys.ts
+++ b/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogKeys.ts
@@ -5,14 +5,54 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import type { OrgMetadataPresence } from './orgMetadataCatalogTypes';
-import type { OrgMetadataComponentReference } from './orgMetadataReference';
+import type { OrgMetadataCatalogInternalEntry, OrgMetadataPresence } from './orgMetadataCatalogTypes';
+import {
+  artifactIdentitiesEqual,
+  artifactIdentityKey,
+  type ArtifactNamespace,
+  type MetadataComponentArtifactIdentity
+} from '../core/artifactIdentity';
+import { isOrgMetadataComponentReference, type OrgMetadataComponentReference } from './orgMetadataReference';
 
 export const emptyPresence = (): OrgMetadataPresence => ({ inOrg: false, inWorkspace: false });
 
+const metadataComponentArtifactIdentity = (
+  reference: OrgMetadataComponentReference,
+  namespace: ArtifactNamespace = null
+): MetadataComponentArtifactIdentity => ({
+  kind: 'metadata-component',
+  metadataType: reference.xmlName,
+  namespace,
+  name: reference.fullName
+});
+
 /** Identity key for a metadata component reference, independent of the org it was observed in. */
-export const componentIdentity = (reference: OrgMetadataComponentReference): string =>
-  `${reference.xmlName}\0${reference.fullName}`;
+export const componentIdentity = (
+  reference: OrgMetadataComponentReference,
+  namespace: ArtifactNamespace = null
+): string => artifactIdentityKey(metadataComponentArtifactIdentity(reference, namespace));
+
+/**
+ * Exact namespace lookup for new callers, with a simple-name compatibility fallback only when namespace is omitted.
+ * The fallback preserves existing catalog APIs until their request references carry required-null namespace identity.
+ */
+export const findInventoryComponent = (
+  components: ReadonlyMap<string, OrgMetadataCatalogInternalEntry>,
+  reference: OrgMetadataComponentReference,
+  namespace?: ArtifactNamespace
+): OrgMetadataCatalogInternalEntry | undefined => {
+  if (namespace !== undefined) return components.get(componentIdentity(reference, namespace));
+  const globalMatch = components.get(componentIdentity(reference));
+  if (globalMatch) return globalMatch;
+  return [...components.values()].find(
+    entry =>
+      isOrgMetadataComponentReference(entry.reference) &&
+      artifactIdentitiesEqual(
+        metadataComponentArtifactIdentity(entry.reference),
+        metadataComponentArtifactIdentity(reference)
+      )
+  );
+};
 
 /**
  * Derives the set of SObject api names whose describe caches are affected by a

--- a/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogProjection.ts
+++ b/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogProjection.ts
@@ -7,7 +7,9 @@
 
 import type { ListedMetadataComponent, TypeInventory } from './orgCatalogInternalTypes';
 import type { OrgMetadataCatalogInternalEntry as OrgMetadataCatalogEntry } from './orgMetadataCatalogTypes';
+import type { ArtifactNamespace } from '../core/artifactIdentity';
 import { URI } from 'vscode-uri';
+import { componentIdentity, findInventoryComponent } from './orgCatalogKeys';
 import { isOrgMetadataComponentReference } from './orgMetadataReference';
 
 export const mergeInventory = ({
@@ -16,6 +18,7 @@ export const mergeInventory = ({
   xmlName,
   orgComponents,
   workspaceUris,
+  workspaceNamespace = null,
   observedAt
 }: {
   readonly entryUri: (orgId: string, xmlName: string, fullName: string) => URI;
@@ -23,11 +26,12 @@ export const mergeInventory = ({
   readonly xmlName: string;
   readonly orgComponents: readonly ListedMetadataComponent[];
   readonly workspaceUris: ReadonlyMap<string, URI>;
+  readonly workspaceNamespace?: ArtifactNamespace;
   readonly observedAt: string;
 }): ReadonlyMap<string, OrgMetadataCatalogEntry> => {
   const orgInventory = orgComponents.reduce(
     (entries, component) =>
-      entries.set(component.fullName, {
+      entries.set(componentIdentity({ xmlName, fullName: component.fullName }, component.namespacePrefix ?? null), {
         orgId,
         observedAt,
         provenance: 'metadata-api',
@@ -47,16 +51,20 @@ export const mergeInventory = ({
     new Map<string, OrgMetadataCatalogEntry>()
   );
   return [...workspaceUris].reduce((entries, [fullName, workspaceUri]) => {
-    const existing = entries.get(fullName);
-    return entries.set(fullName, {
+    const reference = { xmlName, fullName };
+    const key = componentIdentity(reference, workspaceNamespace);
+    const existing = entries.get(key);
+    const canonicalReference =
+      existing && isOrgMetadataComponentReference(existing.reference) ? existing.reference : reference;
+    return entries.set(key, {
       orgId,
       observedAt: existing?.observedAt ?? new Date().toISOString(),
       provenance: existing ? 'metadata-api+workspace' : 'workspace',
-      reference: { xmlName, fullName },
+      reference: canonicalReference,
       documentUri: existing?.documentUri ?? entryUri(orgId, xmlName, fullName),
       name: existing?.name ?? fullName.split('/').at(-1) ?? fullName,
       kind: 'component',
-      namespacePrefix: existing?.namespacePrefix,
+      namespacePrefix: existing?.namespacePrefix ?? workspaceNamespace ?? undefined,
       manageableState: existing?.manageableState,
       fileName: existing?.fileName,
       lastModifiedByName: existing?.lastModifiedByName,
@@ -78,7 +86,10 @@ export const projectChildren = (
 ): OrgMetadataCatalogEntry[] => {
   const prefix = parentFullName ? `${parentFullName}/` : '';
   const childNames = new Set<string>();
-  [...inventory.components.keys(), ...inventory.folders.keys()].forEach(fullName => {
+  const componentFullNames = [...inventory.components.values()].flatMap(component =>
+    isOrgMetadataComponentReference(component.reference) ? [component.reference.fullName] : []
+  );
+  [...componentFullNames, ...inventory.folders.keys()].forEach(fullName => {
     if (!fullName.startsWith(prefix)) return;
     const name = fullName.slice(prefix.length).split('/')[0];
     if (name) childNames.add(name);
@@ -86,9 +97,9 @@ export const projectChildren = (
   return [...childNames]
     .map(name => {
       const fullName = `${prefix}${name}`;
-      const component = inventory.components.get(fullName);
+      const component = findInventoryComponent(inventory.components, { xmlName, fullName });
       const folder = inventory.folders.get(fullName);
-      const hasDescendants = [...inventory.components.keys(), ...inventory.folders.keys()].some(candidate =>
+      const hasDescendants = [...componentFullNames, ...inventory.folders.keys()].some(candidate =>
         candidate.startsWith(`${fullName}/`)
       );
       if (!folder && !hasDescendants && component) return { ...component, name };

--- a/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogRemoteSource.ts
+++ b/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogRemoteSource.ts
@@ -16,7 +16,7 @@ import { ConnectionService } from '../core/connectionService';
 import { unknownToErrorCause } from '../core/shared';
 import { FsService } from '../vscode/fsService';
 import { OrgCatalogInventory } from './orgCatalogInventory';
-import { componentIdentity, typeCacheKey } from './orgCatalogKeys';
+import { componentIdentity, findInventoryComponent, typeCacheKey } from './orgCatalogKeys';
 import { OrgCatalogRemoteRetrieve } from './orgCatalogRemoteRetrieve';
 import { OrgCatalogState } from './orgCatalogState';
 import { OrgMetadataCatalogError } from './orgMetadataCatalogErrors';
@@ -156,8 +156,9 @@ export class OrgCatalogRemoteSource extends Effect.Service<OrgCatalogRemoteSourc
             uniqueReferences,
             reference =>
               Effect.gen(function* () {
-                const loadedEntry = (yield* state.getInventory(orgId, reference.xmlName))?.components.get(
-                  reference.fullName
+                const loadedEntry = findInventoryComponent(
+                  (yield* state.getInventory(orgId, reference.xmlName))?.components ?? new Map(),
+                  reference
                 );
                 const entry = forceRefresh ? loadedEntry : yield* inventories.getEntry(orgId, reference);
                 if (!forceRefresh && !entry?.inOrg) {
@@ -199,7 +200,7 @@ export class OrgCatalogRemoteSource extends Effect.Service<OrgCatalogRemoteSourc
                 const key = typeCacheKey(orgId, reference.xmlName);
                 const inventory = next.get(key);
                 if (!inventory) return;
-                const currentEntry = inventory.components.get(reference.fullName);
+                const currentEntry = findInventoryComponent(inventory.components, reference);
                 const remoteLastModifiedDate = artifact.remoteLastModifiedDate;
                 const updatedEntry: OrgMetadataCatalogEntry = {
                   ...currentEntry,
@@ -218,7 +219,10 @@ export class OrgCatalogRemoteSource extends Effect.Service<OrgCatalogRemoteSourc
                 next.set(key, {
                   ...inventory,
                   observedAt,
-                  components: new Map(inventory.components).set(reference.fullName, updatedEntry)
+                  components: new Map(inventory.components).set(
+                    componentIdentity(reference, currentEntry?.namespacePrefix ?? null),
+                    updatedEntry
+                  )
                 });
               });
               return next;

--- a/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogState.ts
+++ b/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogState.ts
@@ -20,7 +20,7 @@ import * as HashSet from 'effect/HashSet';
 import * as Order from 'effect/Order';
 import * as Queue from 'effect/Queue';
 import * as Ref from 'effect/Ref';
-import { metadataListingKey, sobjectDescriptionKey, typeCacheKey } from './orgCatalogKeys';
+import { componentIdentity, metadataListingKey, sobjectDescriptionKey, typeCacheKey } from './orgCatalogKeys';
 import {
   OrgMetadataCatalogStore,
   type OrgMetadataCatalogSnapshot,
@@ -208,7 +208,7 @@ export class OrgCatalogState extends Effect.Service<OrgCatalogState>()('OrgCatal
                 orgId,
                 new Map(
                   snapshot.tracking.map(observation => [
-                    `${observation.xmlName}\0${observation.fullName}`,
+                    componentIdentity({ xmlName: observation.xmlName, fullName: observation.fullName }),
                     {
                       reference: { xmlName: observation.xmlName, fullName: observation.fullName },
                       signature: observation.signature

--- a/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogTreeProjection.ts
+++ b/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogTreeProjection.ts
@@ -11,6 +11,7 @@ import * as vscode from 'vscode';
 import { MetadataDescribeService } from '../core/metadataDescribeService';
 import { TransmogrifierService } from '../core/transmogrifierService';
 import { OrgCatalogInventory } from './orgCatalogInventory';
+import { findInventoryComponent } from './orgCatalogKeys';
 import { projectChildren } from './orgCatalogProjection';
 import { OrgCatalogState } from './orgCatalogState';
 import { OrgCatalogWorkspace } from './orgCatalogWorkspace';
@@ -126,9 +127,12 @@ export class OrgCatalogTreeProjection extends Effect.Service<OrgCatalogTreeProje
           `${objectEntry.reference.fullName}.${field.name}`,
           `${objectEntry.reference.fullName}.${unqualifiedName}`
         ];
-        const fullName = candidates.find(candidate => fieldInventory.components.has(candidate)) ?? candidates[0];
+        const fullName =
+          candidates.find(candidate =>
+            findInventoryComponent(fieldInventory.components, { xmlName: 'CustomField', fullName: candidate })
+          ) ?? candidates[0];
         if (inventoriedFullNames.has(fullName)) return [];
-        const existing = fieldInventory.components.get(fullName);
+        const existing = findInventoryComponent(fieldInventory.components, { xmlName: 'CustomField', fullName });
         return [
           {
             ...(existing ?? {
@@ -182,7 +186,9 @@ export class OrgCatalogTreeProjection extends Effect.Service<OrgCatalogTreeProje
           .toSorted((left, right) => left.name.localeCompare(right.name));
       }
       const inventory = yield* inventories.loadType(orgId, reference.xmlName);
-      const component = reference.fullName ? inventory.components.get(reference.fullName) : undefined;
+      const component = reference.fullName
+        ? findInventoryComponent(inventory.components, { xmlName: reference.xmlName, fullName: reference.fullName })
+        : undefined;
       if (component && reference.xmlName === 'CustomObject') {
         return yield* getCustomFieldChildren(orgId, component);
       }

--- a/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogWorkspace.ts
+++ b/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogWorkspace.ts
@@ -28,13 +28,16 @@ export class OrgCatalogWorkspace extends Effect.Service<OrgCatalogWorkspace>()('
       MetadataRetrieveService,
       ProjectService
     ]);
-    const scanWorkspace = Effect.fn('OrgCatalogWorkspace.scanWorkspace')(function* (xmlName: string) {
-      const project = yield* projectService.getSfProject();
+    const scanWorkspaceInventory = Effect.fn('OrgCatalogWorkspace.scanWorkspaceInventory')(function* (xmlName: string) {
+      const [project, namespace] = yield* Effect.all([
+        projectService.getSfProject(),
+        projectService.getProjectNamespace()
+      ]);
       const packageDirectories = project.getPackageDirectories().map(directory => directory.fullPath);
       const componentSet = yield* metadataRetrieveService.buildComponentSetFromSource(packageDirectories, [
         { type: xmlName, fullName: '*' }
       ]);
-      return [...componentSet.getSourceComponents()].reduce((workspaceUris, component) => {
+      const components = [...componentSet.getSourceComponents()].reduce((workspaceUris, component) => {
         if (component.type.name !== xmlName) return workspaceUris;
         // Decomposed child metadata (for example CustomField) has an XML source file but no
         // `content` path. Treat the XML path as its workspace artifact so local presence is not
@@ -48,7 +51,12 @@ export class OrgCatalogWorkspace extends Effect.Service<OrgCatalogWorkspace>()('
         }
         return workspaceUris;
       }, new Map<string, URI>());
+      return { namespace, components } as const;
     });
+
+    const scanWorkspace = Effect.fn('OrgCatalogWorkspace.scanWorkspace')((xmlName: string) =>
+      scanWorkspaceInventory(xmlName).pipe(Effect.map(inventory => inventory.components))
+    );
 
     const getWorkspaceMetadataTypes = Effect.fn('OrgCatalogWorkspace.getWorkspaceMetadataTypes')(function* (
       orgId: string
@@ -113,6 +121,6 @@ export class OrgCatalogWorkspace extends Effect.Service<OrgCatalogWorkspace>()('
       return resolutions;
     });
 
-    return { getWorkspaceMetadataTypes, resolveComponents, scanWorkspace } as const;
+    return { getWorkspaceMetadataTypes, resolveComponents, scanWorkspace, scanWorkspaceInventory } as const;
   })
 }) {}

--- a/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogWorkspace.ts
+++ b/packages/salesforcedx-vscode-services/src/orgCatalog/orgCatalogWorkspace.ts
@@ -5,6 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import type { SObjectArtifactIdentity } from '../core/artifactIdentity';
+import type { WorkspaceSObjectMetadata, WorkspaceSObjectMetadataDocument } from '../core/transmogrifierService';
+import * as Data from 'effect/Data';
 import * as Effect from 'effect/Effect';
 import { URI } from 'vscode-uri';
 import { MetadataRetrieveService } from '../core/metadataRetrieveService';
@@ -12,6 +15,11 @@ import { ProjectService } from '../core/projectService';
 import { toUri } from '../vscode/uriUtils';
 import { OrgCatalogState } from './orgCatalogState';
 import { OrgMetadataReferenceService, type OrgMetadataComponentReference } from './orgMetadataReference';
+
+class WorkspaceSObjectMetadataReadError extends Data.TaggedError('WorkspaceSObjectMetadataReadError')<{
+  readonly identity: SObjectArtifactIdentity;
+  readonly cause: unknown;
+}> {}
 
 export class OrgCatalogWorkspace extends Effect.Service<OrgCatalogWorkspace>()('OrgCatalogWorkspace', {
   accessors: true,
@@ -57,6 +65,60 @@ export class OrgCatalogWorkspace extends Effect.Service<OrgCatalogWorkspace>()('
     const scanWorkspace = Effect.fn('OrgCatalogWorkspace.scanWorkspace')((xmlName: string) =>
       scanWorkspaceInventory(xmlName).pipe(Effect.map(inventory => inventory.components))
     );
+
+    const loadSObjectMetadata = Effect.fn('OrgCatalogWorkspace.loadSObjectMetadata')(function* (
+      identity: SObjectArtifactIdentity
+    ) {
+      if (!(yield* projectService.isArtifactNamespaceWorkspaceEligible(identity.namespace))) return null;
+      const project = yield* projectService.getSfProject();
+      const packageDirectories = project.getPackageDirectories().map(directory => directory.fullPath);
+      const componentSet = yield* metadataRetrieveService.buildComponentSetFromSource(packageDirectories, [
+        { type: 'CustomObject', fullName: identity.name }
+      ]);
+      const sourceComponents = [...componentSet.getSourceComponents()];
+      const objectComponent = sourceComponents.find(
+        component =>
+          component.type.name === 'CustomObject' && component.fullName.toLowerCase() === identity.name.toLowerCase()
+      );
+      const objectXml = objectComponent?.xml;
+      if (!objectComponent || !objectXml) return null;
+
+      return yield* Effect.tryPromise({
+        try: async (): Promise<WorkspaceSObjectMetadata> => {
+          const childComponents = [...sourceComponents, ...objectComponent.getChildren()].filter(
+            (component, index, components) =>
+              component.type.name === 'CustomField' &&
+              component.fullName.toLowerCase().startsWith(`${identity.name.toLowerCase()}.`) &&
+              components.findIndex(
+                candidate => candidate.fullName.toLowerCase() === component.fullName.toLowerCase()
+              ) === index
+          );
+          const object: WorkspaceSObjectMetadataDocument = {
+            fullName: objectComponent.fullName,
+            metadata: await objectComponent.parseXml(),
+            definitionUri: toUri(objectXml)
+          };
+          const fields = await Promise.all(
+            childComponents.flatMap(component => {
+              const sourcePath = component.xml ?? component.content;
+              if (!sourcePath) return [];
+              const definitionUri = toUri(sourcePath);
+              return [
+                component.parseXml().then(
+                  (metadata): WorkspaceSObjectMetadataDocument => ({
+                    fullName: component.fullName,
+                    metadata,
+                    definitionUri
+                  })
+                )
+              ];
+            })
+          );
+          return { object, fields };
+        },
+        catch: cause => new WorkspaceSObjectMetadataReadError({ identity, cause })
+      });
+    });
 
     const getWorkspaceMetadataTypes = Effect.fn('OrgCatalogWorkspace.getWorkspaceMetadataTypes')(function* (
       orgId: string
@@ -121,6 +183,12 @@ export class OrgCatalogWorkspace extends Effect.Service<OrgCatalogWorkspace>()('
       return resolutions;
     });
 
-    return { getWorkspaceMetadataTypes, resolveComponents, scanWorkspace, scanWorkspaceInventory } as const;
+    return {
+      getWorkspaceMetadataTypes,
+      loadSObjectMetadata,
+      resolveComponents,
+      scanWorkspace,
+      scanWorkspaceInventory
+    } as const;
   })
 }) {}

--- a/packages/salesforcedx-vscode-services/src/orgCatalog/orgMetadataCatalogRecorder.ts
+++ b/packages/salesforcedx-vscode-services/src/orgCatalog/orgMetadataCatalogRecorder.ts
@@ -16,7 +16,12 @@ import * as Effect from 'effect/Effect';
 import * as PubSub from 'effect/PubSub';
 import type { URI } from 'vscode-uri';
 import { TransmogrifierService, type DescribeSObjectResult } from '../core/transmogrifierService';
-import { componentIdentity, referencesToAffectedSObjects, typeCacheKey } from './orgCatalogKeys';
+import {
+  componentIdentity,
+  findInventoryComponent,
+  referencesToAffectedSObjects,
+  typeCacheKey
+} from './orgCatalogKeys';
 import { OrgCatalogState } from './orgCatalogState';
 import { OrgMetadataCatalogChangePubSub } from './orgMetadataCatalogChangePubSub';
 import { OrgMetadataReferenceService, type OrgMetadataComponentReference } from './orgMetadataReference';
@@ -100,6 +105,7 @@ export class OrgMetadataCatalogRecorder extends Effect.Service<OrgMetadataCatalo
         components: readonly {
           readonly type: string;
           readonly fullName: string;
+          readonly namespacePrefix?: string;
           readonly lastModifiedDate?: string;
           readonly workspaceUri?: URI;
         }[]
@@ -113,7 +119,9 @@ export class OrgMetadataCatalogRecorder extends Effect.Service<OrgMetadataCatalo
             const reference = { xmlName: component.type, fullName: component.fullName };
             const key = typeCacheKey(orgId, component.type);
             const inventory = next.get(key);
-            const previous = inventory?.components.get(component.fullName);
+            const previous = inventory
+              ? findInventoryComponent(inventory.components, reference, component.namespacePrefix ?? null)
+              : undefined;
             const entry: OrgMetadataCatalogEntry = {
               ...previous,
               orgId,
@@ -126,6 +134,7 @@ export class OrgMetadataCatalogRecorder extends Effect.Service<OrgMetadataCatalo
               documentUri: referenceService.documentUri({ orgId, ...reference }),
               name: previous?.name ?? component.fullName.split('/').at(-1) ?? component.fullName,
               kind: 'component',
+              namespacePrefix: component.namespacePrefix ?? previous?.namespacePrefix,
               inOrg: true,
               inWorkspace: Boolean(component.workspaceUri) || (previous?.inWorkspace ?? false),
               workspaceUri: component.workspaceUri ?? previous?.workspaceUri,
@@ -135,7 +144,10 @@ export class OrgMetadataCatalogRecorder extends Effect.Service<OrgMetadataCatalo
             next.set(key, {
               observedAt,
               complete: inventory?.complete ?? false,
-              components: new Map(inventory?.components).set(component.fullName, entry),
+              components: new Map(inventory?.components).set(
+                componentIdentity(reference, component.namespacePrefix ?? null),
+                entry
+              ),
               folders: inventory?.folders ?? new Map()
             });
           });
@@ -265,7 +277,7 @@ export class OrgMetadataCatalogRecorder extends Effect.Service<OrgMetadataCatalo
         yield* state.ensureHydrated(orgId);
         const revisionByIdentity = new Map(
           remoteChanges.map(change => [
-            `${change.type}\0${change.name}`,
+            componentIdentity({ xmlName: change.type, fullName: change.name }),
             JSON.stringify([
               change.revisionCounter,
               change.lastModifiedDate,
@@ -317,7 +329,7 @@ export class OrgMetadataCatalogRecorder extends Effect.Service<OrgMetadataCatalo
           fullName: change.fullName
         }));
         const affectedTypes = new Set(references.map(reference => reference.xmlName));
-        const identities = new Set(references.map(componentIdentity));
+        const identities = new Set(references.map(reference => componentIdentity(reference)));
         const affectedSObjects = referencesToAffectedSObjects(references);
         yield* state.invalidateTypes(orgId, affectedTypes);
         yield* state.removeTracking(orgId, identities);

--- a/packages/salesforcedx-vscode-services/test/jest/core/apexSymbolTableSchema.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/apexSymbolTableSchema.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Schema from 'effect/Schema';
+import {
+  ApexSymbolTableSchemas,
+  RawApexTypeReferenceSchema,
+  RawApexTypeStubResponseSchema
+} from '../../../src/core/apexSymbolTableSchema';
+import * as responseFixture from './fixtures/apexSymbolTableResponse.json';
+
+describe('Apex Symbol Table raw response schemas', () => {
+  it('decodes representative class, interface, enum, trigger, managed-package, and compile-error stubs', () => {
+    const response = Schema.decodeUnknownSync(RawApexTypeStubResponseSchema)(responseFixture);
+
+    expect(response.typeStubs.map(stub => stub.kind)).toEqual(['CLASS', 'INTERFACE', 'ENUM', 'TRIGGER', 'CLASS']);
+    expect(response.typeStubs[0]).toMatchObject({
+      name: 'ManagedOuter',
+      namespacePrefix: 'ExamplePkg',
+      documentation: 'Managed class documentation.'
+    });
+    expect(response.typeStubs[0].innerTypes?.[0].name).toBe('ManagedOuter.Inner');
+    expect(response.typeStubs[3]).toMatchObject({
+      triggerOperations: ['AFTER INSERT', 'BEFORE UPDATE'],
+      triggerObjectType: { namespacePrefix: 'Schema', name: 'Account' }
+    });
+    expect(response.typeStubs[4]).toMatchObject({
+      compileError: 'Unexpected token near line 4',
+      fields: null,
+      methods: null
+    });
+  });
+
+  it('preserves recursive nested generic arguments', () => {
+    const reference = Schema.decodeUnknownSync(RawApexTypeReferenceSchema)({
+      namespacePrefix: 'System',
+      name: 'List',
+      typeParameters: [
+        {
+          name: 'Set',
+          typeParameters: [
+            {
+              name: 'Map',
+              typeParameters: [{ name: 'String' }, { name: 'Object', typeParameters: null }]
+            }
+          ]
+        }
+      ]
+    });
+
+    expect(reference.typeParameters?.[0].typeParameters?.[0].typeParameters?.map(type => type.name)).toEqual([
+      'String',
+      'Object'
+    ]);
+  });
+
+  it('accepts omitted and explicit-null optional provider fields without normalizing them yet', () => {
+    expect(
+      Schema.decodeUnknownSync(ApexSymbolTableSchemas.TypeStub)({
+        name: 'Minimal',
+        kind: 'CLASS'
+      })
+    ).toEqual({ name: 'Minimal', kind: 'CLASS' });
+    expect(
+      Schema.decodeUnknownSync(ApexSymbolTableSchemas.TypeStub)({
+        name: 'NullHeavy',
+        namespacePrefix: null,
+        kind: 'CLASS',
+        modifiers: null,
+        annotations: null,
+        compileError: null
+      })
+    ).toEqual({
+      name: 'NullHeavy',
+      namespacePrefix: null,
+      kind: 'CLASS',
+      modifiers: null,
+      annotations: null,
+      compileError: null
+    });
+  });
+
+  it('rejects malformed type kinds and type references', () => {
+    expect(() =>
+      Schema.decodeUnknownSync(RawApexTypeStubResponseSchema)({
+        typeStubs: [{ name: 'BadKind', kind: 'STRUCT' }]
+      })
+    ).toThrow('CLASS');
+    expect(() => Schema.decodeUnknownSync(RawApexTypeReferenceSchema)({ namespacePrefix: 'System' })).toThrow('name');
+  });
+});

--- a/packages/salesforcedx-vscode-services/test/jest/core/artifactIdentity.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/artifactIdentity.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Schema from 'effect/Schema';
+import {
+  ApexTypeArtifactIdentitySchema,
+  ArtifactIdentitySchema,
+  artifactIdentitiesEqual,
+  artifactIdentityKey,
+  artifactNamespacesEqual,
+  normalizeArtifactIdentity
+} from '../../../src/core/artifactIdentity';
+
+describe('artifact identity', () => {
+  it.each([
+    { kind: 'apex-type', namespace: null, name: 'GlobalType' },
+    { kind: 'apex-type', namespace: 'System', name: 'String' },
+    { kind: 'apex-type', namespace: 'MyPackage', name: 'Outer.Inner' },
+    { kind: 'sobject', namespace: null, name: 'Widget__c' },
+    { kind: 'metadata-component', metadataType: 'ApexClass', namespace: null, name: 'Example' }
+  ] as const)('decodes a canonical $kind identity for $name', identity => {
+    expect(Schema.decodeUnknownSync(ArtifactIdentitySchema)(identity)).toEqual(identity);
+  });
+
+  it('requires an explicit null namespace for a global identity', () => {
+    expect(() =>
+      Schema.decodeUnknownSync(ApexTypeArtifactIdentitySchema)({ kind: 'apex-type', name: 'String' })
+    ).toThrow('namespace');
+    expect(() =>
+      Schema.decodeUnknownSync(ApexTypeArtifactIdentitySchema)({ kind: 'apex-type', namespace: '', name: 'String' })
+    ).toThrow('namespace');
+  });
+
+  it('normalizes comparison fields without changing the canonical input', () => {
+    const identity = {
+      kind: 'metadata-component',
+      metadataType: 'ApexClass',
+      namespace: 'MyPackage',
+      name: 'Outer.Inner'
+    } as const;
+
+    expect(normalizeArtifactIdentity(identity)).toEqual({
+      kind: 'metadata-component',
+      metadataType: 'apexclass',
+      namespace: 'mypackage',
+      name: 'outer.inner'
+    });
+    expect(identity).toEqual({
+      kind: 'metadata-component',
+      metadataType: 'ApexClass',
+      namespace: 'MyPackage',
+      name: 'Outer.Inner'
+    });
+  });
+
+  it('matches namespace and name case-insensitively', () => {
+    expect(
+      artifactIdentitiesEqual(
+        { kind: 'apex-type', namespace: 'System', name: 'String' },
+        { kind: 'apex-type', namespace: 'SYSTEM', name: 'string' }
+      )
+    ).toBe(true);
+    expect(artifactNamespacesEqual('MyPackage', 'mypackage')).toBe(true);
+  });
+
+  it('does not conflate namespace with inner-type qualification', () => {
+    const namespacedInner = { kind: 'apex-type', namespace: 'MyPackage', name: 'Outer.Inner' } as const;
+    const dottedName = { kind: 'apex-type', namespace: null, name: 'MyPackage.Outer.Inner' } as const;
+
+    expect(artifactIdentitiesEqual(namespacedInner, dottedName)).toBe(false);
+    expect(artifactIdentityKey(namespacedInner)).not.toBe(artifactIdentityKey(dottedName));
+  });
+
+  it('distinguishes target kind and metadata type', () => {
+    expect(
+      artifactIdentitiesEqual(
+        { kind: 'apex-type', namespace: null, name: 'Widget__c' },
+        { kind: 'sobject', namespace: null, name: 'Widget__c' }
+      )
+    ).toBe(false);
+    expect(
+      artifactIdentitiesEqual(
+        { kind: 'metadata-component', metadataType: 'ApexClass', namespace: null, name: 'Example' },
+        { kind: 'metadata-component', metadataType: 'ApexTrigger', namespace: null, name: 'Example' }
+      )
+    ).toBe(false);
+  });
+});

--- a/packages/salesforcedx-vscode-services/test/jest/core/artifactProjection.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/artifactProjection.test.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Schema from 'effect/Schema';
+import {
+  ApexTypeStubSchema,
+  ArtifactProjectionSchema,
+  CatalogEntryDescriptorSchema,
+  ProjectionUnavailableSchema,
+  SObjectSemanticModelSchema,
+  SourceDocumentSchema,
+  type SObjectSemanticModel
+} from '../../../src/core/artifactProjection';
+
+const emptyApexStub = (overrides: Record<string, unknown> = {}) => ({
+  name: 'Example',
+  namespacePrefix: null,
+  kind: 'CLASS',
+  modifiers: ['public'],
+  annotations: [],
+  superClass: null,
+  interfaces: [],
+  fields: [],
+  properties: [],
+  methods: [],
+  innerTypes: [],
+  triggerOperations: null,
+  triggerObjectType: null,
+  documentation: null,
+  compileError: null,
+  ...overrides
+});
+
+describe('canonical artifact projections', () => {
+  it('decodes an actual source URI and encodes it back to a JSON-safe string', () => {
+    const input = {
+      kind: 'source-document',
+      identity: { kind: 'apex-type', namespace: null, name: 'WorkspaceClass' },
+      fidelity: 'actual-source',
+      uri: 'file:///workspace/classes/WorkspaceClass.cls',
+      languageId: 'apex'
+    } as const;
+
+    const decoded = Schema.decodeUnknownSync(SourceDocumentSchema)(input);
+
+    expect(decoded.uri.toString()).toBe(input.uri);
+    expect(Schema.encodeSync(SourceDocumentSchema)(decoded)).toEqual(input);
+    expect(() => Schema.decodeUnknownSync(SourceDocumentSchema)({ ...input, fidelity: 'stub-source' })).toThrow(
+      'actual-source'
+    );
+  });
+
+  it('represents truthful partial workspace SObject semantics without fabricated REST capabilities', () => {
+    const decoded: SObjectSemanticModel = Schema.decodeUnknownSync(SObjectSemanticModelSchema)({
+      kind: 'sobject',
+      value: {
+        identity: { kind: 'sobject', namespace: null, name: 'Broker__c' },
+        label: 'Broker',
+        fields: [
+          {
+            name: 'Email__c',
+            type: 'Email',
+            definitionUri: 'file:///workspace/objects/Broker__c/fields/Email__c.field-meta.xml'
+          }
+        ],
+        definitionUri: 'file:///workspace/objects/Broker__c/Broker__c.object-meta.xml'
+      }
+    });
+
+    expect(decoded.value.queryable).toBeUndefined();
+    expect(decoded.value.fields[0].runtimeCapabilities).toBeUndefined();
+    expect(decoded.value.definitionUri?.scheme).toBe('file');
+    expect(decoded.value.fields[0].definitionUri?.path).toContain('Email__c.field-meta.xml');
+  });
+
+  it('accepts REST-known runtime SObject capabilities when they are available', () => {
+    const decoded = Schema.decodeUnknownSync(SObjectSemanticModelSchema)({
+      kind: 'sobject',
+      value: {
+        identity: { kind: 'sobject', namespace: null, name: 'Account' },
+        custom: false,
+        queryable: true,
+        fields: [
+          {
+            name: 'Name',
+            type: 'string',
+            runtimeCapabilities: {
+              aggregatable: true,
+              filterable: true,
+              groupable: true,
+              nillable: false,
+              sortable: true
+            }
+          }
+        ],
+        childRelationships: []
+      }
+    });
+
+    expect(decoded.value.queryable).toBe(true);
+    expect(decoded.value.fields[0].runtimeCapabilities?.nillable).toBe(false);
+  });
+
+  it('decodes recursive Apex inner types and nested generic references', () => {
+    const decoded = Schema.decodeUnknownSync(ApexTypeStubSchema)(
+      emptyApexStub({
+        namespacePrefix: 'MyPackage',
+        name: 'Outer',
+        interfaces: [
+          {
+            namespacePrefix: 'System',
+            name: 'Iterator',
+            typeParameters: [
+              {
+                namespacePrefix: null,
+                name: 'List',
+                typeParameters: [{ namespacePrefix: null, name: 'String', typeParameters: null }]
+              }
+            ]
+          }
+        ],
+        innerTypes: [emptyApexStub({ name: 'Outer.Inner', namespacePrefix: 'MyPackage' })]
+      })
+    );
+
+    expect(decoded.interfaces[0].typeParameters?.[0].typeParameters?.[0].name).toBe('String');
+    expect(decoded.innerTypes[0]).toMatchObject({ name: 'Outer.Inner', namespacePrefix: 'MyPackage' });
+  });
+
+  it('requires explicit canonical nulls that the raw endpoint adapter will normalize', () => {
+    const incomplete: Record<string, unknown> = emptyApexStub();
+    delete incomplete.documentation;
+
+    expect(() => Schema.decodeUnknownSync(ApexTypeStubSchema)(incomplete)).toThrow('documentation');
+  });
+
+  it('decodes catalog descriptors without conflating workspace and org locations', () => {
+    const decoded = Schema.decodeUnknownSync(CatalogEntryDescriptorSchema)({
+      kind: 'catalog-entry',
+      identity: { kind: 'metadata-component', metadataType: 'ApexClass', namespace: null, name: 'Example' },
+      presence: 'both',
+      providers: ['workspace', 'metadata-api'],
+      workspaceUri: 'file:///workspace/classes/Example.cls',
+      orgUri: 'sf-org-metadata:/orgs/00D/ApexClass/Example.cls'
+    });
+
+    expect(decoded.workspaceUri?.scheme).toBe('file');
+    expect(decoded.orgUri?.scheme).toBe('sf-org-metadata');
+  });
+
+  it.each([
+    { kind: 'catalog-entry' },
+    { kind: 'source-document' },
+    { kind: 'semantic-model', model: 'sobject' },
+    { kind: 'semantic-model', model: 'apex-type-stub' }
+  ] as const)('publishes the $kind projection descriptor', projection => {
+    expect(Schema.decodeUnknownSync(ArtifactProjectionSchema)(projection)).toEqual(projection);
+  });
+
+  it('reports projection unavailability separately from not-found', () => {
+    const unavailable = {
+      kind: 'projection-unavailable',
+      reason: 'protected-source',
+      availableProjections: [{ kind: 'catalog-entry' }, { kind: 'semantic-model', model: 'apex-type-stub' }]
+    } as const;
+
+    expect(Schema.decodeUnknownSync(ProjectionUnavailableSchema)(unavailable)).toEqual(unavailable);
+  });
+});

--- a/packages/salesforcedx-vscode-services/test/jest/core/fixtures/apexSymbolTableResponse.json
+++ b/packages/salesforcedx-vscode-services/test/jest/core/fixtures/apexSymbolTableResponse.json
@@ -1,0 +1,115 @@
+{
+  "typeStubs": [
+    {
+      "name": "ManagedOuter",
+      "namespacePrefix": "ExamplePkg",
+      "kind": "CLASS",
+      "modifiers": ["global"],
+      "annotations": [{ "name": "AuraEnabled", "parameters": [], "documentation": null }],
+      "interfaces": [
+        {
+          "namespacePrefix": "System",
+          "name": "Iterator",
+          "typeParameters": [
+            {
+              "name": "List",
+              "typeParameters": [{ "name": "String" }]
+            }
+          ]
+        }
+      ],
+      "fields": [
+        {
+          "name": "items",
+          "type": { "name": "List", "typeParameters": [{ "name": "String" }] },
+          "modifiers": ["global"],
+          "annotations": [],
+          "definingType": { "namespacePrefix": "ExamplePkg", "name": "ManagedBase" }
+        }
+      ],
+      "properties": [
+        {
+          "name": "value",
+          "type": { "name": "String" },
+          "modifiers": ["global"],
+          "annotations": [],
+          "getter": { "modifiers": ["global"], "documentation": "Reads the value." },
+          "setter": null
+        }
+      ],
+      "methods": [
+        {
+          "name": "convert",
+          "returnType": { "name": "String" },
+          "modifiers": ["global"],
+          "annotations": [],
+          "parameters": [
+            {
+              "name": "input",
+              "type": { "name": "Object" },
+              "annotations": [],
+              "documentation": null
+            }
+          ],
+          "documentation": "Converts an input value."
+        }
+      ],
+      "innerTypes": [
+        {
+          "name": "ManagedOuter.Inner",
+          "namespacePrefix": "ExamplePkg",
+          "kind": "CLASS",
+          "modifiers": ["global"],
+          "annotations": [],
+          "interfaces": [],
+          "fields": [],
+          "properties": [],
+          "methods": [],
+          "innerTypes": []
+        }
+      ],
+      "documentation": "Managed class documentation.",
+      "compileError": null
+    },
+    {
+      "name": "RunnableContract",
+      "kind": "INTERFACE",
+      "modifiers": ["public"],
+      "annotations": [],
+      "interfaces": [],
+      "fields": [],
+      "properties": [],
+      "methods": [],
+      "innerTypes": []
+    },
+    {
+      "name": "State",
+      "namespacePrefix": null,
+      "kind": "ENUM",
+      "modifiers": ["public"],
+      "fields": [
+        {
+          "name": "OPEN",
+          "type": { "name": "State" },
+          "modifiers": ["final", "public", "static"],
+          "annotations": []
+        }
+      ]
+    },
+    {
+      "name": "AccountTrigger",
+      "kind": "TRIGGER",
+      "modifiers": ["public"],
+      "triggerOperations": ["AFTER INSERT", "BEFORE UPDATE"],
+      "triggerObjectType": { "namespacePrefix": "Schema", "name": "Account" }
+    },
+    {
+      "name": "BrokenType",
+      "kind": "CLASS",
+      "compileError": "Unexpected token near line 4",
+      "fields": null,
+      "methods": null,
+      "innerTypes": null
+    }
+  ]
+}

--- a/packages/salesforcedx-vscode-services/test/jest/core/projectService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/projectService.test.ts
@@ -11,9 +11,15 @@ import * as Exit from 'effect/Exit';
 import * as Layer from 'effect/Layer';
 import * as Option from 'effect/Option';
 import * as Ref from 'effect/Ref';
+import { SfProject } from '@salesforce/core';
 import * as vscode from 'vscode';
 import { URI } from 'vscode-uri';
-import { ProjectService, setProjectOpenedContext } from '../../../src/core/projectService';
+import {
+  canonicalProjectNamespace,
+  isWorkspaceNamespaceEligible,
+  ProjectService,
+  setProjectOpenedContext
+} from '../../../src/core/projectService';
 import { NoWorkspaceOpenError, WorkspaceService } from '../../../src/vscode/workspaceService';
 
 const workspaceLayer = (uri: URI | undefined) =>
@@ -89,5 +95,60 @@ describe('ProjectService opened context', () => {
     expect(vscode.commands.executeCommand).toHaveBeenNthCalledWith(1, 'setContext', 'sf:project_opened', true);
     expect(vscode.commands.executeCommand).toHaveBeenNthCalledWith(2, 'setContext', 'sf:project_opened', false);
     expect(vscode.commands.executeCommand).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('ProjectService namespace', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    ['MyPackage', 'MyPackage'],
+    ['  MyPackage  ', 'MyPackage'],
+    ['', null],
+    ['   ', null],
+    [undefined, null],
+    [42, null]
+  ])('normalizes project namespace %p to %p', (value, expected) => {
+    expect(canonicalProjectNamespace(value)).toBe(expected);
+  });
+
+  it.each([
+    ['MyPackage', 'mypackage', true],
+    [null, null, true],
+    ['MyPackage', null, false],
+    [null, 'MyPackage', false],
+    ['MyPackage', 'OtherPackage', false]
+  ] as const)(
+    'evaluates requested namespace %p against project namespace %p',
+    (requestedNamespace, projectNamespace, expected) => {
+      expect(isWorkspaceNamespaceEligible(requestedNamespace, projectNamespace)).toBe(expected);
+    }
+  );
+
+  it('reads canonical namespace casing through ProjectService', async () => {
+    jest.spyOn(SfProject, 'resolve').mockResolvedValue({
+      getSfProjectJson: () => ({ getContents: () => ({ namespace: 'MyPackage' }) })
+    } as unknown as SfProject);
+
+    const namespace = await Effect.runPromise(
+      ProjectService.getProjectNamespace().pipe(Effect.provide(layerFor(URI.file('/project-namespace'))))
+    );
+
+    expect(namespace).toBe('MyPackage');
+  });
+
+  it('reports a missing Salesforce project as a typed resolution failure', async () => {
+    jest.spyOn(SfProject, 'resolve').mockRejectedValue(new Error('not a Salesforce project'));
+
+    const exit = await Effect.runPromiseExit(
+      ProjectService.getProjectNamespace().pipe(Effect.provide(layerFor(URI.file('/missing-project-namespace'))))
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    expect(Exit.isFailure(exit) ? Option.getOrUndefined(Cause.failureOption(exit.cause)) : undefined).toMatchObject({
+      _tag: 'FailedToResolveSfProjectError'
+    });
   });
 });

--- a/packages/salesforcedx-vscode-services/test/jest/core/templateService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/templateService.test.ts
@@ -80,6 +80,8 @@ const createMockProjectService = (): Layer.Layer<ProjectService> => {
     ProjectService.make({
       isSalesforceProject: () => Effect.succeed(true),
       getSfProject: () => Effect.succeed(mockSfProject),
+      getProjectNamespace: () => Effect.succeed(null),
+      isArtifactNamespaceWorkspaceEligible: namespace => Effect.succeed(namespace === null),
       isInPackageDirectories: () => Effect.succeed(true),
       ensureInPackageDirectories: () => Effect.void,
       getSoqlMetadataPath: () => Effect.succeed(URI.file('/test/soql')),

--- a/packages/salesforcedx-vscode-services/test/jest/core/transmogrifierService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/transmogrifierService.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Effect from 'effect/Effect';
+import { TransmogrifierService, type DescribeSObjectResult } from '../../../src/core/transmogrifierService';
+
+const describeResult = {
+  name: 'Broker__c',
+  label: 'Broker',
+  custom: true,
+  queryable: true,
+  fields: [
+    {
+      name: 'Zed__c',
+      label: 'Zed',
+      type: 'string',
+      custom: true,
+      aggregatable: true,
+      defaultValue: null,
+      extraTypeInfo: null,
+      filterable: true,
+      groupable: true,
+      inlineHelpText: null,
+      length: 80,
+      nillable: true,
+      picklistValues: [],
+      referenceTo: [],
+      relationshipName: null,
+      sortable: true
+    },
+    {
+      name: 'Account__c',
+      label: 'Account',
+      type: 'reference',
+      custom: true,
+      aggregatable: false,
+      defaultValue: null,
+      extraTypeInfo: null,
+      filterable: true,
+      groupable: false,
+      inlineHelpText: 'Related account',
+      nillable: false,
+      picklistValues: [],
+      referenceTo: ['Account'],
+      relationshipName: 'Account__r',
+      sortable: true
+    }
+  ],
+  childRelationships: [{ childSObject: 'Deal__c', field: 'Broker__c', relationshipName: 'Deals__r' }]
+} as unknown as DescribeSObjectResult;
+
+const run = <A, E>(effect: Effect.Effect<A, E, TransmogrifierService>): Promise<A> =>
+  Effect.runPromise(effect.pipe(Effect.provide(TransmogrifierService.Default)));
+
+describe('TransmogrifierService', () => {
+  it('preserves the existing minimal SObject operation', async () => {
+    const result = await run(
+      TransmogrifierService.pipe(Effect.flatMap(service => service.toMinimalSObject(describeResult)))
+    );
+
+    expect(result.name).toBe('Broker__c');
+    expect(result.fields.map(field => field.name)).toEqual(['Zed__c', 'Account__c']);
+    expect(result.fields[1]).toMatchObject({ referenceTo: ['Account'], relationshipName: 'Account__r' });
+  });
+
+  it('transforms REST Describe through one discriminated canonical boundary', async () => {
+    const result = await run(
+      TransmogrifierService.pipe(
+        Effect.flatMap(service =>
+          service.toSemanticModel({
+            source: 'rest-sobject-describe',
+            identity: { kind: 'sobject', namespace: null, name: 'Broker__c' },
+            value: describeResult
+          })
+        )
+      )
+    );
+
+    expect(result).toMatchObject({
+      kind: 'sobject',
+      value: {
+        identity: { kind: 'sobject', namespace: null, name: 'Broker__c' },
+        label: 'Broker',
+        custom: true,
+        queryable: true
+      }
+    });
+    expect(result.value.fields.map(field => field.name)).toEqual(['Account__c', 'Zed__c']);
+    expect(result.value.fields[0]).toMatchObject({
+      referenceTo: ['Account'],
+      runtimeCapabilities: { filterable: true, nillable: false }
+    });
+  });
+});

--- a/packages/salesforcedx-vscode-services/test/jest/core/transmogrifierService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/transmogrifierService.test.ts
@@ -6,6 +6,7 @@
  */
 
 import * as Effect from 'effect/Effect';
+import { URI } from 'vscode-uri';
 import { TransmogrifierService, type DescribeSObjectResult } from '../../../src/core/transmogrifierService';
 
 const describeResult = {
@@ -94,5 +95,91 @@ describe('TransmogrifierService', () => {
       referenceTo: ['Account'],
       runtimeCapabilities: { filterable: true, nillable: false }
     });
+  });
+
+  it('transforms SDR-parsed workspace metadata without inventing runtime capabilities', async () => {
+    const objectUri = URI.file('/workspace/force-app/main/default/objects/Broker__c/Broker__c.object-meta.xml');
+    const accountFieldUri = URI.file(
+      '/workspace/force-app/main/default/objects/Broker__c/fields/Account__c.field-meta.xml'
+    );
+    const incompleteFieldUri = URI.file(
+      '/workspace/force-app/main/default/objects/Broker__c/fields/Incomplete__c.field-meta.xml'
+    );
+    const result = await run(
+      TransmogrifierService.pipe(
+        Effect.flatMap(service =>
+          service.toSemanticModel({
+            source: 'workspace-sobject-metadata',
+            identity: { kind: 'sobject', namespace: null, name: 'Broker__c' },
+            value: {
+              object: {
+                fullName: 'Broker__c',
+                definitionUri: objectUri,
+                metadata: {
+                  CustomObject: {
+                    label: 'Broker',
+                    pluralLabel: 'Brokers',
+                    nameField: { label: 'Broker Number', type: 'AutoNumber' },
+                    fields: {
+                      fullName: 'Legacy__c',
+                      label: 'Legacy',
+                      type: 'Checkbox',
+                      defaultValue: 'false'
+                    }
+                  }
+                }
+              },
+              fields: [
+                {
+                  fullName: 'Broker__c.Account__c',
+                  definitionUri: accountFieldUri,
+                  metadata: {
+                    CustomField: {
+                      fullName: 'Account__c',
+                      label: 'Account',
+                      type: 'Lookup',
+                      referenceTo: 'Account',
+                      relationshipName: 'Account__r',
+                      inlineHelpText: 'Related account'
+                    }
+                  }
+                },
+                {
+                  fullName: 'Broker__c.Incomplete__c',
+                  definitionUri: incompleteFieldUri,
+                  metadata: { CustomField: { label: 'Incomplete' } }
+                }
+              ]
+            }
+          })
+        )
+      )
+    );
+
+    expect(result).toMatchObject({
+      kind: 'sobject',
+      value: {
+        identity: { kind: 'sobject', namespace: null, name: 'Broker__c' },
+        label: 'Broker',
+        pluralLabel: 'Brokers',
+        custom: true,
+        definitionUri: objectUri
+      }
+    });
+    expect(result.value.fields.map(field => field.name)).toEqual(['Account__c', 'Incomplete__c', 'Legacy__c', 'Name']);
+    expect(result.value.fields[0]).toMatchObject({
+      type: 'reference',
+      referenceTo: ['Account'],
+      relationshipName: 'Account__r',
+      definitionUri: accountFieldUri
+    });
+    expect(result.value.fields[0]).not.toHaveProperty('runtimeCapabilities');
+    expect(result.value.fields[1]).toEqual({
+      name: 'Incomplete__c',
+      label: 'Incomplete',
+      custom: true,
+      definitionUri: incompleteFieldUri
+    });
+    expect(result.value.fields[3]).toMatchObject({ name: 'Name', type: 'string', custom: false });
   });
 });

--- a/packages/salesforcedx-vscode-services/test/jest/core/transmogrifierService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/transmogrifierService.test.ts
@@ -8,6 +8,7 @@
 import * as Effect from 'effect/Effect';
 import { URI } from 'vscode-uri';
 import { TransmogrifierService, type DescribeSObjectResult } from '../../../src/core/transmogrifierService';
+import * as symbolTableResponse from './fixtures/apexSymbolTableResponse.json';
 
 const describeResult = {
   name: 'Broker__c',
@@ -181,5 +182,168 @@ describe('TransmogrifierService', () => {
       definitionUri: incompleteFieldUri
     });
     expect(result.value.fields[3]).toMatchObject({ name: 'Name', type: 'string', custom: false });
+  });
+
+  it('validates and normalizes recursive Symbol Table Apex payloads', async () => {
+    const result = await run(
+      TransmogrifierService.pipe(
+        Effect.flatMap(service =>
+          service.toSemanticModel({
+            source: 'symbol-table-apex',
+            identity: { kind: 'apex-type', namespace: 'examplepkg', name: 'managedouter' },
+            value: symbolTableResponse.typeStubs[0]
+          })
+        )
+      )
+    );
+
+    expect(result).toMatchObject({
+      kind: 'apex-type-stub',
+      identity: { kind: 'apex-type', namespace: 'ExamplePkg', name: 'ManagedOuter' },
+      value: {
+        namespacePrefix: 'ExamplePkg',
+        name: 'ManagedOuter',
+        kind: 'CLASS',
+        documentation: 'Managed class documentation.',
+        compileError: null
+      }
+    });
+    if (result.kind !== 'apex-type-stub') throw new Error('Expected an Apex type stub');
+    expect(result.value.interfaces[0]).toEqual({
+      namespacePrefix: 'System',
+      name: 'Iterator',
+      typeParameters: [
+        {
+          namespacePrefix: null,
+          name: 'List',
+          typeParameters: [{ namespacePrefix: null, name: 'String', typeParameters: null }]
+        }
+      ]
+    });
+    expect(result.value.fields[0]).toMatchObject({
+      name: 'items',
+      definingType: { namespacePrefix: 'ExamplePkg', name: 'ManagedBase' }
+    });
+    expect(result.value.properties[0]).toMatchObject({
+      name: 'value',
+      getter: { documentation: 'Reads the value.' },
+      setter: null
+    });
+    expect(result.value.methods[0]).toMatchObject({
+      name: 'convert',
+      documentation: 'Converts an input value.',
+      parameters: [{ name: 'input', documentation: null }]
+    });
+    expect(result.value.innerTypes[0]).toMatchObject({
+      name: 'ManagedOuter.Inner',
+      namespacePrefix: 'ExamplePkg'
+    });
+  });
+
+  it('preserves compile errors while completing omitted canonical fields', async () => {
+    const result = await run(
+      TransmogrifierService.pipe(
+        Effect.flatMap(service =>
+          service.toSemanticModel({
+            source: 'symbol-table-apex',
+            identity: { kind: 'apex-type', namespace: null, name: 'BrokenType' },
+            value: symbolTableResponse.typeStubs[4]
+          })
+        )
+      )
+    );
+
+    expect(result).toMatchObject({
+      kind: 'apex-type-stub',
+      value: {
+        fields: [],
+        methods: [],
+        innerTypes: [],
+        compileError: 'Unexpected token near line 4'
+      }
+    });
+  });
+
+  it('orders unordered Symbol Table collections deterministically without reordering parameters', async () => {
+    const result = await run(
+      TransmogrifierService.pipe(
+        Effect.flatMap(service =>
+          service.toSemanticModel({
+            source: 'symbol-table-apex',
+            identity: { kind: 'apex-type', namespace: 'System', name: 'String' },
+            value: {
+              name: 'String',
+              namespacePrefix: 'System',
+              kind: 'CLASS',
+              modifiers: ['virtual', 'global'],
+              fields: [
+                { name: 'Z_VALUE', modifiers: ['static', 'global'] },
+                { name: 'A_VALUE', modifiers: ['global', 'static'] }
+              ],
+              methods: [
+                {
+                  name: 'valueOf',
+                  parameters: [
+                    { name: 'first', type: { name: 'Object' } },
+                    { name: 'second', type: { name: 'String' } }
+                  ]
+                },
+                { name: 'compareTo' }
+              ]
+            }
+          })
+        )
+      )
+    );
+
+    if (result.kind !== 'apex-type-stub') throw new Error('Expected an Apex type stub');
+    expect(result.value.modifiers).toEqual(['global', 'virtual']);
+    expect(result.value.fields.map(field => field.name)).toEqual(['A_VALUE', 'Z_VALUE']);
+    expect(result.value.methods.map(method => method.name)).toEqual(['compareTo', 'valueOf']);
+    expect(result.value.methods[1].parameters.map(parameter => parameter.name)).toEqual(['first', 'second']);
+  });
+
+  it('rejects malformed and identity-mismatched Symbol Table payloads with typed errors', async () => {
+    const malformed = await run(
+      TransmogrifierService.pipe(
+        Effect.flatMap(service =>
+          service.toSemanticModel({
+            source: 'symbol-table-apex',
+            identity: { kind: 'apex-type', namespace: null, name: 'Broken' },
+            value: { name: 'Broken', kind: 'CLASS', fields: [{ name: '' }] }
+          })
+        ),
+        Effect.either
+      )
+    );
+    expect(malformed).toMatchObject({
+      _tag: 'Left',
+      left: {
+        _tag: 'TransmogrifierError',
+        source: 'symbol-table-apex',
+        message: 'Failed to validate the Symbol Table Apex payload'
+      }
+    });
+
+    const mismatched = await run(
+      TransmogrifierService.pipe(
+        Effect.flatMap(service =>
+          service.toSemanticModel({
+            source: 'symbol-table-apex',
+            identity: { kind: 'apex-type', namespace: 'OtherPackage', name: 'ManagedOuter' },
+            value: symbolTableResponse.typeStubs[0]
+          })
+        ),
+        Effect.either
+      )
+    );
+    expect(mismatched).toMatchObject({
+      _tag: 'Left',
+      left: {
+        _tag: 'TransmogrifierError',
+        source: 'symbol-table-apex',
+        message: 'Symbol Table Apex payload identity does not match the requested artifact identity'
+      }
+    });
   });
 });

--- a/packages/salesforcedx-vscode-services/test/jest/orgCatalog/orgCatalogProjection.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/orgCatalog/orgCatalogProjection.test.ts
@@ -7,6 +7,7 @@
 
 import { URI } from 'vscode-uri';
 import type { TypeInventory } from '../../../src/orgCatalog/orgCatalogInternalTypes';
+import { componentIdentity } from '../../../src/orgCatalog/orgCatalogKeys';
 import { mergeInventory, projectChildren } from '../../../src/orgCatalog/orgCatalogProjection';
 
 const entryUri = (orgId: string, xmlName: string, fullName: string): URI =>
@@ -28,23 +29,69 @@ describe('Org Catalog inventory projection', () => {
       ])
     });
 
-    expect(inventory.get('Both')).toMatchObject({
+    expect(inventory.get(componentIdentity({ xmlName: 'ApexClass', fullName: 'Both' }))).toMatchObject({
       provenance: 'metadata-api+workspace',
       inOrg: true,
       inWorkspace: true,
       workspaceUri,
       remoteLastModifiedDate: '2026-08-03T11:00:00.000Z'
     });
-    expect(inventory.get('RemoteOnly')).toMatchObject({
+    expect(inventory.get(componentIdentity({ xmlName: 'ApexClass', fullName: 'RemoteOnly' }))).toMatchObject({
       provenance: 'metadata-api',
       inOrg: true,
       inWorkspace: false
     });
-    expect(inventory.get('LocalOnly')).toMatchObject({
+    expect(inventory.get(componentIdentity({ xmlName: 'ApexClass', fullName: 'LocalOnly' }))).toMatchObject({
       provenance: 'workspace',
       inOrg: false,
       inWorkspace: true,
       workspaceUri: localOnlyUri
+    });
+  });
+
+  it('keeps a namespaced remote component separate from an ineligible unnamespaced workspace file', () => {
+    const workspaceUri = URI.file('/workspace/classes/MyClass.cls');
+    const inventory = mergeInventory({
+      entryUri,
+      orgId: 'org-one',
+      xmlName: 'ApexClass',
+      observedAt: '2026-08-03T12:00:00.000Z',
+      orgComponents: [{ fullName: 'MyClass', namespacePrefix: 'InstalledPackage' }],
+      workspaceUris: new Map([['MyClass', workspaceUri]]),
+      workspaceNamespace: null
+    });
+
+    expect(inventory.size).toBe(2);
+    expect(
+      inventory.get(componentIdentity({ xmlName: 'ApexClass', fullName: 'MyClass' }, 'InstalledPackage'))
+    ).toMatchObject({ namespacePrefix: 'InstalledPackage', inOrg: true, inWorkspace: false });
+    expect(inventory.get(componentIdentity({ xmlName: 'ApexClass', fullName: 'MyClass' }, null))).toMatchObject({
+      inOrg: false,
+      inWorkspace: true,
+      workspaceUri
+    });
+  });
+
+  it('merges matching project and remote namespaces while preserving provider casing', () => {
+    const workspaceUri = URI.file('/workspace/classes/MyClass.cls');
+    const inventory = mergeInventory({
+      entryUri,
+      orgId: 'org-one',
+      xmlName: 'ApexClass',
+      observedAt: '2026-08-03T12:00:00.000Z',
+      orgComponents: [{ fullName: 'MyClass', namespacePrefix: 'MyPackage' }],
+      workspaceUris: new Map([['myclass', workspaceUri]]),
+      workspaceNamespace: 'mypackage'
+    });
+
+    expect(inventory.size).toBe(1);
+    expect(inventory.values().next().value).toMatchObject({
+      namespacePrefix: 'MyPackage',
+      reference: { xmlName: 'ApexClass', fullName: 'MyClass' },
+      provenance: 'metadata-api+workspace',
+      inOrg: true,
+      inWorkspace: true,
+      workspaceUri
     });
   });
 

--- a/packages/salesforcedx-vscode-services/test/jest/orgCatalog/orgCatalogState.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/orgCatalog/orgCatalogState.test.ts
@@ -10,6 +10,7 @@ import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
 import { URI } from 'vscode-uri';
 import { OrgCatalogState } from '../../../src/orgCatalog/orgCatalogState';
+import { componentIdentity } from '../../../src/orgCatalog/orgCatalogKeys';
 import {
   OrgMetadataCatalogStore,
   type OrgMetadataCatalogSnapshot
@@ -50,7 +51,7 @@ describe('OrgCatalogState', () => {
       folders: new Map(),
       components: new Map([
         [
-          'RemoteAndLocal',
+          componentIdentity({ xmlName: 'ApexClass', fullName: 'RemoteAndLocal' }),
           {
             orgId: 'org-one',
             observedAt: '2026-08-03T12:00:00.000Z',
@@ -65,7 +66,7 @@ describe('OrgCatalogState', () => {
           }
         ],
         [
-          'LocalOnly',
+          componentIdentity({ xmlName: 'ApexClass', fullName: 'LocalOnly' }),
           {
             orgId: 'org-one',
             observedAt: '2026-08-03T12:00:00.000Z',
@@ -130,7 +131,9 @@ describe('OrgCatalogState', () => {
 
     expect(load).toHaveBeenCalledTimes(1);
     expect(result.inventory?.components).toEqual([expect.objectContaining({ fullName: 'RemoteTest' })]);
-    expect(result.tracking.get('ApexClass\0RemoteTest')?.signature).toBe('Changed|7');
+    expect(result.tracking.get(componentIdentity({ xmlName: 'ApexClass', fullName: 'RemoteTest' }))?.signature).toBe(
+      'Changed|7'
+    );
     expect(saved[0]?.generation).toBe(8);
   });
 

--- a/packages/salesforcedx-vscode-services/test/jest/orgCatalog/orgCatalogWorkspace.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/orgCatalog/orgCatalogWorkspace.test.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+import { MetadataRetrieveService } from '../../../src/core/metadataRetrieveService';
+import { ProjectService } from '../../../src/core/projectService';
+import { OrgCatalogState } from '../../../src/orgCatalog/orgCatalogState';
+import { OrgCatalogWorkspace } from '../../../src/orgCatalog/orgCatalogWorkspace';
+import { OrgMetadataReferenceService } from '../../../src/orgCatalog/orgMetadataReference';
+
+const objectMetadata = {
+  CustomObject: {
+    label: 'Broker',
+    pluralLabel: 'Brokers'
+  }
+};
+
+const fieldMetadata = {
+  CustomField: {
+    fullName: 'Account__c',
+    label: 'Account',
+    type: 'Lookup',
+    referenceTo: 'Account'
+  }
+};
+
+const createFixture = (eligible = true) => {
+  const parseObject = jest.fn(async () => objectMetadata);
+  const parseField = jest.fn(async () => fieldMetadata);
+  const fieldComponent = {
+    type: { name: 'CustomField' },
+    fullName: 'Broker__c.Account__c',
+    xml: '/workspace/force-app/main/default/objects/Broker__c/fields/Account__c.field-meta.xml',
+    parseXml: parseField
+  };
+  const objectComponent = {
+    type: { name: 'CustomObject' },
+    fullName: 'Broker__c',
+    xml: '/workspace/force-app/main/default/objects/Broker__c/Broker__c.object-meta.xml',
+    parseXml: parseObject,
+    getChildren: jest.fn(() => [fieldComponent])
+  };
+  const buildComponentSetFromSource = jest.fn(() =>
+    Effect.succeed({ getSourceComponents: () => [objectComponent, fieldComponent] })
+  );
+  const dependencies = Layer.mergeAll(
+    Layer.succeed(OrgCatalogState, {} as unknown as InstanceType<typeof OrgCatalogState>),
+    Layer.succeed(OrgMetadataReferenceService, {} as unknown as InstanceType<typeof OrgMetadataReferenceService>),
+    Layer.succeed(MetadataRetrieveService, {
+      buildComponentSetFromSource
+    } as unknown as InstanceType<typeof MetadataRetrieveService>),
+    Layer.succeed(ProjectService, {
+      getSfProject: () => Effect.succeed({ getPackageDirectories: () => [{ fullPath: '/workspace/force-app' }] }),
+      isArtifactNamespaceWorkspaceEligible: () => Effect.succeed(eligible)
+    } as unknown as InstanceType<typeof ProjectService>)
+  );
+  const layer = OrgCatalogWorkspace.DefaultWithoutDependencies.pipe(Layer.provide(dependencies));
+  return { buildComponentSetFromSource, layer, parseField, parseObject };
+};
+
+describe('OrgCatalogWorkspace', () => {
+  it('loads structured SObject metadata through SDR SourceComponent parsing', async () => {
+    const fixture = createFixture();
+    const result = await Effect.runPromise(
+      OrgCatalogWorkspace.pipe(
+        Effect.flatMap(service => service.loadSObjectMetadata({ kind: 'sobject', namespace: null, name: 'Broker__c' })),
+        Effect.provide(fixture.layer)
+      )
+    );
+
+    expect(result).toMatchObject({
+      object: {
+        fullName: 'Broker__c',
+        metadata: objectMetadata
+      },
+      fields: [
+        {
+          fullName: 'Broker__c.Account__c',
+          metadata: fieldMetadata
+        }
+      ]
+    });
+    expect(result?.object.definitionUri.toString()).toBe(
+      'file:///workspace/force-app/main/default/objects/Broker__c/Broker__c.object-meta.xml'
+    );
+    expect(fixture.buildComponentSetFromSource).toHaveBeenCalledWith(
+      ['/workspace/force-app'],
+      [{ type: 'CustomObject', fullName: 'Broker__c' }]
+    );
+    expect(fixture.parseObject).toHaveBeenCalledTimes(1);
+    expect(fixture.parseField).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not attribute a mismatched namespace to the workspace', async () => {
+    const fixture = createFixture(false);
+    const result = await Effect.runPromise(
+      OrgCatalogWorkspace.pipe(
+        Effect.flatMap(service =>
+          service.loadSObjectMetadata({ kind: 'sobject', namespace: 'OtherPackage', name: 'Broker__c' })
+        ),
+        Effect.provide(fixture.layer)
+      )
+    );
+
+    expect(result).toBeNull();
+    expect(fixture.buildComponentSetFromSource).not.toHaveBeenCalled();
+  });
+});

--- a/packages/salesforcedx-vscode-services/test/jest/orgCatalog/orgMetadataCatalog.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/orgCatalog/orgMetadataCatalog.test.ts
@@ -314,7 +314,8 @@ const makeHarness = (options: HarnessOptions = {}) => {
       getSfProject: () =>
         Effect.succeed({
           getPackageDirectories: () => [{ fullPath: '/workspace/force-app' }]
-        })
+        }),
+      getProjectNamespace: () => Effect.succeed(null)
     } as unknown as InstanceType<typeof ProjectService>),
     Layer.succeed(TransmogrifierService, {
       toMinimalSObject: (value: SObject) => Effect.succeed(value)

--- a/packages/salesforcedx-vscode-services/test/jest/orgCatalog/orgMetadataCatalogRecorder.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/orgCatalog/orgMetadataCatalogRecorder.test.ts
@@ -13,6 +13,7 @@ import * as Queue from 'effect/Queue';
 import { URI } from 'vscode-uri';
 import { TransmogrifierService } from '../../../src/core/transmogrifierService';
 import { OrgCatalogState } from '../../../src/orgCatalog/orgCatalogState';
+import { componentIdentity, findInventoryComponent } from '../../../src/orgCatalog/orgCatalogKeys';
 import { OrgMetadataCatalogRecorder } from '../../../src/orgCatalog/orgMetadataCatalogRecorder';
 import { OrgMetadataReferenceService } from '../../../src/orgCatalog/orgMetadataReference';
 import {
@@ -111,7 +112,10 @@ describe('OrgMetadataCatalogRecorder', () => {
         yield* recorder.recordRemoteComponents('org-one', 'metadata-api', [
           { type: 'ApexClass', fullName: 'DiscoveredTest', lastModifiedDate: '2026-08-13T00:00:00.000Z' }
         ]);
-        const discovered = (yield* state.getInventory('org-one', 'ApexClass'))?.components.get('DiscoveredTest');
+        const discovered = findInventoryComponent(
+          (yield* state.getInventory('org-one', 'ApexClass'))?.components ?? new Map(),
+          { xmlName: 'ApexClass', fullName: 'DiscoveredTest' }
+        );
         yield* Effect.sleep('350 millis');
         return discovered;
       }).pipe(Effect.provide(layer))
@@ -169,7 +173,7 @@ describe('OrgMetadataCatalogRecorder', () => {
             'org-one',
             new Map([
               [
-                'ApexClass\0Foo',
+                componentIdentity({ xmlName: 'ApexClass', fullName: 'Foo' }),
                 { reference: { xmlName: 'ApexClass', fullName: 'Foo' }, signature: 'modify\0revision-1' }
               ]
             ])


### PR DESCRIPTION
### What does this PR do?

Completes the Symbol Table Apex transformation slice for W-23973850:

- adds a Symbol Table input to the shared TransmogrifierService boundary
- validates provider payloads with the published raw Effect Schema before transformation
- normalizes namespaces, recursive type references, generics, annotations, fields, properties, methods, inner types, trigger data, documentation, and compile errors
- produces canonical Apex type stub semantic models with provider-canonical identity casing
- orders unordered collections deterministically while preserving method parameter and generic argument order
- rejects malformed payloads and namespace/name identity mismatches with typed TransmogrifierError values

The transformation preserves the endpoint visibility-filtered member set and never generates source or a synthetic document. Services continue to be resolved through Effect tags and Layers.

### What issues does this PR fix or reference?

@W-23973850@

### Functionality Before

Services could validate raw Symbol Table responses, but no shared adapter converted a returned type into the canonical Apex semantic projection.

### Functionality After

Consumers and later provider-routing services can pass an unknown Symbol Table payload through one validated Transmogrifier boundary and receive a canonical, namespace-aware Apex type stub.

### Validation

- recursive managed-package fixture coverage
- standard System namespace coverage
- compile-error, deterministic ordering, malformed payload, and identity-mismatch coverage
- production and test TypeScript checks
- focused ESLint and Jest
- complete repository pre-commit workflow
- complete repository pre-push workflow

This is PR 8 in stack #8036 and is based on #8041.
