### PR TITLE
build: narrow decision for extensions [skip-validate-pr]

### DIFF
--- a/scripts/release-package-selection.js
+++ b/scripts/release-package-selection.js
@@ -1,6 +1,6 @@
 const shouldUpdateVersion = packageJson =>
-  packageJson.private !== true &&
   !packageJson.versionedIndependently &&
-  (Boolean(packageJson.scripts?.['vscode:publish']) || Boolean(packageJson.publishConfig));
+  (Boolean(packageJson.scripts?.['vscode:publish']) ||
+    (packageJson.private !== true && Boolean(packageJson.publishConfig)));
 
 module.exports = { shouldUpdateVersion };


### PR DESCRIPTION
The narrowing for deciding to update a version should consider extensions independent of npm modules

## Verification

Applied `shouldUpdateVersion()` from `scripts/release-package-selection.js` to every top-level package with a `package.json` under `packages/`.

The property columns below show the values as evaluated by the predicate:

- `!versionedIndependently`
- `Boolean(scripts['vscode:publish'])`
- `private !== true`
- `Boolean(publishConfig)`

| Package | `!versionedIndependently` | `vscode:publish` | `private !== true` | `publishConfig` | Result |
|---|---:|---:|---:|---:|---:|
| drivable-vscode | `true` | `false` | `false` | `false` | `false` |
| effect-ext-utils | `true` | `false` | `true` | `true` | `true` |
| eslint-local-rules | `false` | `false` | `true` | `true` | `false` |
| playwright-vscode-ext | `false` | `false` | `true` | `true` | `false` |
| salesforcedx-apex | `true` | `false` | `true` | `true` | `true` |
| salesforcedx-apex-debugger | `true` | `false` | `true` | `false` | `false` |
| salesforcedx-apex-replay-debugger | `true` | `false` | `true` | `false` | `false` |
| salesforcedx-aura-language-server | `true` | `false` | `true` | `false` | `false` |
| salesforcedx-lightning-lsp-common | `true` | `false` | `true` | `false` | `false` |
| salesforcedx-lwc-language-server | `true` | `false` | `true` | `false` | `false` |
| salesforcedx-utils | `true` | `false` | `true` | `false` | `false` |
| salesforcedx-utils-vscode | `true` | `false` | `true` | `false` | `false` |
| salesforcedx-visualforce-language-server | `true` | `false` | `true` | `false` | `false` |
| salesforcedx-visualforce-markup-language-server | `true` | `false` | `true` | `false` | `false` |
| salesforcedx-vscode | `true` | `true` | `false` | `false` | `true` |
| salesforcedx-vscode-apex | `true` | `true` | `false` | `false` | `true` |
| salesforcedx-vscode-apex-debugger | `true` | `true` | `false` | `false` | `true` |
| salesforcedx-vscode-apex-log | `true` | `true` | `false` | `false` | `true` |
| salesforcedx-vscode-apex-oas | `true` | `true` | `false` | `false` | `true` |
| salesforcedx-vscode-apex-replay-debugger | `true` | `true` | `false` | `false` | `true` |
| salesforcedx-vscode-apex-testing | `true` | `true` | `false` | `false` | `true` |
| salesforcedx-vscode-core | `true` | `true` | `false` | `false` | `true` |
| salesforcedx-vscode-expanded | `true` | `true` | `false` | `false` | `true` |
| salesforcedx-vscode-i18n | `false` | `false` | `true` | `true` | `false` |
| salesforcedx-vscode-lightning | `true` | `true` | `false` | `false` | `true` |
| salesforcedx-vscode-lwc | `true` | `true` | `false` | `false` | `true` |
| salesforcedx-vscode-metadata | `true` | `true` | `false` | `false` | `true` |
| salesforcedx-vscode-org | `true` | `true` | `false` | `false` | `true` |
| salesforcedx-vscode-org-browser | `true` | `true` | `false` | `false` | `true` |
| salesforcedx-vscode-services | `true` | `true` | `false` | `false` | `true` |
| salesforcedx-vscode-services-types | `true` | `false` | `true` | `true` | `true` |
| salesforcedx-vscode-soql | `true` | `true` | `false` | `false` | `true` |
| salesforcedx-vscode-visualforce | `true` | `true` | `false` | `false` | `true` |
| soql-builder-ui | `true` | `false` | `false` | `false` | `false` |
| soql-common | `false` | `false` | `true` | `true` | `false` |
| soql-model | `true` | `false` | `false` | `false` | `false` |

The final result is equivalent to:

```js
!versionedIndependently &&
  (vscodePublish || (privateIsNotTrue && publishConfig));
```

### Summary by package type

Packages with a present/truthy `vscode:publish` script are classified as **extension**; packages without one are classified as **not extension**.

| Group | Packages | Result `true` | Result `false` |
|---|---:|---:|---:|
| Extension | 17 | 17 | 0 |
| Not extension | 19 | 3 | 16 |
| **Total** | **36** | **20** | **16** |

The three non-extension packages that evaluate to `true` are:

- `effect-ext-utils`
- `salesforcedx-apex`
- `salesforcedx-vscode-services-types`

`soql-builder-web-example` and `test-workspaces` were excluded because they do not have top-level `package.json` files.
