### PR TITLE
feat(services): persist typed semantic projections - W-23973887

### DIFF
--- a/packages/salesforcedx-vscode-services/src/core/transmogrifierService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/transmogrifierService.ts
@@ -5,11 +5,11 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import type { SObjectArtifactIdentity } from './artifactIdentity';
 import type { Connection } from '@salesforce/core';
 import * as Effect from 'effect/Effect';
 import * as S from 'effect/Schema';
 import type { URI } from 'vscode-uri';
+import { artifactIdentitiesEqual, type SObjectArtifactIdentity } from './artifactIdentity';
 import { SObjectSemanticModelSchema, type SObjectSemanticField, type SObjectSemanticModel } from './artifactProjection';
 import { SObjectSchema, type SObject, type SObjectField } from './schemas/sObject';
 
@@ -42,11 +42,20 @@ export type WorkspaceSObjectMetadataTransmogrifierInput = {
   readonly value: WorkspaceSObjectMetadata;
 };
 
-/** Provider-native SObject inputs accepted by the canonical transformation boundary. */
-export type TransmogrifierInput = RestSObjectDescribeTransmogrifierInput | WorkspaceSObjectMetadataTransmogrifierInput;
+type PersistedSObjectSemanticModelTransmogrifierInput = {
+  readonly source: 'persisted-semantic-model';
+  readonly identity: SObjectArtifactIdentity;
+  readonly value: unknown;
+};
+
+/** Provider-native SObject inputs normalized into the canonical semantic model. */
+export type TransmogrifierInput =
+  | RestSObjectDescribeTransmogrifierInput
+  | WorkspaceSObjectMetadataTransmogrifierInput
+  | PersistedSObjectSemanticModelTransmogrifierInput;
 
 export class TransmogrifierError extends S.TaggedError<TransmogrifierError>()('TransmogrifierError', {
-  source: S.Literal('rest-sobject-describe', 'workspace-sobject-metadata'),
+  source: S.Literal('rest-sobject-describe', 'workspace-sobject-metadata', 'persisted-semantic-model'),
   message: S.String,
   cause: S.optional(S.Unknown)
 }) {}
@@ -316,22 +325,43 @@ export class TransmogrifierService extends Effect.Service<TransmogrifierService>
       return yield* S.decodeUnknown(SObjectSchema)(input);
     });
 
-    const toSemanticModel = Effect.fn('TransmogrifierService.toSemanticModel')(function* (input: TransmogrifierInput) {
-      const model =
-        input.source === 'rest-sobject-describe'
-          ? mapRestDescribeToSemanticModel(input.identity, input.value)
-          : mapWorkspaceSObjectToSemanticModel(input.identity, input.value);
-      return yield* S.validate(SObjectSemanticModelSchema)(model).pipe(
-        Effect.mapError(
-          cause =>
-            new TransmogrifierError({
+    const toSemanticModel: (input: TransmogrifierInput) => Effect.Effect<SObjectSemanticModel, TransmogrifierError> =
+      Effect.fn('TransmogrifierService.toSemanticModel')(function* (input: TransmogrifierInput) {
+        if (input.source === 'persisted-semantic-model') {
+          const persistedModel = yield* S.decodeUnknown(SObjectSemanticModelSchema)(input.value).pipe(
+            Effect.mapError(
+              cause =>
+                new TransmogrifierError({
+                  source: input.source,
+                  message: 'Failed to validate the persisted canonical semantic model',
+                  cause
+                })
+            )
+          );
+          if (!artifactIdentitiesEqual(input.identity, persistedModel.value.identity)) {
+            return yield* new TransmogrifierError({
               source: input.source,
-              message: `Failed to transform ${input.source} into the canonical semantic model`,
-              cause
-            })
-        )
-      );
-    });
+              message: 'Persisted semantic model identity does not match the requested artifact identity',
+              cause: { requested: input.identity, received: persistedModel.value.identity }
+            });
+          }
+          return persistedModel;
+        }
+        const model =
+          input.source === 'rest-sobject-describe'
+            ? mapRestDescribeToSemanticModel(input.identity, input.value)
+            : mapWorkspaceSObjectToSemanticModel(input.identity, input.value);
+        return yield* S.validate(SObjectSemanticModelSchema)(model).pipe(
+          Effect.mapError(
+            cause =>
+              new TransmogrifierError({
+                source: input.source,
+                message: `Failed to transform ${input.source} into the canonical semantic model`,
+                cause
+              })
+          )
+        );
+      });
 
     return { toMinimalSObject, decodeSObject, toSemanticModel, SObjectSchema };
   })

--- a/packages/salesforcedx-vscode-services/src/orgCatalog/orgSemanticArtifactPersistence.ts
+++ b/packages/salesforcedx-vscode-services/src/orgCatalog/orgSemanticArtifactPersistence.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Effect from 'effect/Effect';
+import * as Schema from 'effect/Schema';
+import type { URI } from 'vscode-uri';
+import { SObjectSemanticModelSchema, type SObjectSemanticModel } from '../core/artifactProjection';
+import { TransmogrifierService, type RestSObjectDescribeTransmogrifierInput } from '../core/transmogrifierService';
+import { OrgSemanticArtifactStore, type SemanticArtifactStoreKey } from './orgSemanticArtifactStore';
+
+type SemanticArtifactPersistenceFields = {
+  readonly orgId: string;
+  readonly capabilityVersion: string;
+  readonly revision: string | null;
+};
+
+export type SemanticArtifactPersistenceInput = SemanticArtifactPersistenceFields &
+  RestSObjectDescribeTransmogrifierInput;
+type SObjectSemanticArtifactStoreKey = Extract<
+  SemanticArtifactStoreKey,
+  { readonly identity: { readonly kind: 'sobject' } }
+>;
+
+class SemanticArtifactPersistenceError extends Schema.TaggedError<SemanticArtifactPersistenceError>()(
+  'SemanticArtifactPersistenceError',
+  { message: Schema.String, cause: Schema.optional(Schema.Unknown) }
+) {}
+
+const semanticArtifactKey = (
+  input: SemanticArtifactPersistenceInput,
+  model: SObjectSemanticModel
+): SObjectSemanticArtifactStoreKey => ({
+  orgId: input.orgId,
+  identity: model.value.identity,
+  projection: { kind: 'semantic-model', model: 'sobject' },
+  provider: 'rest-api',
+  capabilityVersion: input.capabilityVersion,
+  revision: input.revision
+});
+
+/** Typed canonical persistence boundary for remote semantic projections. Actual source remains in metadata-shadow. */
+export class OrgSemanticArtifactPersistence extends Effect.Service<OrgSemanticArtifactPersistence>()(
+  'OrgSemanticArtifactPersistence',
+  {
+    accessors: true,
+    dependencies: [OrgSemanticArtifactStore.Default, TransmogrifierService.Default],
+    effect: Effect.gen(function* () {
+      const [store, transmogrifier] = yield* Effect.all([OrgSemanticArtifactStore, TransmogrifierService]);
+
+      const persist: (input: SemanticArtifactPersistenceInput) => Effect.Effect<
+        {
+          readonly key: SObjectSemanticArtifactStoreKey;
+          readonly writtenAt: string;
+          readonly uri: URI;
+          readonly model: SObjectSemanticModel;
+        },
+        unknown
+      > = Effect.fn('OrgSemanticArtifactPersistence.persist')(function* (input: SemanticArtifactPersistenceInput) {
+        const model = yield* transmogrifier.toSemanticModel(input);
+        const key = semanticArtifactKey(input, model);
+        const encoded = yield* Schema.encode(SObjectSemanticModelSchema)(model).pipe(
+          Effect.mapError(
+            cause =>
+              new SemanticArtifactPersistenceError({
+                message: 'Failed to encode the canonical semantic model for persistence',
+                cause
+              })
+          )
+        );
+        const stored = yield* store.save(key, encoded);
+        return { key, writtenAt: stored.writtenAt, uri: stored.uri, model };
+      });
+
+      const hydrate: (
+        key: SObjectSemanticArtifactStoreKey
+      ) => Effect.Effect<SObjectSemanticModel | undefined, unknown> = Effect.fn(
+        'OrgSemanticArtifactPersistence.hydrate'
+      )(function* (key: SObjectSemanticArtifactStoreKey) {
+        const stored = yield* store.load(key);
+        if (!stored) return undefined;
+        return yield* transmogrifier.toSemanticModel({
+          source: 'persisted-semantic-model',
+          identity: key.identity,
+          value: stored.value
+        });
+      });
+
+      return { hydrate, persist };
+    })
+  }
+) {}

--- a/packages/salesforcedx-vscode-services/test/jest/orgCatalog/orgSemanticArtifactPersistence.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/orgCatalog/orgSemanticArtifactPersistence.test.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Effect from 'effect/Effect';
+import { URI } from 'vscode-uri';
+import { type DescribeSObjectResult, TransmogrifierService } from '../../../src/core/transmogrifierService';
+import {
+  OrgSemanticArtifactPersistence,
+  type SemanticArtifactPersistenceInput
+} from '../../../src/orgCatalog/orgSemanticArtifactPersistence';
+import {
+  OrgSemanticArtifactStore,
+  type SemanticArtifactStoreKey
+} from '../../../src/orgCatalog/orgSemanticArtifactStore';
+
+type StoredRecord = {
+  readonly key: SemanticArtifactStoreKey;
+  readonly writtenAt: string;
+  readonly value: unknown;
+  readonly uri: URI;
+};
+
+const makeHarness = () => {
+  let record: StoredRecord | undefined;
+  const store = new OrgSemanticArtifactStore({
+    save: (key: SemanticArtifactStoreKey, value: unknown) =>
+      Effect.sync(() => {
+        record = {
+          key,
+          writtenAt: '2026-08-25T12:00:00.000Z',
+          value,
+          uri: URI.file('/workspace/.sf/orgs/00D/semantic-artifacts/artifact.json')
+        };
+        return record;
+      }),
+    load: () => Effect.sync(() => record)
+  } as unknown as OrgSemanticArtifactStore);
+  const run = <A, E>(effect: Effect.Effect<A, E, OrgSemanticArtifactPersistence>) =>
+    Effect.runPromise(
+      effect.pipe(
+        Effect.provide(OrgSemanticArtifactPersistence.DefaultWithoutDependencies),
+        Effect.provide(TransmogrifierService.Default),
+        Effect.provideService(OrgSemanticArtifactStore, store)
+      )
+    );
+  return {
+    getRecord: () => record,
+    run,
+    setRecord: (value: StoredRecord) => {
+      record = value;
+    }
+  };
+};
+
+const describeResult = {
+  name: 'Invoice__c',
+  label: 'Invoice',
+  custom: true,
+  queryable: true,
+  fields: [],
+  childRelationships: []
+} as unknown as DescribeSObjectResult;
+
+const restInput: SemanticArtifactPersistenceInput = {
+  source: 'rest-sobject-describe',
+  orgId: '00D',
+  identity: { kind: 'sobject', namespace: null, name: 'Invoice__c' },
+  value: describeResult,
+  capabilityVersion: '66.0',
+  revision: '2026-08-25T11:00:00.000Z'
+};
+
+describe('OrgSemanticArtifactPersistence', () => {
+  it('transforms, persists, and rehydrates REST SObject semantics through one typed boundary', async () => {
+    const { getRecord, run } = makeHarness();
+    const [persisted, hydrated] = await run(
+      Effect.gen(function* () {
+        const persistence = yield* OrgSemanticArtifactPersistence;
+        const saved = yield* persistence.persist(restInput);
+        return [saved, yield* persistence.hydrate(saved.key)] as const;
+      })
+    );
+
+    expect(persisted.key).toEqual({
+      orgId: '00D',
+      identity: { kind: 'sobject', namespace: null, name: 'Invoice__c' },
+      projection: { kind: 'semantic-model', model: 'sobject' },
+      provider: 'rest-api',
+      capabilityVersion: '66.0',
+      revision: '2026-08-25T11:00:00.000Z'
+    });
+    expect(hydrated).toEqual(persisted.model);
+    expect(getRecord()?.value).not.toHaveProperty('workspaceUri');
+    expect(getRecord()?.value).not.toHaveProperty('presence');
+  });
+
+  it('rejects corrupt persisted semantic values during hydration', async () => {
+    const { run, setRecord } = makeHarness();
+    const key: SemanticArtifactStoreKey = {
+      orgId: '00D',
+      identity: { kind: 'sobject', namespace: null, name: 'Invoice__c' },
+      projection: { kind: 'semantic-model', model: 'sobject' },
+      provider: 'rest-api',
+      capabilityVersion: '66.0',
+      revision: null
+    };
+    setRecord({ key, writtenAt: '2026-08-25T12:00:00.000Z', value: { kind: 'sobject' }, uri: URI.file('/corrupt') });
+
+    await expect(
+      run(
+        Effect.gen(function* () {
+          return yield* (yield* OrgSemanticArtifactPersistence).hydrate(key);
+        })
+      )
+    ).rejects.toThrow('Failed to validate the persisted canonical semantic model');
+  });
+
+  it('rejects a persisted value whose namespace-aware identity does not match its key', async () => {
+    const { run, setRecord } = makeHarness();
+    const key: SemanticArtifactStoreKey = {
+      orgId: '00D',
+      identity: { kind: 'sobject', namespace: 'OtherPackage', name: 'Invoice__c' },
+      projection: { kind: 'semantic-model', model: 'sobject' },
+      provider: 'rest-api',
+      capabilityVersion: '66.0',
+      revision: null
+    };
+    setRecord({
+      key,
+      writtenAt: '2026-08-25T12:00:00.000Z',
+      value: {
+        kind: 'sobject',
+        value: {
+          identity: { kind: 'sobject', namespace: null, name: 'Invoice__c' },
+          fields: [],
+        }
+      },
+      uri: URI.file('/mismatched')
+    });
+
+    await expect(
+      run(
+        Effect.gen(function* () {
+          return yield* (yield* OrgSemanticArtifactPersistence).hydrate(key);
+        })
+      )
+    ).rejects.toThrow('Persisted semantic model identity does not match the requested artifact identity');
+  });
+});


### PR DESCRIPTION
## Summary

- add one typed persistence boundary for REST SObject descriptions
- re-enter TransmogrifierService when hydrating persisted JSON so canonical schemas and namespace-aware identity checks run again
- infer the authoritative REST provider from the structured input
- keep actual remote source on the existing metadata-shadow path and keep finder orchestration out of this slice
- obtain TransmogrifierService and OrgSemanticArtifactStore through Effect dependencies rather than method parameters

## Validation

- focused persistence Jest: 3 tests passed
- combined artifact identity, projection, store, and persistence Jest: 26 tests passed
- Services production TypeScript check passed
- repository pre-commit workflow passed on amended stack commits

## Stack

- Work item: W-23973887
- Depends on #8046
