### PR TITLE
feat(codebuilder-e2e): swap utility (wipe-by-glob + host unpack) - W-23898518

### DIFF
--- a/packages/playwright-vscode-ext/src/codeBuilder/runner.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/runner.ts
@@ -74,3 +74,24 @@ export const withTimeoutRetry = <T>(attempt: () => T): T => {
 /** Default runner: real process execution, arg-array form (no shell interpolation), with timeout + retry. */
 export const defaultRunner: CommandRunner = (file, args) =>
   withTimeoutRetry(() => execFileSync(file, args as string[], { encoding: 'utf-8', timeout: runnerTimeoutMs() }));
+
+/*
+ * Shared charset guard for every value that gets interpolated into a `bash -c` string — a publisher
+ * prefix, a package.json name/version, an extension id. These are the ONLY places a shelled command
+ * is built from a string rather than an argv array, so a stray shell/glob metacharacter (`;`, `$`,
+ * backtick, `*`, `?`, `[`, whitespace) would otherwise be interpreted by the shell or silently widen
+ * a glob. Only npm-style chars are legitimate. Also reject a value that is only dots (`.`/`..`): a
+ * `.`-prefix would make a wipe glob like `${value}.*` reach the parent dir, so require at least one
+ * alphanumeric so `..`, `.`, `--`, etc. can't slip through. swap and verify BOTH call this so their
+ * injection defenses can never diverge. Returns the validated value so callers can use it inline.
+ */
+const VALID_SHELL_SEGMENT = /^[A-Za-z0-9._-]+$/;
+export const assertSafeShellSegment = (value: unknown, label: string): string => {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`missing or non-string ${label} (got ${JSON.stringify(value)})`);
+  }
+  if (!VALID_SHELL_SEGMENT.test(value) || !/[A-Za-z0-9]/.test(value)) {
+    throw new Error(`unsafe ${label} ${JSON.stringify(value)}: expected only [A-Za-z0-9._-] with an alphanumeric`);
+  }
+  return value;
+};

--- a/packages/playwright-vscode-ext/src/codeBuilder/swap.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/swap.ts
@@ -30,7 +30,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { computeExtensionDigest, resolveExtensionRoot } from './digest';
 import { makeManifest, type Manifest } from './manifest';
-import { defaultRunner, runnerTimeoutMs, withTimeoutRetry, type CommandRunner } from './runner';
+import { assertSafeShellSegment, defaultRunner, runnerTimeoutMs, withTimeoutRetry, type CommandRunner } from './runner';
 // OVERRIDES_DIR + RUNTIME_EXT_DIR live in verify (the module that also reads them), so swap and
 // verify share one definition of the image's extension locations rather than drifting copies.
 import { OVERRIDES_DIR, RUNTIME_EXT_DIR } from './verify';
@@ -73,30 +73,22 @@ export type SwapOptions = {
 };
 
 /*
- * Charset guard for every value that gets interpolated into a `bash -c` string: the publisher
- * prefix, and the name/version read from the (attacker-influenced) extracted package.json. Only
- * npm-style chars are legitimate; reject any shell/glob metacharacter up front. Also reject a value
- * that is only dots (`.`/`..`) — a `.`-prefix would make the wipe glob `${prefix}.*` reach the
- * parent dir. Require at least one alphanumeric so `..`, `.`, `--`, etc. can't slip through.
- */
-const VALID_SEGMENT = /^[A-Za-z0-9._-]+$/;
-const assertSafeSegment = (value: unknown, label: string): string => {
-  if (typeof value !== 'string' || value.length === 0) {
-    throw new Error(`missing or non-string ${label} (got ${JSON.stringify(value)})`);
-  }
-  if (!VALID_SEGMENT.test(value) || !/[A-Za-z0-9]/.test(value)) {
-    throw new Error(`unsafe ${label} ${JSON.stringify(value)}: expected only [A-Za-z0-9._-] with an alphanumeric`);
-  }
-  return value;
-};
-
-/*
  * Install the given VSIXes into the container and return the Manifest of exactly what was installed.
  * Explicit list only — no directory scan, no dedup (that selection is the consumer's job).
+ *
+ * The publisher prefix and the name/version read from each (attacker-influenceable) package.json are
+ * charset-validated via the shared assertSafeShellSegment guard before they reach any `bash -c`
+ * string, so swap and verify share one injection defense that can't drift.
  */
 export const swap = (container: string, vsixPaths: readonly string[], options: SwapOptions): Manifest => {
   const { publisherPrefix } = options;
-  assertSafeSegment(publisherPrefix, 'publisher prefix');
+  assertSafeShellSegment(publisherPrefix, 'publisher prefix');
+  // Fail-fast BEFORE the destructive wipe: an empty list would wipe the container's extensions and
+  // then emit an empty Manifest that verify rejects downstream anyway ("no entries — nothing to
+  // verify"). Reject it here so a caller mistake never leaves the container stripped bare.
+  if (vsixPaths.length === 0) {
+    throw new Error('swap requires at least one vsixPath — refusing to wipe the container with nothing to install');
+  }
   const runner = options.runner ?? defaultRunner;
   const extract = options.extract ?? defaultExtract;
   const workDir = options.workDir ?? mkdtempSync(join(tmpdir(), 'cb-swap-'));
@@ -125,12 +117,20 @@ export const swap = (container: string, vsixPaths: readonly string[], options: S
       // Read package.json ONCE and reuse it: name/version validation here + the digest below (passed
       // in so computeExtensionDigest doesn't re-read it for the hash or the entrypoint).
       const rawPkgJson = readFileSync(join(root, 'package.json'), 'utf-8');
-      const parsed = JSON.parse(rawPkgJson) as { name?: unknown; version?: unknown };
+      // The wipe has already run by now, so a bad package.json must fail with enough context to
+      // identify the culprit — name the ORIGINAL vsixPath (not the anonymous vsix-${i} extractDir),
+      // since JSON.parse's own error mentions neither.
+      let parsed: { name?: unknown; version?: unknown };
+      try {
+        parsed = JSON.parse(rawPkgJson) as { name?: unknown; version?: unknown };
+      } catch (err) {
+        throw new Error(`invalid package.json in ${vsixPath}: ${(err as Error).message}`);
+      }
       // Validate before interpolating into destDir's `bash -c` (name/version come from an
       // attacker-influenceable package.json) — and fail loud on a missing/blank name or version
       // rather than silently installing a "salesforce.undefined-undefined" dir.
-      const name = assertSafeSegment(parsed.name, 'package.json name');
-      const version = assertSafeSegment(parsed.version, 'package.json version');
+      const name = assertSafeShellSegment(parsed.name, 'package.json name');
+      const version = assertSafeShellSegment(parsed.version, 'package.json version');
       const id = `${publisherPrefix}.${name}`;
       const digest = computeExtensionDigest(root, rawPkgJson);
       const destDir = `${OVERRIDES_DIR}/${id}-${version}`;

--- a/packages/playwright-vscode-ext/src/codeBuilder/swap.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/swap.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Swap: install the VSIXes under test into a running Code Builder container, and emit the Manifest
+ * verify will gate against. This is the WRITE side of the false-green fix (ADR 0022).
+ *
+ * Two things make it trustworthy:
+ *  1. UNCONDITIONAL WIPE BY PUBLISHER GLOB — before installing anything, delete every override dir
+ *     AND runtime symlink under the consumer's publisher prefix. start.sh re-links an override into
+ *     the runtime dir only when it is strictly-newer semver than what's already linked; an
+ *     equal-or-lower pre-release build would never re-link unless the runtime symlink is also
+ *     cleared. Wiping by glob (not a hardcoded id list) means a baked extension under an unlisted id
+ *     cannot survive to be falsely green.
+ *  2. HOST-SIDE UNPACK + docker cp — a .vsix is a zip (content under extension/); the image loads
+ *     an extracted override *dir*, not a .vsix. We extract on the host, compute the digest with the
+ *     SAME digest core verify uses, then docker cp the tree in. Same bytes, both sides.
+ *
+ * swap MUTATES but does NOT restart — applying the swap (re-scan + activation) is the lifecycle
+ * restart's job. Sequence stays: swap -> restart -> verify.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { computeExtensionDigest, resolveExtensionRoot } from './digest';
+import { makeManifest, type Manifest } from './manifest';
+import { defaultRunner, type CommandRunner } from './runner';
+import { OVERRIDES_DIR } from './verify';
+
+/*
+ * Runtime extensions dir code-server loads from. start.sh symlinks each override here (strictly-newer
+ * semver only), so the wipe must clear this too — else a same-or-lower VSIX never re-links on restart.
+ */
+export const RUNTIME_EXT_DIR = '/home/codebuilder/.local/share/code-server/extensions';
+
+/** Extracts a .vsix (a zip) into destDir, yielding destDir/extension/... Injectable for tests. */
+export type ExtractZip = (vsixPath: string, destDir: string) => void;
+
+/*
+ * Default extractor: host-side `unzip`, with a python3 fallback (both present on macOS and the CI
+ * ubuntu runners — same pair #7718 relied on, just host-side rather than in-container).
+ */
+export const defaultExtract: ExtractZip = (vsixPath, destDir) => {
+  try {
+    execFileSync('unzip', ['-q', '-o', vsixPath, '-d', destDir], { stdio: 'ignore' });
+  } catch {
+    execFileSync(
+      'python3',
+      ['-c', 'import sys,zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])', vsixPath, destDir],
+      { stdio: 'ignore' }
+    );
+  }
+};
+
+export type SwapOptions = {
+  /** Publisher prefix to wipe + install under, e.g. "salesforce". Charset-validated. */
+  publisherPrefix: string;
+  /** Command runner (injectable for tests). Defaults to real docker via execFileSync. */
+  runner?: CommandRunner;
+  /** Zip extractor (injectable for tests). Defaults to host `unzip`. */
+  extract?: ExtractZip;
+  /** Host dir to extract into. Defaults to an OS temp dir (cleaned up when owned). */
+  workDir?: string;
+};
+
+// Same charset guard verify uses on ids: publisher/name are npm-style, and the prefix is interpolated
+// into a `bash -c` glob, so reject any shell/glob metacharacter up front.
+const VALID_PREFIX = /^[A-Za-z0-9._-]+$/;
+const assertSafePrefix = (prefix: string): void => {
+  if (!VALID_PREFIX.test(prefix)) {
+    throw new Error(`unsafe publisher prefix ${JSON.stringify(prefix)}: expected only [A-Za-z0-9._-]`);
+  }
+};
+
+/*
+ * Install the given VSIXes into the container and return the Manifest of exactly what was installed.
+ * Explicit list only — no directory scan, no dedup (that selection is the consumer's job).
+ */
+export const swap = (container: string, vsixPaths: readonly string[], options: SwapOptions): Manifest => {
+  const { publisherPrefix } = options;
+  assertSafePrefix(publisherPrefix);
+  const runner = options.runner ?? defaultRunner;
+  const extract = options.extract ?? defaultExtract;
+  const workDir = options.workDir ?? mkdtempSync(join(tmpdir(), 'cb-swap-'));
+  const ownWorkDir = options.workDir === undefined;
+
+  try {
+    // 1. Unconditional wipe by publisher glob — both the override source and the runtime symlink.
+    runner('docker', [
+      'exec',
+      container,
+      'bash',
+      '-c',
+      `rm -rf ${OVERRIDES_DIR}/${publisherPrefix}.* ${RUNTIME_EXT_DIR}/${publisherPrefix}.*`
+    ]);
+
+    // 2. Install each VSIX: extract host-side, digest, docker cp the tree into a fresh override dir.
+    const entries = vsixPaths.map((vsixPath, i) => {
+      const extractDir = join(workDir, `vsix-${i}`);
+      extract(vsixPath, extractDir);
+      const root = resolveExtensionRoot(extractDir); // the dir holding package.json (extension/)
+      const { name, version } = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8')) as {
+        name: string;
+        version: string;
+      };
+      const id = `${publisherPrefix}.${name}`;
+      const digest = computeExtensionDigest(root);
+      const destDir = `${OVERRIDES_DIR}/${id}-${version}`;
+      // Fresh dir, then copy the extracted tree's CONTENTS in (root/. → destDir), matching the flat
+      // installed layout the image scans (package.json at the dir root).
+      runner('docker', ['exec', container, 'bash', '-c', `rm -rf ${destDir} && mkdir -p ${destDir}`]);
+      runner('docker', ['cp', `${root}/.`, `${container}:${destDir}`]);
+      return { id, version, ...digest };
+    });
+
+    return makeManifest(entries);
+  } finally {
+    if (ownWorkDir) {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  }
+};

--- a/packages/playwright-vscode-ext/src/codeBuilder/swap.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/swap.ts
@@ -30,7 +30,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { computeExtensionDigest, resolveExtensionRoot } from './digest';
 import { makeManifest, type Manifest } from './manifest';
-import { defaultRunner, type CommandRunner } from './runner';
+import { defaultRunner, runnerTimeoutMs, withTimeoutRetry, type CommandRunner } from './runner';
 // OVERRIDES_DIR + RUNTIME_EXT_DIR live in verify (the module that also reads them), so swap and
 // verify share one definition of the image's extension locations rather than drifting copies.
 import { OVERRIDES_DIR, RUNTIME_EXT_DIR } from './verify';
@@ -41,17 +41,24 @@ export type ExtractZip = (vsixPath: string, destDir: string) => void;
 /*
  * Default extractor: host-side `unzip`, with a python3 fallback (both present on macOS and the CI
  * ubuntu runners — same pair #7718 relied on, just host-side rather than in-container).
+ *
+ * Each exec carries the runner's per-attempt timeout and the whole extract is wrapped in
+ * withTimeoutRetry, so a wedged unzip/python3 can't hang the swap forever (same hang protection the
+ * command runner gives docker/sf calls). A missing `unzip` (non-timeout failure) still falls through
+ * to python3 immediately.
  */
 export const defaultExtract: ExtractZip = (vsixPath, destDir) => {
-  try {
-    execFileSync('unzip', ['-q', '-o', vsixPath, '-d', destDir], { stdio: 'ignore' });
-  } catch {
-    execFileSync(
-      'python3',
-      ['-c', 'import sys,zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])', vsixPath, destDir],
-      { stdio: 'ignore' }
-    );
-  }
+  withTimeoutRetry(() => {
+    try {
+      execFileSync('unzip', ['-q', '-o', vsixPath, '-d', destDir], { stdio: 'ignore', timeout: runnerTimeoutMs() });
+    } catch {
+      execFileSync(
+        'python3',
+        ['-c', 'import sys,zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])', vsixPath, destDir],
+        { stdio: 'ignore', timeout: runnerTimeoutMs() }
+      );
+    }
+  });
 };
 
 export type SwapOptions = {
@@ -106,21 +113,26 @@ export const swap = (container: string, vsixPaths: readonly string[], options: S
     ]);
 
     // 2. Install each VSIX: extract host-side, digest, docker cp the tree into a fresh override dir.
+    // Sequential by design: swap shells through the SYNCHRONOUS CommandRunner seam (execFileSync) so
+    // unit tests assert exact argv with no docker. Extract + digest are host-side and could in
+    // principle run in parallel, but they aren't the pipeline's cost (the multi-GB image pull + boot
+    // dominate by minutes) and parallelizing would force an async rewrite that breaks that hermetic
+    // seam — deliberately not done.
     const entries = vsixPaths.map((vsixPath, i) => {
       const extractDir = join(workDir, `vsix-${i}`);
       extract(vsixPath, extractDir);
       const root = resolveExtensionRoot(extractDir); // the dir holding package.json (extension/)
-      const parsed = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8')) as {
-        name?: unknown;
-        version?: unknown;
-      };
+      // Read package.json ONCE and reuse it: name/version validation here + the digest below (passed
+      // in so computeExtensionDigest doesn't re-read it for the hash or the entrypoint).
+      const rawPkgJson = readFileSync(join(root, 'package.json'), 'utf-8');
+      const parsed = JSON.parse(rawPkgJson) as { name?: unknown; version?: unknown };
       // Validate before interpolating into destDir's `bash -c` (name/version come from an
       // attacker-influenceable package.json) — and fail loud on a missing/blank name or version
       // rather than silently installing a "salesforce.undefined-undefined" dir.
       const name = assertSafeSegment(parsed.name, 'package.json name');
       const version = assertSafeSegment(parsed.version, 'package.json version');
       const id = `${publisherPrefix}.${name}`;
-      const digest = computeExtensionDigest(root);
+      const digest = computeExtensionDigest(root, rawPkgJson);
       const destDir = `${OVERRIDES_DIR}/${id}-${version}`;
       // Fresh dir, then copy the extracted tree's CONTENTS in (root/. → destDir), matching the flat
       // installed layout the image scans (package.json at the dir root).

--- a/packages/playwright-vscode-ext/src/codeBuilder/swap.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/swap.ts
@@ -69,13 +69,22 @@ export type SwapOptions = {
   workDir?: string;
 };
 
-// Same charset guard verify uses on ids: publisher/name are npm-style, and the prefix is interpolated
-// into a `bash -c` glob, so reject any shell/glob metacharacter up front.
-const VALID_PREFIX = /^[A-Za-z0-9._-]+$/;
-const assertSafePrefix = (prefix: string): void => {
-  if (!VALID_PREFIX.test(prefix)) {
-    throw new Error(`unsafe publisher prefix ${JSON.stringify(prefix)}: expected only [A-Za-z0-9._-]`);
+/*
+ * Charset guard for every value that gets interpolated into a `bash -c` string: the publisher
+ * prefix, and the name/version read from the (attacker-influenced) extracted package.json. Only
+ * npm-style chars are legitimate; reject any shell/glob metacharacter up front. Also reject a value
+ * that is only dots (`.`/`..`) — a `.`-prefix would make the wipe glob `${prefix}.*` reach the
+ * parent dir. Require at least one alphanumeric so `..`, `.`, `--`, etc. can't slip through.
+ */
+const VALID_SEGMENT = /^[A-Za-z0-9._-]+$/;
+const assertSafeSegment = (value: unknown, label: string): string => {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`missing or non-string ${label} (got ${JSON.stringify(value)})`);
   }
+  if (!VALID_SEGMENT.test(value) || !/[A-Za-z0-9]/.test(value)) {
+    throw new Error(`unsafe ${label} ${JSON.stringify(value)}: expected only [A-Za-z0-9._-] with an alphanumeric`);
+  }
+  return value;
 };
 
 /*
@@ -84,7 +93,7 @@ const assertSafePrefix = (prefix: string): void => {
  */
 export const swap = (container: string, vsixPaths: readonly string[], options: SwapOptions): Manifest => {
   const { publisherPrefix } = options;
-  assertSafePrefix(publisherPrefix);
+  assertSafeSegment(publisherPrefix, 'publisher prefix');
   const runner = options.runner ?? defaultRunner;
   const extract = options.extract ?? defaultExtract;
   const workDir = options.workDir ?? mkdtempSync(join(tmpdir(), 'cb-swap-'));
@@ -105,10 +114,15 @@ export const swap = (container: string, vsixPaths: readonly string[], options: S
       const extractDir = join(workDir, `vsix-${i}`);
       extract(vsixPath, extractDir);
       const root = resolveExtensionRoot(extractDir); // the dir holding package.json (extension/)
-      const { name, version } = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8')) as {
-        name: string;
-        version: string;
+      const parsed = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8')) as {
+        name?: unknown;
+        version?: unknown;
       };
+      // Validate before interpolating into destDir's `bash -c` (name/version come from an
+      // attacker-influenceable package.json) — and fail loud on a missing/blank name or version
+      // rather than silently installing a "salesforce.undefined-undefined" dir.
+      const name = assertSafeSegment(parsed.name, 'package.json name');
+      const version = assertSafeSegment(parsed.version, 'package.json version');
       const id = `${publisherPrefix}.${name}`;
       const digest = computeExtensionDigest(root);
       const destDir = `${OVERRIDES_DIR}/${id}-${version}`;

--- a/packages/playwright-vscode-ext/src/codeBuilder/swap.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/swap.ts
@@ -31,13 +31,9 @@ import { join } from 'node:path';
 import { computeExtensionDigest, resolveExtensionRoot } from './digest';
 import { makeManifest, type Manifest } from './manifest';
 import { defaultRunner, type CommandRunner } from './runner';
-import { OVERRIDES_DIR } from './verify';
-
-/*
- * Runtime extensions dir code-server loads from. start.sh symlinks each override here (strictly-newer
- * semver only), so the wipe must clear this too — else a same-or-lower VSIX never re-links on restart.
- */
-export const RUNTIME_EXT_DIR = '/home/codebuilder/.local/share/code-server/extensions';
+// OVERRIDES_DIR + RUNTIME_EXT_DIR live in verify (the module that also reads them), so swap and
+// verify share one definition of the image's extension locations rather than drifting copies.
+import { OVERRIDES_DIR, RUNTIME_EXT_DIR } from './verify';
 
 /** Extracts a .vsix (a zip) into destDir, yielding destDir/extension/... Injectable for tests. */
 export type ExtractZip = (vsixPath: string, destDir: string) => void;

--- a/packages/playwright-vscode-ext/src/codeBuilder/verify.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/verify.ts
@@ -22,7 +22,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { computeExtensionDigest } from './digest';
-import { defaultRunner, type CommandRunner } from './runner';
+import { assertSafeShellSegment, defaultRunner, type CommandRunner } from './runner';
 
 /** Where the CB image stores extension override sources (swap writes here). */
 export const OVERRIDES_DIR = '/base/extension-overrides';
@@ -61,16 +61,11 @@ export type VerifyResult = {
 /*
  * An extension id is "<publisher>.<name>": publisher and name are npm-style, so only letters,
  * digits, dots, underscores and dashes are legitimate. `id` is interpolated into the `bash -c`
- * glob below, so reject anything outside that charset up front — a stray shell/glob metacharacter
- * (`;`, `$`, backtick, `*`, `?`, `[`, whitespace) would otherwise be interpreted by the shell or
- * silently widen the match. Fail loud rather than build an unsafe command. Also require an
- * alphanumeric (reject dot-only `.`/`..`), matching swap's guard so the two agree on a legal id.
+ * glob below, so validate it with the SAME shared guard swap uses before it builds its own
+ * `bash -c` strings — one definition of "safe shell segment" so the two sides can never diverge.
  */
-const VALID_ID = /^[A-Za-z0-9._-]+$/;
 const assertSafeId = (id: string): void => {
-  if (!VALID_ID.test(id) || !/[A-Za-z0-9]/.test(id)) {
-    throw new Error(`unsafe extension id ${JSON.stringify(id)}: expected only [A-Za-z0-9._-] with an alphanumeric`);
-  }
+  assertSafeShellSegment(id, 'extension id');
 };
 
 /*

--- a/packages/playwright-vscode-ext/src/index.ts
+++ b/packages/playwright-vscode-ext/src/index.ts
@@ -206,5 +206,7 @@ export { makeManifest, readManifest, writeManifest } from './codeBuilder/manifes
 export type { Manifest, ManifestEntry } from './codeBuilder/manifest';
 export { verifyExtensions, assertVerified, OVERRIDES_DIR, RUNTIME_EXT_DIR } from './codeBuilder/verify';
 export type { VerifyOptions, VerifyResult, VerifyEntryResult } from './codeBuilder/verify';
+export { swap, defaultExtract, RUNTIME_EXT_DIR } from './codeBuilder/swap';
+export type { SwapOptions, ExtractZip } from './codeBuilder/swap';
 export { defaultRunner } from './codeBuilder/runner';
 export type { CommandRunner } from './codeBuilder/runner';

--- a/packages/playwright-vscode-ext/src/index.ts
+++ b/packages/playwright-vscode-ext/src/index.ts
@@ -206,7 +206,7 @@ export { makeManifest, readManifest, writeManifest } from './codeBuilder/manifes
 export type { Manifest, ManifestEntry } from './codeBuilder/manifest';
 export { verifyExtensions, assertVerified, OVERRIDES_DIR, RUNTIME_EXT_DIR } from './codeBuilder/verify';
 export type { VerifyOptions, VerifyResult, VerifyEntryResult } from './codeBuilder/verify';
-export { swap, defaultExtract, RUNTIME_EXT_DIR } from './codeBuilder/swap';
+export { swap, defaultExtract } from './codeBuilder/swap';
 export type { SwapOptions, ExtractZip } from './codeBuilder/swap';
 export { defaultRunner } from './codeBuilder/runner';
 export type { CommandRunner } from './codeBuilder/runner';

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/swap.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/swap.test.ts
@@ -188,6 +188,24 @@ describe('swap', () => {
     );
   });
 
+  it('fails fast on an empty vsixPaths list — no destructive wipe with nothing to install', () => {
+    const { runner, calls } = makeRecordingRunner();
+    expect(() => swap(CONTAINER, [], { publisherPrefix: PREFIX, runner, extract: fakeExtract })).toThrow(
+      /at least one vsixPath/
+    );
+    expect(calls).toHaveLength(0); // the wipe never ran
+  });
+
+  it('fails loud naming the source vsixPath when its package.json is malformed JSON', () => {
+    const dir = track(mkdtempSync(join(tmpdir(), 'cb-swap-badjson-')));
+    mkdirSync(join(dir, 'extension'), { recursive: true });
+    writeFileSync(join(dir, 'extension/package.json'), '{ not valid json');
+    const { runner } = makeRecordingRunner();
+    expect(() => swap(CONTAINER, [dir], { publisherPrefix: PREFIX, runner, extract: fakeExtract })).toThrow(
+      new RegExp(`invalid package.json in ${dir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`)
+    );
+  });
+
   it('docker cp source ends in /. (loads a flat override dir, not a nested extension/)', () => {
     const vsix = track(makeVsixTree('salesforcedx-vscode-core', '67.4.0', 'x'));
     const { runner, calls } = makeRecordingRunner();

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/swap.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/swap.test.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { CommandRunner } from '../../../src/codeBuilder/runner';
+import { RUNTIME_EXT_DIR, swap, type ExtractZip } from '../../../src/codeBuilder/swap';
+import { OVERRIDES_DIR, verifyExtensions } from '../../../src/codeBuilder/verify';
+
+const PREFIX = 'salesforce';
+
+/** Build a fake .vsix source tree on disk: an `extension/` dir (raw-vsix shape) with package.json + bundle. */
+const makeVsixTree = (name: string, version: string, bundle?: string): string => {
+  const dir = mkdtempSync(join(tmpdir(), 'cb-swap-vsix-'));
+  const ext = join(dir, 'extension');
+  mkdirSync(ext, { recursive: true });
+  const pkg: Record<string, unknown> = { name, version, publisher: PREFIX };
+  if (bundle !== undefined) {
+    pkg.main = 'dist/main.js';
+    mkdirSync(join(ext, 'dist'), { recursive: true });
+    writeFileSync(join(ext, 'dist/main.js'), bundle);
+  }
+  writeFileSync(join(ext, 'package.json'), JSON.stringify(pkg));
+  return dir; // this dir stands in for "the .vsix file" the extractor is handed
+};
+
+/*
+ * Fake extractor: instead of unzipping, copy the pre-built source tree (which already has the
+ * `extension/` layout) into destDir. So `${sourceTree}` plays the role of the .vsix path.
+ */
+const fakeExtract: ExtractZip = (sourceTree, destDir) => {
+  mkdirSync(destDir, { recursive: true });
+  cpSync(sourceTree, destDir, { recursive: true });
+};
+
+/** Records every argv; returns '' (swap ignores stdout). */
+const makeRecordingRunner = (): { runner: CommandRunner; calls: string[][] } => {
+  const calls: string[][] = [];
+  const runner: CommandRunner = (file, args) => {
+    calls.push([file, ...args]);
+    return '';
+  };
+  return { runner, calls };
+};
+
+describe('swap', () => {
+  const cleanup: string[] = [];
+  const track = (d: string): string => {
+    cleanup.push(d);
+    return d;
+  };
+  afterAll(() => cleanup.forEach(d => rmSync(d, { recursive: true, force: true })));
+  const CONTAINER = 'cb-test';
+
+  it('wipes BOTH the override dir and runtime symlink by publisher glob, first', () => {
+    const vsix = track(makeVsixTree('salesforcedx-vscode-core', '67.4.0', 'code'));
+    const { runner, calls } = makeRecordingRunner();
+
+    swap(CONTAINER, [vsix], { publisherPrefix: PREFIX, runner, extract: fakeExtract });
+
+    const wipe = calls[0]; // must be the very first command
+    expect(wipe.slice(0, 4)).toEqual(['docker', 'exec', CONTAINER, 'bash']);
+    const script = wipe.at(-1) as string;
+    expect(script).toContain(`rm -rf ${OVERRIDES_DIR}/${PREFIX}.*`);
+    expect(script).toContain(`${RUNTIME_EXT_DIR}/${PREFIX}.*`);
+  });
+
+  it("docker cp's the extracted tree contents into a fresh <prefix>.<name>-<version> dir", () => {
+    const vsix = track(makeVsixTree('salesforcedx-vscode-core', '67.4.0', 'code'));
+    const { runner, calls } = makeRecordingRunner();
+
+    swap(CONTAINER, [vsix], { publisherPrefix: PREFIX, runner, extract: fakeExtract });
+
+    const dest = `${OVERRIDES_DIR}/salesforce.salesforcedx-vscode-core-67.4.0`;
+    const cp = calls.find(c => c[1] === 'cp');
+    expect(cp?.[2]).toMatch(/\/\.$/); // copies contents (src/.)
+    expect(cp?.[3]).toBe(`${CONTAINER}:${dest}`);
+    // The dest dir is made fresh before the copy.
+    const mk = calls.find(c => (c.at(-1) as string)?.includes(`mkdir -p ${dest}`));
+    expect(mk).toBeDefined();
+    expect(mk?.at(-1) as string).toContain(`rm -rf ${dest}`);
+  });
+
+  it('emits a Manifest whose digests match the installed bytes (swap→verify reconciliation)', () => {
+    const vsixCore = track(makeVsixTree('salesforcedx-vscode-core', '67.4.0', 'core-code'));
+    const vsixDecl = track(makeVsixTree('salesforcedx-vscode-themes', '67.4.0')); // declarative (no main)
+
+    // Simulate the container holding the installed bytes: eagerly copy each cp'd tree to a durable
+    // dir at cp-time (swap deletes its own extraction temp dir on return, just as the real docker cp
+    // has already moved the bytes into the container by then).
+    const store = track(mkdtempSync(join(tmpdir(), 'cb-installed-')));
+    const installedTreeById: Record<string, string> = {};
+    const runner: CommandRunner = (file, args) => {
+      if (args[0] === 'cp') {
+        const src = args[1].replace(/\/\.$/, ''); // host extract root
+        const dest = args[2].slice(args[2].indexOf(':') + 1); // <OVERRIDES_DIR>/<id>-<ver>
+        const held = join(store, dest.replaceAll('/', '_'));
+        mkdirSync(held, { recursive: true });
+        cpSync(src, held, { recursive: true });
+        installedTreeById[dest] = held;
+      }
+      return '';
+    };
+
+    const manifest = swap(CONTAINER, [vsixCore, vsixDecl], { publisherPrefix: PREFIX, runner, extract: fakeExtract });
+
+    expect(manifest.entries).toHaveLength(2);
+    const core = manifest.entries.find(e => e.id === 'salesforce.salesforcedx-vscode-core');
+    expect(core).toMatchObject({ version: '67.4.0' });
+    expect(core?.bundleDigest).toMatch(/^[0-9a-f]{64}$/);
+    expect(manifest.entries.find(e => e.id === 'salesforce.salesforcedx-vscode-themes')?.bundleDigest).toBeNull();
+
+    // Now VERIFY against the very manifest swap emitted, with a runner that returns the installed dirs
+    // and hands back the exact trees swap copied. It must pass — proving the two sides reconcile.
+    const verifyRunner: CommandRunner = (file, args) => {
+      const script = args.at(-1);
+      if (args[0] === 'exec' && typeof script === 'string' && script.includes('ls -d')) {
+        const m = script.match(/ls -d (\S+)-\[0-9\]\*/);
+        const prefix = m?.[1] ?? '';
+        return Object.keys(installedTreeById)
+          .filter(d => d.startsWith(`${prefix}-`))
+          .join('\n');
+      }
+      if (args[0] === 'cp') {
+        const containerDir = args[1].slice(args[1].indexOf(':') + 1).replace(/\/\.$/, '');
+        mkdirSync(args[2], { recursive: true });
+        cpSync(installedTreeById[containerDir], args[2], { recursive: true });
+        return '';
+      }
+      return '';
+    };
+    const result = verifyExtensions(CONTAINER, manifest, { runner: verifyRunner });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects an unsafe publisher prefix before touching the container', () => {
+    const { runner, calls } = makeRecordingRunner();
+    expect(() => swap(CONTAINER, [], { publisherPrefix: 'sf; rm -rf /', runner, extract: fakeExtract })).toThrow(
+      /unsafe publisher prefix/
+    );
+    expect(calls).toHaveLength(0);
+  });
+
+  it('installs an explicit list as-is (no dir scan, no dedup)', () => {
+    const a = track(makeVsixTree('salesforcedx-vscode-core', '67.4.0', 'a'));
+    const b = track(makeVsixTree('salesforcedx-vscode-apex', '67.4.0', 'b'));
+    const { runner, calls } = makeRecordingRunner();
+
+    const manifest = swap(CONTAINER, [a, b], { publisherPrefix: PREFIX, runner, extract: fakeExtract });
+
+    expect(manifest.entries.map(e => e.id).toSorted()).toEqual([
+      'salesforce.salesforcedx-vscode-apex',
+      'salesforce.salesforcedx-vscode-core'
+    ]);
+    expect(calls.filter(c => c[1] === 'cp')).toHaveLength(2);
+  });
+});

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/swap.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/swap.test.ts
@@ -146,6 +146,49 @@ describe('swap', () => {
     expect(calls).toHaveLength(0);
   });
 
+  it('rejects a dot-only publisher prefix (would let the wipe glob reach the parent dir)', () => {
+    const { runner } = makeRecordingRunner();
+    expect(() => swap(CONTAINER, [], { publisherPrefix: '..', runner, extract: fakeExtract })).toThrow(
+      /unsafe publisher prefix/
+    );
+    expect(() => swap(CONTAINER, [], { publisherPrefix: '.', runner, extract: fakeExtract })).toThrow(
+      /unsafe publisher prefix/
+    );
+  });
+
+  it('rejects a package.json name/version with shell metacharacters (no injection into bash -c)', () => {
+    const evil = track(makeVsixTree('core"; rm -rf /home #', '67.4.0', 'x'));
+    const { runner } = makeRecordingRunner();
+    expect(() => swap(CONTAINER, [evil], { publisherPrefix: PREFIX, runner, extract: fakeExtract })).toThrow(
+      /unsafe package.json name/
+    );
+
+    const evilVersion = track(makeVsixTree('salesforcedx-vscode-core', '0.0.0; rm -rf /', 'x'));
+    expect(() => swap(CONTAINER, [evilVersion], { publisherPrefix: PREFIX, runner, extract: fakeExtract })).toThrow(
+      /unsafe package.json version/
+    );
+  });
+
+  it('fails loud when the extension package.json has no name/version (not a silent "undefined" dir)', () => {
+    const dir = track(mkdtempSync(join(tmpdir(), 'cb-swap-nover-')));
+    mkdirSync(join(dir, 'extension'), { recursive: true });
+    writeFileSync(join(dir, 'extension/package.json'), JSON.stringify({ name: 'salesforcedx-vscode-core' })); // no version
+    const { runner } = makeRecordingRunner();
+    expect(() => swap(CONTAINER, [dir], { publisherPrefix: PREFIX, runner, extract: fakeExtract })).toThrow(
+      /missing or non-string package.json version/
+    );
+  });
+
+  it('docker cp source ends in /. (loads a flat override dir, not a nested extension/)', () => {
+    const vsix = track(makeVsixTree('salesforcedx-vscode-core', '67.4.0', 'x'));
+    const { runner, calls } = makeRecordingRunner();
+    swap(CONTAINER, [vsix], { publisherPrefix: PREFIX, runner, extract: fakeExtract });
+    const cp = calls.find(c => c[1] === 'cp')!;
+    // The trailing /. is load-bearing: it copies the extension CONTENTS flat, so package.json lands
+    // at the override dir root (what the image scans + what verify recomputes against).
+    expect(cp[2].endsWith('/.')).toBe(true);
+  });
+
   it('installs an explicit list as-is (no dir scan, no dedup)', () => {
     const a = track(makeVsixTree('salesforcedx-vscode-core', '67.4.0', 'a'));
     const b = track(makeVsixTree('salesforcedx-vscode-apex', '67.4.0', 'b'));

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/swap.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/swap.test.ts
@@ -9,8 +9,8 @@ import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { CommandRunner } from '../../../src/codeBuilder/runner';
-import { RUNTIME_EXT_DIR, swap, type ExtractZip } from '../../../src/codeBuilder/swap';
-import { OVERRIDES_DIR, verifyExtensions } from '../../../src/codeBuilder/verify';
+import { swap, type ExtractZip } from '../../../src/codeBuilder/swap';
+import { OVERRIDES_DIR, RUNTIME_EXT_DIR, verifyExtensions } from '../../../src/codeBuilder/verify';
 
 const PREFIX = 'salesforce';
 
@@ -122,6 +122,15 @@ describe('swap', () => {
       if (args[0] === 'exec' && typeof script === 'string' && script.includes('ls -d')) {
         const m = script.match(/ls -d (\S+)-\[0-9\]\*/);
         const prefix = m?.[1] ?? '';
+        // Runtime ls: simulate a successful start.sh relink — return the installed override dirs'
+        // basenames rebased under RUNTIME_EXT_DIR.
+        if (prefix.startsWith(RUNTIME_EXT_DIR)) {
+          const id = prefix.slice(RUNTIME_EXT_DIR.length + 1);
+          return Object.keys(installedTreeById)
+            .filter(d => d.startsWith(`${OVERRIDES_DIR}/${id}-`))
+            .map(d => `${RUNTIME_EXT_DIR}/${d.slice(d.lastIndexOf('/') + 1)}`)
+            .join('\n');
+        }
         return Object.keys(installedTreeById)
           .filter(d => d.startsWith(`${prefix}-`))
           .join('\n');


### PR DESCRIPTION
### What does this PR do?

Story 2 of the reusable Code Builder e2e toolkit (epic: Code Builder E2E Testing Framework). Adds the **swap** utility to `playwright-vscode-ext` — the WRITE side of the ADR-0022 false-green fix.

`packages/playwright-vscode-ext/src/codeBuilder/swap.ts`:

- **Unconditional wipe by publisher glob** — before installing anything, deletes **both** the override dirs (`/base/extension-overrides/<prefix>.*`) **and** the runtime symlinks (`~/.local/share/code-server/extensions/<prefix>.*`). `start.sh` re-links an override only when it's strictly-newer semver, so an equal-or-lower pre-release build would never re-link unless the runtime symlink is cleared too. Wiping by glob (not a hardcoded id list) means a baked extension under an unlisted id can't survive to be falsely green.
- **Explicit VSIX list, host-side unpack, `docker cp` the tree** — no directory scan, no dedup (selection is the consumer's job). Each VSIX is extracted host-side, digested with the **same digest core** verify uses, then cp'd into a fresh `<prefix>.<name>-<version>` override dir.
- **Emits the `Manifest`** of exactly what was installed — the contract object verify (PR #8009) gates against.
- Extraction is an **injectable seam** (`ExtractZip`, default = host `unzip` with a python3 fallback) so it unit-tests with no real docker or zip. Publisher prefix is charset-validated before it reaches the shell.

Swap **mutates but does not restart** — applying the swap (re-scan + activation) is the lifecycle restart's job.

**Verification:** 5 new Jest tests (wipe-glob-first, cp argv, emitted-manifest, prefix rejection, explicit-list) including a **swap→verify reconciliation** round-trip proving both sides produce the same digest. `tsc`/`eslint`/full pre-commit clean. 38 tests pass across the codeBuilder suite.

Design: `docs/plans/code-builder-e2e-toolkit.md` §6.

### What issues does this PR fix or reference?

@W-23898518@

### Functionality Before

No importable swap; #7718's swap was a standalone script with a hardcoded per-id wipe and in-container unpack.

### Functionality After

`swap(container, vsixPaths, { publisherPrefix })` → wipes by glob, installs host-side, and returns the `Manifest` verify asserts against.

---

> **Stacked PR:** based on `jh/W-23898517-cb-e2e-verify-gate` (PR #8009), since swap shares the digest/Manifest core. Review/merge #8009 first; this diff shows only the swap addition.
