### PR TITLE
chore(services): sync declaration package version - W-23973850

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46437,7 +46437,7 @@
     },
     "packages/salesforcedx-vscode-services-types": {
       "name": "@salesforce/vscode-services",
-      "version": "67.14.0",
+      "version": "67.15.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.43",

--- a/packages/salesforcedx-vscode-services-types/package.json
+++ b/packages/salesforcedx-vscode-services-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/vscode-services",
-  "version": "67.14.0",
+  "version": "67.15.0",
   "description": "TypeScript type definitions for Salesforce VS Code Services extension API",
   "author": "Salesforce",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
### What does this PR do?

Synchronizes the generated `@salesforce/vscode-services` declaration package version and lockfile with the Services package version.

### What issues does this PR fix or reference?

@W-23973850@

### Functionality Before

Services type generation changes the declaration package to `67.15.0`, but the lockfile still records `67.14.0`; `npm ci --dry-run` and pre-push fail.

### Functionality After

The declaration package and lockfile both record `67.15.0`; `npm ci --dry-run` and the full pre-push workflow pass.