### PR TITLE
feat(codebuilder-e2e): lifecycle + org boot-env + seed utilities - W-23898521

### DIFF
--- a/packages/playwright-vscode-ext/src/codeBuilder/auth.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/auth.ts
@@ -45,19 +45,34 @@ export type ResolveOrgBootEnvOptions = {
 export const resolveOrgBootEnv = (orgAlias: string, options: ResolveOrgBootEnvOptions = {}): BootEnv => {
   const runner = options.runner ?? defaultRunner;
 
-  const display = JSON.parse(runner('sf', ['org', 'display', '-o', orgAlias, '--json'])) as {
-    result?: { instanceUrl?: string };
+  /*
+   * Parse `sf --json` stdout, but attach context on failure: if `sf` ever prints an update notice /
+   * banner to stdout (the "hard-won" class of bug), a bare JSON.parse throws an opaque
+   * "Unexpected token" with no clue which command or org. Rethrow with the argv + a stdout snippet.
+   */
+  const runSfJson = (args: string[]): { result?: unknown } => {
+    const out = runner('sf', args);
+    try {
+      return JSON.parse(out) as { result?: unknown };
+    } catch {
+      throw new Error(
+        `\`sf ${args.join(' ')}\` did not return JSON (stdout starts: ${JSON.stringify(out.slice(0, 200))})`
+      );
+    }
   };
+
+  const display = runSfJson(['org', 'display', '-o', orgAlias, '--json']) as { result?: { instanceUrl?: string } };
   const instanceUrl = display.result?.instanceUrl;
   if (!instanceUrl) {
     throw new Error(`could not resolve instanceUrl for org "${orgAlias}" from \`sf org display\``);
   }
 
   // The dedicated command returns the REAL token; `org display` redacts it on recent CLI versions.
-  const tokenResult = JSON.parse(runner('sf', ['org', 'auth', 'show-access-token', '-o', orgAlias, '--json'])) as {
-    result?: { accessToken?: string } | string;
+  const tokenResult = runSfJson(['org', 'auth', 'show-access-token', '-o', orgAlias, '--json']) as {
+    result?: { accessToken?: string } | string | null;
   };
-  const accessToken = typeof tokenResult.result === 'object' ? tokenResult.result?.accessToken : undefined;
+  const accessToken =
+    typeof tokenResult.result === 'object' && tokenResult.result !== null ? tokenResult.result.accessToken : undefined;
   if (!accessToken) {
     throw new Error(`could not resolve accessToken for org "${orgAlias}" from \`sf org auth show-access-token\``);
   }
@@ -67,10 +82,12 @@ export const resolveOrgBootEnv = (orgAlias: string, options: ResolveOrgBootEnvOp
 
 /** Flatten a BootEnv into the `-e KEY=VALUE` env pairs the CB image expects at `docker run`. */
 export const bootEnvToDockerArgs = (bootEnv: BootEnv): string[] => {
+  // extraEnv is spread FIRST so the resolved core keys (SF_ACCESS_TOKEN/INSTANCE_URL) always win —
+  // an escape-hatch extraEnv can't silently clobber the org credentials the image boots from.
   const env: Record<string, string> = {
+    ...bootEnv.extraEnv,
     SF_ACCESS_TOKEN: bootEnv.accessToken,
-    INSTANCE_URL: bootEnv.instanceUrl,
-    ...bootEnv.extraEnv
+    INSTANCE_URL: bootEnv.instanceUrl
   };
   return Object.entries(env).flatMap(([k, v]) => ['-e', `${k}=${v}`]);
 };

--- a/packages/playwright-vscode-ext/src/codeBuilder/auth.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/auth.ts
@@ -55,9 +55,11 @@ export const resolveOrgBootEnv = (orgAlias: string, options: ResolveOrgBootEnvOp
     try {
       return JSON.parse(out) as { result?: unknown };
     } catch {
-      throw new Error(
-        `\`sf ${args.join(' ')}\` did not return JSON (stdout starts: ${JSON.stringify(out.slice(0, 200))})`
-      );
+      // Slicing raw stdout at a byte offset can split a multi-byte UTF-8 char (e.g. an emoji in a
+      // CLI banner), which JSON.stringify then renders as a replacement char. Strip non-printable-
+      // ASCII from the snippet first so the diagnostic stays clean and readable.
+      const snippet = out.slice(0, 200).replaceAll(/[^\x20-\x7E]/g, '?');
+      throw new Error(`\`sf ${args.join(' ')}\` did not return JSON (stdout starts: ${JSON.stringify(snippet)})`);
     }
   };
 

--- a/packages/playwright-vscode-ext/src/codeBuilder/auth.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/auth.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Org boot-env: the env the Code Builder image consumes at container start to log into an org
+ * (its start-time sfdx-org-auth.sh reads SF_ACCESS_TOKEN + INSTANCE_URL). The lifecycle `run`/
+ * `restart` inject this; how you obtain it is up to you.
+ *
+ * `resolveOrgBootEnv` is the OPTIONAL, `sf`-aware helper. It exists mainly to encapsulate one
+ * hard-won lesson: read the access token from `sf org auth show-access-token`, NOT `sf org display`.
+ * Recent CLI versions REDACT accessToken in `org display --json` (returning a "[REDACTED] Use 'sf
+ * org auth show-access-token' ..." placeholder), so a container booted from that placeholder fails
+ * its start-time login. Sourcing the real token here means the next adopter never re-hits it.
+ *
+ * NOTE: the container org model is an open question (plan §16 OQ3). Token injection is today's
+ * baseline; this helper may be superseded by a different auth path later.
+ */
+
+import { defaultRunner, type CommandRunner } from './runner';
+
+/** The env keys the CB image reads at boot to authenticate an org, plus an escape hatch for extras. */
+export type BootEnv = {
+  /** Real org access token (from `sf org auth show-access-token`, not the redacted `org display`). */
+  accessToken: string;
+  /** Org instance URL. */
+  instanceUrl: string;
+  /** Any additional env the consumer wants injected at container start. */
+  extraEnv?: Record<string, string>;
+};
+
+export type ResolveOrgBootEnvOptions = {
+  /** Command runner (injectable for tests). Defaults to real `sf` via execFileSync. */
+  runner?: CommandRunner;
+};
+
+/*
+ * Produce the boot env for an org alias using the `sf` CLI. Two calls, because the two facts live in
+ * two commands: instanceUrl from `org display`, and the (un-redacted) token from
+ * `org auth show-access-token`.
+ */
+export const resolveOrgBootEnv = (orgAlias: string, options: ResolveOrgBootEnvOptions = {}): BootEnv => {
+  const runner = options.runner ?? defaultRunner;
+
+  const display = JSON.parse(runner('sf', ['org', 'display', '-o', orgAlias, '--json'])) as {
+    result?: { instanceUrl?: string };
+  };
+  const instanceUrl = display.result?.instanceUrl;
+  if (!instanceUrl) {
+    throw new Error(`could not resolve instanceUrl for org "${orgAlias}" from \`sf org display\``);
+  }
+
+  // The dedicated command returns the REAL token; `org display` redacts it on recent CLI versions.
+  const tokenResult = JSON.parse(runner('sf', ['org', 'auth', 'show-access-token', '-o', orgAlias, '--json'])) as {
+    result?: { accessToken?: string } | string;
+  };
+  const accessToken = typeof tokenResult.result === 'object' ? tokenResult.result?.accessToken : undefined;
+  if (!accessToken) {
+    throw new Error(`could not resolve accessToken for org "${orgAlias}" from \`sf org auth show-access-token\``);
+  }
+
+  return { accessToken, instanceUrl };
+};
+
+/** Flatten a BootEnv into the `-e KEY=VALUE` env pairs the CB image expects at `docker run`. */
+export const bootEnvToDockerArgs = (bootEnv: BootEnv): string[] => {
+  const env: Record<string, string> = {
+    SF_ACCESS_TOKEN: bootEnv.accessToken,
+    INSTANCE_URL: bootEnv.instanceUrl,
+    ...bootEnv.extraEnv
+  };
+  return Object.entries(env).flatMap(([k, v]) => ['-e', `${k}=${v}`]);
+};

--- a/packages/playwright-vscode-ext/src/codeBuilder/auth.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/auth.ts
@@ -20,7 +20,21 @@
  * baseline; this helper may be superseded by a different auth path later.
  */
 
+import * as Schema from 'effect/Schema';
 import { defaultRunner, type CommandRunner } from './runner';
+
+/*
+ * Schemas for the `sf --json` shapes we consume, validated at the boundary (TS standards / precedent
+ * in manifest.ts) rather than trusted via `as` casts. Excess CLI fields are ignored; the fields we
+ * read are optional here so a MISSING field yields a clean domain error below (not a decode failure).
+ */
+const OrgDisplayShape = Schema.Struct({
+  result: Schema.optional(Schema.Struct({ instanceUrl: Schema.optional(Schema.String) }))
+});
+const ShowAccessTokenShape = Schema.Struct({
+  // `result` can legitimately be null on this command (#7718), so allow NullOr, not just optional.
+  result: Schema.Struct({ accessToken: Schema.optional(Schema.String) }).pipe(Schema.NullOr, Schema.optional)
+});
 
 /** The env keys the CB image reads at boot to authenticate an org, plus an escape hatch for extras. */
 export type BootEnv = {
@@ -50,10 +64,11 @@ export const resolveOrgBootEnv = (orgAlias: string, options: ResolveOrgBootEnvOp
    * banner to stdout (the "hard-won" class of bug), a bare JSON.parse throws an opaque
    * "Unexpected token" with no clue which command or org. Rethrow with the argv + a stdout snippet.
    */
-  const runSfJson = (args: string[]): { result?: unknown } => {
+  const runSfJson = <A>(args: string[], schema: Schema.Schema<A>): A => {
     const out = runner('sf', args);
+    let parsed: unknown;
     try {
-      return JSON.parse(out) as { result?: unknown };
+      parsed = JSON.parse(out);
     } catch {
       // Slicing raw stdout at a byte offset can split a multi-byte UTF-8 char (e.g. an emoji in a
       // CLI banner), which JSON.stringify then renders as a replacement char. Strip non-printable-
@@ -61,9 +76,12 @@ export const resolveOrgBootEnv = (orgAlias: string, options: ResolveOrgBootEnvOp
       const snippet = out.slice(0, 200).replaceAll(/[^\x20-\x7E]/g, '?');
       throw new Error(`\`sf ${args.join(' ')}\` did not return JSON (stdout starts: ${JSON.stringify(snippet)})`);
     }
+    // Validate the parsed shape at the boundary (schema, not `as`), so an unexpected `sf` output
+    // shape fails loud here rather than surfacing as an undefined further down.
+    return Schema.decodeUnknownSync(schema)(parsed);
   };
 
-  const display = runSfJson(['org', 'display', '-o', orgAlias, '--json']) as { result?: { instanceUrl?: string } };
+  const display = runSfJson(['org', 'display', '-o', orgAlias, '--json'], OrgDisplayShape);
   const instanceUrl = display.result?.instanceUrl;
   if (!instanceUrl) {
     throw new Error(`could not resolve instanceUrl for org "${orgAlias}" from \`sf org display\``);
@@ -71,10 +89,8 @@ export const resolveOrgBootEnv = (orgAlias: string, options: ResolveOrgBootEnvOp
 
   // The dedicated command returns the REAL token; `org display` redacts it on recent CLI versions.
   // `sf org auth show-access-token --json` returns `{ result: { accessToken } }` (an object — the
-  // #7718 workflow reads `.result.accessToken`); guard against a null result defensively.
-  const tokenResult = runSfJson(['org', 'auth', 'show-access-token', '-o', orgAlias, '--json']) as {
-    result?: { accessToken?: string } | null;
-  };
+  // #7718 workflow reads `.result.accessToken`); the schema allows a null result defensively.
+  const tokenResult = runSfJson(['org', 'auth', 'show-access-token', '-o', orgAlias, '--json'], ShowAccessTokenShape);
   const accessToken = tokenResult.result?.accessToken;
   if (!accessToken) {
     throw new Error(`could not resolve accessToken for org "${orgAlias}" from \`sf org auth show-access-token\``);

--- a/packages/playwright-vscode-ext/src/codeBuilder/auth.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/auth.ts
@@ -68,11 +68,12 @@ export const resolveOrgBootEnv = (orgAlias: string, options: ResolveOrgBootEnvOp
   }
 
   // The dedicated command returns the REAL token; `org display` redacts it on recent CLI versions.
+  // `sf org auth show-access-token --json` returns `{ result: { accessToken } }` (an object — the
+  // #7718 workflow reads `.result.accessToken`); guard against a null result defensively.
   const tokenResult = runSfJson(['org', 'auth', 'show-access-token', '-o', orgAlias, '--json']) as {
-    result?: { accessToken?: string } | string | null;
+    result?: { accessToken?: string } | null;
   };
-  const accessToken =
-    typeof tokenResult.result === 'object' && tokenResult.result !== null ? tokenResult.result.accessToken : undefined;
+  const accessToken = tokenResult.result?.accessToken;
   if (!accessToken) {
     throw new Error(`could not resolve accessToken for org "${orgAlias}" from \`sf org auth show-access-token\``);
   }

--- a/packages/playwright-vscode-ext/src/codeBuilder/lifecycle.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/lifecycle.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Container lifecycle: pull / run / restart / teardown, returning a typed ContainerHandle that
+ * threads through swap, seed, and verify. The toolkit owns docker (plan C1).
+ *
+ * Readiness is FOLDED INTO run and restart — they resolve only once the workbench URL answers, so a
+ * caller can never obtain an unhealthy handle. `restart` is a SINGLE verb: one `docker restart`
+ * re-scans /base/extension-overrides (applies a swap) AND re-runs the image's start-time org auth;
+ * splitting them would be a fiction the image doesn't support (ADR 0022).
+ */
+
+import { bootEnvToDockerArgs, type BootEnv } from './auth';
+import { defaultRunner, type CommandRunner } from './runner';
+
+/** The code-server port inside the CB image (served with --auth none); published to a host port. */
+export const CONTAINER_PORT = 58_080;
+
+/** A running container + the facts downstream steps need. Returned by run/restart, accepted by every verb. */
+export type ContainerHandle = {
+  name: string;
+  imageRef: string;
+  /** URL the workbench is served at, e.g. http://localhost:8123. */
+  publishedUrl: string;
+  /** Host port published to the container's code-server port. */
+  publishedPort: number;
+  /** The org boot env the container was started with (re-applied on restart). */
+  bootEnv: BootEnv;
+};
+
+/** A host→container bind mount (e.g. the fixture project). */
+export type Mount = { hostPath: string; containerPath: string };
+
+/** Returns true once the workbench URL answers. Injectable for tests; default does an HTTP GET. */
+export type ReadinessProbe = (url: string) => Promise<boolean>;
+
+export type ReadinessOptions = {
+  /** Overall wait budget in ms (default 120_000 — 60×2s, matching #7718). */
+  timeoutMs?: number;
+  /** Poll interval in ms (default 2_000). */
+  intervalMs?: number;
+  /** Health probe (default: fetch the URL, ok on any response). */
+  probe?: ReadinessProbe;
+};
+
+export type RunSpec = {
+  name: string;
+  imageRef: string;
+  /** Host port to publish the container's code-server port to. */
+  publishedPort: number;
+  bootEnv: BootEnv;
+  mounts?: readonly Mount[];
+  /** Workbench URL; defaults to http://localhost:<publishedPort>. */
+  url?: string;
+  readiness?: ReadinessOptions;
+};
+
+export type LifecycleOptions = { runner?: CommandRunner };
+
+const defaultProbe: ReadinessProbe = async url => {
+  try {
+    await fetch(url, { method: 'GET' });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+/** Poll until the workbench answers or the budget is exhausted; throw loud (with docker logs) on timeout. */
+const waitForWorkbench = async (
+  runner: CommandRunner,
+  handle: ContainerHandle,
+  readiness: ReadinessOptions = {}
+): Promise<void> => {
+  const timeoutMs = readiness.timeoutMs ?? 120_000;
+  const intervalMs = readiness.intervalMs ?? 2000;
+  const probe = readiness.probe ?? defaultProbe;
+  const deadline = Date.now() + timeoutMs;
+  do {
+    if (await probe(handle.publishedUrl)) {
+      return;
+    }
+    await sleep(intervalMs);
+  } while (Date.now() < deadline);
+  let logs = '';
+  try {
+    logs = runner('docker', ['logs', handle.name]);
+  } catch {
+    /* best-effort */
+  }
+  throw new Error(`Code Builder never became reachable at ${handle.publishedUrl} within ${timeoutMs}ms\n${logs}`);
+};
+
+/** Pull the image. */
+export const pull = (imageRef: string, options: LifecycleOptions = {}): void => {
+  (options.runner ?? defaultRunner)('docker', ['pull', imageRef]);
+};
+
+/*
+ * Start the container (detached), then wait for the workbench. Resolves only when healthy — the
+ * returned handle is always usable.
+ */
+export const run = async (spec: RunSpec, options: LifecycleOptions = {}): Promise<ContainerHandle> => {
+  const runner = options.runner ?? defaultRunner;
+  const publishedUrl = spec.url ?? `http://localhost:${spec.publishedPort}`;
+  const mountArgs = (spec.mounts ?? []).flatMap(m => ['-v', `${m.hostPath}:${m.containerPath}`]);
+  runner('docker', [
+    'run',
+    '-d',
+    '--name',
+    spec.name,
+    ...bootEnvToDockerArgs(spec.bootEnv),
+    ...mountArgs,
+    '-p',
+    `${spec.publishedPort}:${CONTAINER_PORT}`,
+    spec.imageRef
+  ]);
+  const handle: ContainerHandle = {
+    name: spec.name,
+    imageRef: spec.imageRef,
+    publishedUrl,
+    publishedPort: spec.publishedPort,
+    bootEnv: spec.bootEnv
+  };
+  await waitForWorkbench(runner, handle, spec.readiness);
+  return handle;
+};
+
+/*
+ * Restart the container and wait for the workbench again. One `docker restart` both re-scans the
+ * extension-overrides (applying a prior swap) and re-runs the image's start-time org auth.
+ */
+export const restart = async (
+  handle: ContainerHandle,
+  readiness: ReadinessOptions = {},
+  options: LifecycleOptions = {}
+): Promise<ContainerHandle> => {
+  const runner = options.runner ?? defaultRunner;
+  runner('docker', ['restart', handle.name]);
+  await waitForWorkbench(runner, handle, readiness);
+  return handle;
+};
+
+/** Remove the container (best-effort; safe to call in an always()/finally cleanup). */
+export const teardown = (handle: ContainerHandle, options: LifecycleOptions = {}): void => {
+  try {
+    (options.runner ?? defaultRunner)('docker', ['rm', '-f', handle.name]);
+  } catch {
+    /* best-effort cleanup */
+  }
+};

--- a/packages/playwright-vscode-ext/src/codeBuilder/lifecycle.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/lifecycle.ts
@@ -62,10 +62,18 @@ export type RunSpec = {
 
 export type LifecycleOptions = { runner?: CommandRunner };
 
+/*
+ * Default probe: GET the workbench URL. Two guards the naive version missed:
+ *  - a per-request AbortSignal.timeout — otherwise a half-open socket (container accepted the TCP
+ *    connection but never responds) hangs the fetch forever and the overall readiness budget is a
+ *    lie (the loop can only check the deadline BETWEEN probes, not mid-probe).
+ *  - res.ok — a booting code-server can bind the port and answer 404/500/502 before the workbench is
+ *    actually serving; only a 2xx means ready, else we'd hand back an unhealthy handle.
+ */
 const defaultProbe: ReadinessProbe = async url => {
   try {
-    await fetch(url, { method: 'GET' });
-    return true;
+    const res = await fetch(url, { method: 'GET', signal: AbortSignal.timeout(5000) });
+    return res.ok;
   } catch {
     return false;
   }
@@ -129,7 +137,14 @@ export const run = async (spec: RunSpec, options: LifecycleOptions = {}): Promis
     publishedPort: spec.publishedPort,
     bootEnv: spec.bootEnv
   };
-  await waitForWorkbench(runner, handle, spec.readiness);
+  try {
+    await waitForWorkbench(runner, handle, spec.readiness);
+  } catch (err) {
+    // Readiness failed — tear the just-started container down so a retry with the same name isn't
+    // blocked by "container name already in use", and no orphan is left running.
+    teardown(handle, { runner });
+    throw err;
+  }
   return handle;
 };
 

--- a/packages/playwright-vscode-ext/src/codeBuilder/lifecycle.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/lifecycle.ts
@@ -35,6 +35,11 @@ export type ContainerHandle = {
   publishedUrl: string;
   /** Host port published to the container's code-server port. */
   publishedPort: number;
+  /**
+   * The bind mounts `run` applied (empty when none). Recorded so downstream steps — notably seed —
+   * can validate a path against a REAL mount instead of trusting a "keep in sync" comment.
+   */
+  mounts: readonly Mount[];
 };
 
 /** A host→container bind mount (e.g. the fixture project). */
@@ -97,12 +102,17 @@ const waitForWorkbench = async (
   const intervalMs = readiness.intervalMs ?? 2000;
   const probe = readiness.probe ?? defaultProbe;
   const deadline = Date.now() + timeoutMs;
-  do {
+  // Check the deadline BEFORE the trailing sleep (not after): the loop still probes first — an
+  // already-up container returns on the first iteration with zero wasted interval — but it never
+  // burns a full intervalMs sleep once the budget is spent, so the effective wait stays within
+  // timeoutMs (the do-while overshot by up to one interval) and a timeoutMs: 0 fast-fail probes zero
+  // times. Each probe is itself time-bounded (default AbortSignal.timeout), so no probe can hang.
+  while (Date.now() < deadline) {
     if (await probe(handle.publishedUrl)) {
       return;
     }
     await sleep(intervalMs);
-  } while (Date.now() < deadline);
+  }
   let logs = '';
   try {
     logs = runner('docker', ['logs', handle.name]);
@@ -140,7 +150,8 @@ export const run = async (spec: RunSpec, options: LifecycleOptions = {}): Promis
     name: spec.name,
     imageRef: spec.imageRef,
     publishedUrl,
-    publishedPort: spec.publishedPort
+    publishedPort: spec.publishedPort,
+    mounts: spec.mounts ?? []
   };
   try {
     await waitForWorkbench(runner, handle, spec.readiness);
@@ -156,6 +167,14 @@ export const run = async (spec: RunSpec, options: LifecycleOptions = {}): Promis
 /*
  * Restart the container and wait for the workbench again. One `docker restart` both re-scans the
  * extension-overrides (applying a prior swap) and re-runs the image's start-time org auth.
+ *
+ * CAVEAT (plan §16 OQ3): `docker restart` reuses the env baked at `docker run`, so start-time org
+ * auth re-runs against the ORIGINAL SF_ACCESS_TOKEN — there is no path to inject a fresh token here.
+ * `waitForWorkbench` only probes code-server's HTTP surface (which answers 2xx/3xx regardless of org
+ * auth state), so a restart after the token expired resolves as "healthy" while the org is actually
+ * unauthenticated, and downstream org-dependent specs then fail with confusing auth errors far from
+ * the cause. Low likelihood in practice (sf tokens last ~2h vs. a typically-seconds run→restart gap),
+ * so this is documented rather than asserted; if it ever bites, add a post-restart org-auth check.
  */
 export const restart = async (
   handle: ContainerHandle,

--- a/packages/playwright-vscode-ext/src/codeBuilder/lifecycle.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/lifecycle.ts
@@ -21,7 +21,13 @@ import { defaultRunner, type CommandRunner } from './runner';
 /** The code-server port inside the CB image (served with --auth none); published to a host port. */
 export const CONTAINER_PORT = 58_080;
 
-/** A running container + the facts downstream steps need. Returned by run/restart, accepted by every verb. */
+/*
+ * A running container + the facts downstream steps need. Returned by run/restart, accepted by every
+ * verb. Deliberately does NOT carry bootEnv: the access token is an INPUT to `run` (baked into the
+ * container's env by `docker run`), not a downstream fact — keeping it here would (a) leak a live
+ * secret into any object a consumer logs, and (b) falsely imply mutating it before `restart` re-auths
+ * (it can't — `docker restart` reuses the original container env).
+ */
 export type ContainerHandle = {
   name: string;
   imageRef: string;
@@ -29,8 +35,6 @@ export type ContainerHandle = {
   publishedUrl: string;
   /** Host port published to the container's code-server port. */
   publishedPort: number;
-  /** The org boot env the container was started with (re-applied on restart). */
-  bootEnv: BootEnv;
 };
 
 /** A host→container bind mount (e.g. the fixture project). */
@@ -67,13 +71,15 @@ export type LifecycleOptions = { runner?: CommandRunner };
  *  - a per-request AbortSignal.timeout — otherwise a half-open socket (container accepted the TCP
  *    connection but never responds) hangs the fetch forever and the overall readiness budget is a
  *    lie (the loop can only check the deadline BETWEEN probes, not mid-probe).
- *  - res.ok — a booting code-server can bind the port and answer 404/500/502 before the workbench is
- *    actually serving; only a 2xx means ready, else we'd hand back an unhealthy handle.
+ *  - `status < 400` (NOT res.ok) — code-server with `--auth none` answers `/` with a 302 redirect
+ *    (e.g. to `?folder=…`); res.ok (2xx-only) would reject that healthy response and burn the whole
+ *    budget. This matches #7718's proven `curl -fsS` (no -L), which treats 3xx as success and only
+ *    fails on 4xx/5xx. A booting server that answers 4xx/5xx is correctly still "not ready".
  */
 const defaultProbe: ReadinessProbe = async url => {
   try {
-    const res = await fetch(url, { method: 'GET', signal: AbortSignal.timeout(5000) });
-    return res.ok;
+    const res = await fetch(url, { method: 'GET', redirect: 'manual', signal: AbortSignal.timeout(5000) });
+    return res.status < 400;
   } catch {
     return false;
   }
@@ -134,8 +140,7 @@ export const run = async (spec: RunSpec, options: LifecycleOptions = {}): Promis
     name: spec.name,
     imageRef: spec.imageRef,
     publishedUrl,
-    publishedPort: spec.publishedPort,
-    bootEnv: spec.bootEnv
+    publishedPort: spec.publishedPort
   };
   try {
     await waitForWorkbench(runner, handle, spec.readiness);

--- a/packages/playwright-vscode-ext/src/codeBuilder/seed.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/seed.ts
@@ -39,9 +39,14 @@ coder=${CODER_JSON}
 settings=${USER_SETTINGS}
 mkdir -p "$(dirname "$coder")" "$(dirname "$settings")"
 jq -n --arg folder "$FIXTURE_PATH" '{query: {folder: $folder}}' > "$coder"
-[ -s "$settings" ] || echo '{}' > "$settings"
+# Start from a valid object if settings.json is absent OR not valid JSON (whitespace-only, corrupt),
+# so the trust edit below can't silently no-op. Bare 'jq' statements (NOT 'jq ... && mv') so 'set -e'
+# aborts loud on a jq failure — with '&&' the jq is the left operand and errexit would NOT fire, and
+# the trust setting would be silently skipped (workspace opens Restricted, extensions never activate).
+jq -e . "$settings" > /dev/null 2>&1 || echo '{}' > "$settings"
 tmp="$(mktemp)"
-jq '.["security.workspace.trust.enabled"] = false' "$settings" > "$tmp" && mv "$tmp" "$settings"
+jq '.["security.workspace.trust.enabled"] = false' "$settings" > "$tmp"
+mv "$tmp" "$settings"
 chown codebuilder:codebuilder "$coder" "$settings"
 `;
 

--- a/packages/playwright-vscode-ext/src/codeBuilder/seed.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/seed.ts
@@ -35,6 +35,10 @@ const USER_SETTINGS = '/home/codebuilder/.local/share/code-server/User/settings.
  */
 const SEED_SCRIPT = `
 set -e
+# jq preflight: the whole script hard-depends on jq and the CB image is team-owned + changeable
+# (ADR 0022). Without this, an image missing jq aborts with an opaque "jq: command not found"; fail
+# early with a clear, greppable message instead.
+command -v jq >/dev/null 2>&1 || { echo "seed: jq not found in container (SEED_SCRIPT requires jq)" >&2; exit 127; }
 coder=${CODER_JSON}
 settings=${USER_SETTINGS}
 mkdir -p "$(dirname "$coder")" "$(dirname "$settings")"
@@ -74,5 +78,32 @@ export const seedWorkspace = (handle: ContainerHandle, options: SeedOptions = {}
   const runner = options.runner ?? defaultRunner;
   const fixturePath = options.fixturePath ?? FIXTURE_MOUNT_PATH;
 
-  runner('docker', ['exec', '-e', `FIXTURE_PATH=${fixturePath}`, handle.name, 'bash', '-c', SEED_SCRIPT]);
+  // Cross-check the fixture path against the container's REAL mounts (recorded by `run`) instead of
+  // trusting the FIXTURE_MOUNT_PATH "keep in sync" comment. A caller who mounts the fixture at a
+  // custom containerPath but forgets to pass the matching fixturePath here would otherwise write a
+  // coder.json pointing at a non-mounted folder — code-server opens an empty dir and specs fail with
+  // a confusing "no SFDX project" far from the cause. Skip when no mounts were recorded.
+  const mountPaths = handle.mounts.map(m => m.containerPath);
+  if (mountPaths.length > 0 && !mountPaths.includes(fixturePath)) {
+    throw new Error(
+      `seedWorkspace: fixturePath "${fixturePath}" is not a container mount (mounted: ${mountPaths.join(', ')}). ` +
+        'Pass the same containerPath you gave run()\'s mounts, or omit fixturePath to use the default.'
+    );
+  }
+
+  try {
+    runner('docker', ['exec', '-e', `FIXTURE_PATH=${fixturePath}`, handle.name, 'bash', '-c', SEED_SCRIPT]);
+  } catch (err) {
+    // Parity with waitForWorkbench's diagnostics: a bare exec failure (jq missing, chown/mkdir fails)
+    // otherwise surfaces downstream as "extensions didn't activate" with no context. Append docker
+    // logs (best-effort) so the real cause travels with the thrown error.
+    let logs = '';
+    try {
+      logs = runner('docker', ['logs', handle.name]);
+    } catch {
+      /* best-effort */
+    }
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(`seedWorkspace failed for container "${handle.name}": ${detail}\n${logs}`);
+  }
 };

--- a/packages/playwright-vscode-ext/src/codeBuilder/seed.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/seed.ts
@@ -38,15 +38,23 @@ set -e
 coder=${CODER_JSON}
 settings=${USER_SETTINGS}
 mkdir -p "$(dirname "$coder")" "$(dirname "$settings")"
-jq -n --arg folder "$FIXTURE_PATH" '{query: {folder: $folder}}' > "$coder"
-# Start from a valid object if settings.json is absent OR not valid JSON (whitespace-only, corrupt),
-# so the trust edit below can't silently no-op. Bare 'jq' statements (NOT 'jq ... && mv') so 'set -e'
-# aborts loud on a jq failure — with '&&' the jq is the left operand and errexit would NOT fire, and
-# the trust setting would be silently skipped (workspace opens Restricted, extensions never activate).
-jq -e . "$settings" > /dev/null 2>&1 || echo '{}' > "$settings"
-tmp="$(mktemp)"
-jq '.["security.workspace.trust.enabled"] = false' "$settings" > "$tmp"
-mv "$tmp" "$settings"
+
+# coder.json: build in a temp then atomically mv into place so a concurrent reader never sees a
+# partial file. Bare statements (NOT 'jq ... && mv') so 'set -e' aborts loud on a jq failure.
+ctmp="$(mktemp)"
+jq -n --arg folder "$FIXTURE_PATH" '{query: {folder: $folder}}' > "$ctmp"
+mv "$ctmp" "$coder"
+
+# settings.json (disable workspace trust): ONE atomic read-modify-write. Read the current settings,
+# defaulting to {} if the file is absent OR not valid JSON (so the edit can't silently no-op), apply
+# the trust edit in a single jq, then mv into place. The mv is the ONLY mutation of settings.json —
+# there is no separate truncating 'echo > settings' that could clobber a concurrent code-server
+# write (the check-then-write race). Bare statements so 'set -e' catches a jq failure.
+stmp="$(mktemp)"
+current="$(jq . "$settings" 2>/dev/null || echo '{}')"
+printf '%s' "$current" | jq '.["security.workspace.trust.enabled"] = false' > "$stmp"
+mv "$stmp" "$settings"
+
 chown codebuilder:codebuilder "$coder" "$settings"
 `;
 

--- a/packages/playwright-vscode-ext/src/codeBuilder/seed.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/seed.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Seed the workspace before specs run. One brick owning BOTH post-boot docker-exec writes (plan §7.3):
+ *  1. coder.json — point code-server at the bind-mounted fixture project (bypasses the image's
+ *     first-boot SFDX_COBU_* generate path, which the CB team owns and can change — ADR 0022).
+ *  2. workspace-trust setting — an untrusted workspace opens in Restricted Mode where the Salesforce
+ *     extensions don't activate and their commands never register. The setting is workspace-agnostic,
+ *     so it covers the mount.
+ *
+ * The bind MOUNT itself is a `run` param (lifecycle), not seeded here — seed only does the exec
+ * writes. Run this AFTER the workbench is up and BEFORE the swap restart, so the host boots opening
+ * the fixture in trusted mode.
+ */
+
+import type { ContainerHandle } from './lifecycle';
+import { defaultRunner, type CommandRunner } from './runner';
+
+/** Default path the fixture project is bind-mounted to (keep in sync with the lifecycle run mount). */
+export const FIXTURE_MOUNT_PATH = '/home/codebuilder/fixture-project';
+
+const CODER_JSON = '/home/codebuilder/.local/share/code-server/coder.json';
+const USER_SETTINGS = '/home/codebuilder/.local/share/code-server/User/settings.json';
+
+/*
+ * The write script. Reads the fixture path from the env var $FIXTURE_PATH (passed via `docker exec
+ * -e`), so it's a DATA value — never interpolated into the script and safe for any path. jq -n --arg
+ * builds coder.json; jq edits settings.json. Both files are written as the codebuilder user (docker
+ * exec runs as root) since start.sh reads them from that home.
+ */
+const SEED_SCRIPT = `
+set -e
+coder=${CODER_JSON}
+settings=${USER_SETTINGS}
+mkdir -p "$(dirname "$coder")" "$(dirname "$settings")"
+jq -n --arg folder "$FIXTURE_PATH" '{query: {folder: $folder}}' > "$coder"
+[ -s "$settings" ] || echo '{}' > "$settings"
+tmp="$(mktemp)"
+jq '.["security.workspace.trust.enabled"] = false' "$settings" > "$tmp" && mv "$tmp" "$settings"
+chown codebuilder:codebuilder "$coder" "$settings"
+`;
+
+export type SeedOptions = {
+  /** Where the fixture project is mounted in the container. Defaults to FIXTURE_MOUNT_PATH. */
+  fixturePath?: string;
+  /** Command runner (injectable for tests). Defaults to real docker via execFileSync. */
+  runner?: CommandRunner;
+};
+
+/*
+ * Write coder.json + disable workspace trust in the container. The fixture path is passed as a
+ * container env var (`docker exec -e FIXTURE_PATH=…`), a single argv token — no shell interpolation,
+ * so any path is safe.
+ */
+export const seedWorkspace = (handle: ContainerHandle, options: SeedOptions = {}): void => {
+  const runner = options.runner ?? defaultRunner;
+  const fixturePath = options.fixturePath ?? FIXTURE_MOUNT_PATH;
+
+  runner('docker', ['exec', '-e', `FIXTURE_PATH=${fixturePath}`, handle.name, 'bash', '-c', SEED_SCRIPT]);
+};

--- a/packages/playwright-vscode-ext/src/index.ts
+++ b/packages/playwright-vscode-ext/src/index.ts
@@ -208,5 +208,18 @@ export { verifyExtensions, assertVerified, OVERRIDES_DIR, RUNTIME_EXT_DIR } from
 export type { VerifyOptions, VerifyResult, VerifyEntryResult } from './codeBuilder/verify';
 export { swap, defaultExtract } from './codeBuilder/swap';
 export type { SwapOptions, ExtractZip } from './codeBuilder/swap';
+export { pull, run, restart, teardown, CONTAINER_PORT } from './codeBuilder/lifecycle';
+export type {
+  ContainerHandle,
+  Mount,
+  RunSpec,
+  ReadinessOptions,
+  ReadinessProbe,
+  LifecycleOptions
+} from './codeBuilder/lifecycle';
+export { resolveOrgBootEnv, bootEnvToDockerArgs } from './codeBuilder/auth';
+export type { BootEnv, ResolveOrgBootEnvOptions } from './codeBuilder/auth';
+export { seedWorkspace, FIXTURE_MOUNT_PATH } from './codeBuilder/seed';
+export type { SeedOptions } from './codeBuilder/seed';
 export { defaultRunner } from './codeBuilder/runner';
 export type { CommandRunner } from './codeBuilder/runner';

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/auth.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/auth.test.ts
@@ -54,6 +54,19 @@ describe('resolveOrgBootEnv', () => {
     const { runner } = makeSfRunner({ instanceUrl: 'https://x', token: null });
     expect(() => resolveOrgBootEnv('myOrg', { runner })).toThrow(/accessToken/);
   });
+
+  it('does not crash when show-access-token result is null (typeof null === object)', () => {
+    const runner: CommandRunner = (file, args) => {
+      if (args[1] === 'display') return JSON.stringify({ result: { instanceUrl: 'https://x' } });
+      return JSON.stringify({ result: null }); // show-access-token
+    };
+    expect(() => resolveOrgBootEnv('myOrg', { runner })).toThrow(/accessToken/); // clean error, not a TypeError
+  });
+
+  it('throws a diagnostic (command + snippet) when sf prints non-JSON stdout noise', () => {
+    const runner: CommandRunner = () => 'Warning: @salesforce/cli update available...\n{"result":{}}';
+    expect(() => resolveOrgBootEnv('myOrg', { runner })).toThrow(/org display[\s\S]*did not return JSON/);
+  });
 });
 
 describe('bootEnvToDockerArgs', () => {
@@ -69,5 +82,17 @@ describe('bootEnvToDockerArgs', () => {
   it('includes extraEnv pairs', () => {
     const args = bootEnvToDockerArgs({ accessToken: 'T', instanceUrl: 'https://x', extraEnv: { FOO: 'bar' } });
     expect(args).toContain('FOO=bar');
+  });
+
+  it('does not let extraEnv override the resolved core credentials', () => {
+    const args = bootEnvToDockerArgs({
+      accessToken: 'REAL',
+      instanceUrl: 'https://real',
+      extraEnv: { SF_ACCESS_TOKEN: 'HIJACK', INSTANCE_URL: 'https://evil' }
+    });
+    expect(args).toContain('SF_ACCESS_TOKEN=REAL');
+    expect(args).toContain('INSTANCE_URL=https://real');
+    expect(args).not.toContain('SF_ACCESS_TOKEN=HIJACK');
+    expect(args).not.toContain('INSTANCE_URL=https://evil');
   });
 });

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/auth.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/auth.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { bootEnvToDockerArgs, resolveOrgBootEnv } from '../../../src/codeBuilder/auth';
+import type { CommandRunner } from '../../../src/codeBuilder/runner';
+
+const REDACTED = "[REDACTED] Use 'sf org auth show-access-token' to view";
+
+/** Fake `sf` runner: org display returns instanceUrl (token redacted); show-access-token returns the real token. */
+const makeSfRunner = (opts: {
+  instanceUrl?: string;
+  token?: string | null;
+  displayToken?: string;
+}): {
+  runner: CommandRunner;
+  calls: string[][];
+} => {
+  const calls: string[][] = [];
+  const runner: CommandRunner = (file, args) => {
+    calls.push([file, ...args]);
+    if (args[0] === 'org' && args[1] === 'display') {
+      return JSON.stringify({ result: { instanceUrl: opts.instanceUrl, accessToken: opts.displayToken ?? REDACTED } });
+    }
+    if (args[0] === 'org' && args[1] === 'auth' && args[2] === 'show-access-token') {
+      return JSON.stringify({ result: { accessToken: opts.token } });
+    }
+    return '{}';
+  };
+  return { runner, calls };
+};
+
+describe('resolveOrgBootEnv', () => {
+  it('reads the token from show-access-token, NOT the redacted org display', () => {
+    const { runner, calls } = makeSfRunner({ instanceUrl: 'https://x.my.salesforce.com', token: 'REAL_TOKEN' });
+    const env = resolveOrgBootEnv('myOrg', { runner });
+
+    expect(env).toEqual({ accessToken: 'REAL_TOKEN', instanceUrl: 'https://x.my.salesforce.com' });
+    // It actually called the dedicated token command (the whole point of this helper).
+    expect(calls.some(c => c[1] === 'org' && c[2] === 'auth' && c[3] === 'show-access-token')).toBe(true);
+    // And it did NOT use org display's (redacted) token.
+    expect(env.accessToken).not.toContain('REDACTED');
+  });
+
+  it('throws when instanceUrl is missing', () => {
+    const { runner } = makeSfRunner({ instanceUrl: undefined, token: 'T' });
+    expect(() => resolveOrgBootEnv('myOrg', { runner })).toThrow(/instanceUrl/);
+  });
+
+  it('throws when the access token is missing/null', () => {
+    const { runner } = makeSfRunner({ instanceUrl: 'https://x', token: null });
+    expect(() => resolveOrgBootEnv('myOrg', { runner })).toThrow(/accessToken/);
+  });
+});
+
+describe('bootEnvToDockerArgs', () => {
+  it('maps to the CB image env keys the image reads at boot', () => {
+    expect(bootEnvToDockerArgs({ accessToken: 'T', instanceUrl: 'https://x' })).toEqual([
+      '-e',
+      'SF_ACCESS_TOKEN=T',
+      '-e',
+      'INSTANCE_URL=https://x'
+    ]);
+  });
+
+  it('includes extraEnv pairs', () => {
+    const args = bootEnvToDockerArgs({ accessToken: 'T', instanceUrl: 'https://x', extraEnv: { FOO: 'bar' } });
+    expect(args).toContain('FOO=bar');
+  });
+});

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/lifecycle.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/lifecycle.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { CONTAINER_PORT, pull, restart, run, teardown, type ReadinessProbe } from '../../../src/codeBuilder/lifecycle';
+import type { CommandRunner } from '../../../src/codeBuilder/runner';
+import type { BootEnv } from '../../../src/codeBuilder/auth';
+
+const BOOT_ENV: BootEnv = { accessToken: 'TOK', instanceUrl: 'https://x.my.salesforce.com' };
+
+const recorder = (): { runner: CommandRunner; calls: string[][] } => {
+  const calls: string[][] = [];
+  return { calls, runner: (file, args) => (calls.push([file, ...args]), '') };
+};
+
+const alwaysReady: ReadinessProbe = () => Promise.resolve(true);
+const neverReady: ReadinessProbe = () => Promise.resolve(false);
+
+describe('lifecycle', () => {
+  it('pull issues docker pull', () => {
+    const { runner, calls } = recorder();
+    pull('img:latest', { runner });
+    expect(calls[0]).toEqual(['docker', 'pull', 'img:latest']);
+  });
+
+  it('run builds the correct docker run argv (env, mount, port) and returns a healthy handle', async () => {
+    const { runner, calls } = recorder();
+    const handle = await run(
+      {
+        name: 'cb',
+        imageRef: 'img:latest',
+        publishedPort: 8123,
+        bootEnv: BOOT_ENV,
+        mounts: [{ hostPath: '/host/fixture', containerPath: '/home/codebuilder/fixture-project' }],
+        readiness: { probe: alwaysReady, intervalMs: 1 }
+      },
+      { runner }
+    );
+
+    const runCall = calls.find(c => c[1] === 'run')!;
+    expect(runCall).toContain('-d');
+    expect(runCall).toEqual(expect.arrayContaining(['--name', 'cb']));
+    expect(runCall).toEqual(expect.arrayContaining(['-e', 'SF_ACCESS_TOKEN=TOK']));
+    expect(runCall).toEqual(expect.arrayContaining(['-e', 'INSTANCE_URL=https://x.my.salesforce.com']));
+    expect(runCall).toEqual(expect.arrayContaining(['-v', '/host/fixture:/home/codebuilder/fixture-project']));
+    expect(runCall).toEqual(expect.arrayContaining(['-p', `8123:${CONTAINER_PORT}`]));
+    expect(runCall.at(-1)).toBe('img:latest');
+
+    expect(handle).toEqual({
+      name: 'cb',
+      imageRef: 'img:latest',
+      publishedUrl: 'http://localhost:8123',
+      publishedPort: 8123,
+      bootEnv: BOOT_ENV
+    });
+  });
+
+  it('run throws (with docker logs) when the workbench never becomes ready', async () => {
+    const runner: CommandRunner = (file, args) => (args[0] === 'logs' ? 'boot failed line' : '');
+    await expect(
+      run(
+        {
+          name: 'cb',
+          imageRef: 'img',
+          publishedPort: 8123,
+          bootEnv: BOOT_ENV,
+          readiness: { probe: neverReady, timeoutMs: 5, intervalMs: 1 }
+        },
+        { runner }
+      )
+    ).rejects.toThrow(/never became reachable[\s\S]*boot failed line/);
+  });
+
+  it('restart issues docker restart then waits for readiness', async () => {
+    const { runner, calls } = recorder();
+    const handle = {
+      name: 'cb',
+      imageRef: 'img',
+      publishedUrl: 'http://localhost:8123',
+      publishedPort: 8123,
+      bootEnv: BOOT_ENV
+    };
+    const returned = await restart(handle, { probe: alwaysReady, intervalMs: 1 }, { runner });
+    expect(calls.find(c => c[1] === 'restart')).toEqual(['docker', 'restart', 'cb']);
+    expect(returned).toBe(handle);
+  });
+
+  it('teardown removes the container and swallows errors', () => {
+    const { runner, calls } = recorder();
+    const handle = {
+      name: 'cb',
+      imageRef: 'img',
+      publishedUrl: 'http://localhost:8123',
+      publishedPort: 8123,
+      bootEnv: BOOT_ENV
+    };
+    teardown(handle, { runner });
+    expect(calls[0]).toEqual(['docker', 'rm', '-f', 'cb']);
+    // A throwing runner must not propagate out of teardown (safe in finally/always cleanup).
+    expect(() =>
+      teardown(handle, {
+        runner: () => {
+          throw new Error('boom');
+        }
+      })
+    ).not.toThrow();
+  });
+});

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/lifecycle.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/lifecycle.test.ts
@@ -53,9 +53,10 @@ describe('lifecycle', () => {
       name: 'cb',
       imageRef: 'img:latest',
       publishedUrl: 'http://localhost:8123',
-      publishedPort: 8123,
-      bootEnv: BOOT_ENV
+      publishedPort: 8123
     });
+    // The handle must NOT carry the access token (secret-leak guard).
+    expect(handle).not.toHaveProperty('bootEnv');
   });
 
   it('run throws (with docker logs) AND tears down the container when readiness times out', async () => {
@@ -86,8 +87,7 @@ describe('lifecycle', () => {
       name: 'cb',
       imageRef: 'img',
       publishedUrl: 'http://localhost:8123',
-      publishedPort: 8123,
-      bootEnv: BOOT_ENV
+      publishedPort: 8123
     };
     const returned = await restart(handle, { probe: alwaysReady, intervalMs: 1 }, { runner });
     expect(calls.find(c => c[1] === 'restart')).toEqual(['docker', 'restart', 'cb']);
@@ -100,8 +100,7 @@ describe('lifecycle', () => {
       name: 'cb',
       imageRef: 'img',
       publishedUrl: 'http://localhost:8123',
-      publishedPort: 8123,
-      bootEnv: BOOT_ENV
+      publishedPort: 8123
     };
     teardown(handle, { runner });
     expect(calls[0]).toEqual(['docker', 'rm', '-f', 'cb']);

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/lifecycle.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/lifecycle.test.ts
@@ -58,8 +58,12 @@ describe('lifecycle', () => {
     });
   });
 
-  it('run throws (with docker logs) when the workbench never becomes ready', async () => {
-    const runner: CommandRunner = (file, args) => (args[0] === 'logs' ? 'boot failed line' : '');
+  it('run throws (with docker logs) AND tears down the container when readiness times out', async () => {
+    const calls: string[][] = [];
+    const runner: CommandRunner = (file, args) => {
+      calls.push([file, ...args]);
+      return args[0] === 'logs' ? 'boot failed line' : '';
+    };
     await expect(
       run(
         {
@@ -72,6 +76,8 @@ describe('lifecycle', () => {
         { runner }
       )
     ).rejects.toThrow(/never became reachable[\s\S]*boot failed line/);
+    // The just-started container is removed so a retry isn't blocked by a name conflict.
+    expect(calls.find(c => c[0] === 'docker' && c[1] === 'rm' && c[2] === '-f' && c[3] === 'cb')).toBeDefined();
   });
 
   it('restart issues docker restart then waits for readiness', async () => {

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/lifecycle.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/lifecycle.test.ts
@@ -53,7 +53,9 @@ describe('lifecycle', () => {
       name: 'cb',
       imageRef: 'img:latest',
       publishedUrl: 'http://localhost:8123',
-      publishedPort: 8123
+      publishedPort: 8123,
+      // run records the mounts it applied so downstream steps (seed) can validate against them.
+      mounts: [{ hostPath: '/host/fixture', containerPath: '/home/codebuilder/fixture-project' }]
     });
     // The handle must NOT carry the access token (secret-leak guard).
     expect(handle).not.toHaveProperty('bootEnv');
@@ -81,13 +83,37 @@ describe('lifecycle', () => {
     expect(calls.find(c => c[0] === 'docker' && c[1] === 'rm' && c[2] === '-f' && c[3] === 'cb')).toBeDefined();
   });
 
+  it('checks the deadline before sleeping: timeoutMs 0 fast-fails without probing (no trailing sleep)', async () => {
+    const { runner } = recorder();
+    let probes = 0;
+    const countingProbe: ReadinessProbe = () => {
+      probes += 1;
+      return Promise.resolve(false);
+    };
+    await expect(
+      run(
+        {
+          name: 'cb',
+          imageRef: 'img',
+          publishedPort: 8123,
+          bootEnv: BOOT_ENV,
+          readiness: { probe: countingProbe, timeoutMs: 0, intervalMs: 1000 }
+        },
+        { runner }
+      )
+    ).rejects.toThrow(/never became reachable/);
+    // A spent budget must not burn a probe or a trailing interval sleep.
+    expect(probes).toBe(0);
+  });
+
   it('restart issues docker restart then waits for readiness', async () => {
     const { runner, calls } = recorder();
     const handle = {
       name: 'cb',
       imageRef: 'img',
       publishedUrl: 'http://localhost:8123',
-      publishedPort: 8123
+      publishedPort: 8123,
+      mounts: []
     };
     const returned = await restart(handle, { probe: alwaysReady, intervalMs: 1 }, { runner });
     expect(calls.find(c => c[1] === 'restart')).toEqual(['docker', 'restart', 'cb']);
@@ -100,7 +126,8 @@ describe('lifecycle', () => {
       name: 'cb',
       imageRef: 'img',
       publishedUrl: 'http://localhost:8123',
-      publishedPort: 8123
+      publishedPort: 8123,
+      mounts: []
     };
     teardown(handle, { runner });
     expect(calls[0]).toEqual(['docker', 'rm', '-f', 'cb']);

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/seed.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/seed.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import type { ContainerHandle } from '../../../src/codeBuilder/lifecycle';
+import type { CommandRunner } from '../../../src/codeBuilder/runner';
+import { FIXTURE_MOUNT_PATH, seedWorkspace } from '../../../src/codeBuilder/seed';
+
+const HANDLE: ContainerHandle = {
+  name: 'cb',
+  imageRef: 'img',
+  publishedUrl: 'http://localhost:8123',
+  publishedPort: 8123,
+  bootEnv: { accessToken: 'T', instanceUrl: 'https://x' }
+};
+
+const recorder = (): { runner: CommandRunner; calls: string[][] } => {
+  const calls: string[][] = [];
+  return { calls, runner: (file, args) => (calls.push([file, ...args]), '') };
+};
+
+describe('seedWorkspace', () => {
+  it('passes the fixture path as a container env var (not interpolated) and writes both files', () => {
+    const { runner, calls } = recorder();
+    seedWorkspace(HANDLE, { runner });
+
+    const call = calls[0];
+    expect(call.slice(0, 2)).toEqual(['docker', 'exec']);
+    // Fixture path is a `-e FIXTURE_PATH=…` argv token — data, not shell-interpolated.
+    expect(call).toEqual(expect.arrayContaining(['-e', `FIXTURE_PATH=${FIXTURE_MOUNT_PATH}`]));
+    expect(call).toContain('cb');
+    const script = call.at(-1) as string;
+    // Writes coder.json from $FIXTURE_PATH, and disables workspace trust.
+    expect(script).toContain('coder.json');
+    expect(script).toContain('jq -n --arg folder "$FIXTURE_PATH"');
+    expect(script).toContain('security.workspace.trust.enabled');
+    expect(script).toContain('chown codebuilder:codebuilder');
+  });
+
+  it('honors a custom fixture path (still as an env token, safe for odd paths)', () => {
+    const { runner, calls } = recorder();
+    seedWorkspace(HANDLE, { runner, fixturePath: '/home/codebuilder/my project' });
+    expect(calls[0]).toEqual(expect.arrayContaining(['-e', 'FIXTURE_PATH=/home/codebuilder/my project']));
+  });
+});

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/seed.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/seed.test.ts
@@ -13,8 +13,7 @@ const HANDLE: ContainerHandle = {
   name: 'cb',
   imageRef: 'img',
   publishedUrl: 'http://localhost:8123',
-  publishedPort: 8123,
-  bootEnv: { accessToken: 'T', instanceUrl: 'https://x' }
+  publishedPort: 8123
 };
 
 const recorder = (): { runner: CommandRunner; calls: string[][] } => {

--- a/packages/playwright-vscode-ext/test/jest/codeBuilder/seed.test.ts
+++ b/packages/playwright-vscode-ext/test/jest/codeBuilder/seed.test.ts
@@ -13,7 +13,8 @@ const HANDLE: ContainerHandle = {
   name: 'cb',
   imageRef: 'img',
   publishedUrl: 'http://localhost:8123',
-  publishedPort: 8123
+  publishedPort: 8123,
+  mounts: []
 };
 
 const recorder = (): { runner: CommandRunner; calls: string[][] } => {
@@ -43,5 +44,42 @@ describe('seedWorkspace', () => {
     const { runner, calls } = recorder();
     seedWorkspace(HANDLE, { runner, fixturePath: '/home/codebuilder/my project' });
     expect(calls[0]).toEqual(expect.arrayContaining(['-e', 'FIXTURE_PATH=/home/codebuilder/my project']));
+  });
+
+  it('preflights jq inside the container so a missing jq fails loud, not opaque', () => {
+    const { runner, calls } = recorder();
+    seedWorkspace(HANDLE, { runner });
+    const script = calls[0].at(-1) as string;
+    expect(script).toContain('command -v jq');
+  });
+
+  it('validates the fixture path against the recorded mounts and throws on a mismatch', () => {
+    const { runner } = recorder();
+    const handle: ContainerHandle = {
+      ...HANDLE,
+      mounts: [{ hostPath: '/host/fixture', containerPath: '/home/codebuilder/fixture-project' }]
+    };
+    // Caller mounted at the default but asks to seed a path that isn't mounted — must fail clearly.
+    expect(() => seedWorkspace(handle, { runner, fixturePath: '/home/codebuilder/typo' })).toThrow(
+      /not a container mount/
+    );
+  });
+
+  it('accepts a fixture path that matches a recorded mount', () => {
+    const { runner, calls } = recorder();
+    const handle: ContainerHandle = {
+      ...HANDLE,
+      mounts: [{ hostPath: '/host/fixture', containerPath: '/home/codebuilder/fixture-project' }]
+    };
+    seedWorkspace(handle, { runner, fixturePath: '/home/codebuilder/fixture-project' });
+    expect(calls[0]).toEqual(expect.arrayContaining(['-e', 'FIXTURE_PATH=/home/codebuilder/fixture-project']));
+  });
+
+  it('appends docker logs to the error when the exec fails (diagnostic parity with lifecycle)', () => {
+    const runner: CommandRunner = (_file, args) => {
+      if (args[0] === 'logs') return 'container boot log line';
+      throw new Error('exec exited 127');
+    };
+    expect(() => seedWorkspace(HANDLE, { runner })).toThrow(/seedWorkspace failed[\s\S]*container boot log line/);
   });
 });


### PR DESCRIPTION
### What does this PR do?

Story 3 of the reusable Code Builder e2e toolkit (epic: Code Builder E2E Testing Framework). Adds the **container-operation** utilities to `playwright-vscode-ext` — everything needed to stand up, authenticate, and seed the container around swap+verify.

`packages/playwright-vscode-ext/src/codeBuilder/`:

- **`lifecycle.ts`** — `pull` / `run` / `restart` / `teardown` returning a typed **`ContainerHandle`** (`{ name, imageRef, publishedUrl, publishedPort, bootEnv }`). **Readiness is folded into `run`/`restart`** (they resolve only once the workbench URL answers), so a caller can never obtain an unhealthy handle. `restart` is a **single verb** — one `docker restart` re-scans the extension overrides (applies a swap) *and* re-runs the image's start-time org auth. Readiness probe is injectable (default = HTTP GET); timeout throws loud with `docker logs`.
- **`auth.ts`** — `resolveOrgBootEnv(alias)` (optional, `sf`-aware) encapsulating the **hard-won redaction lesson**: read the token from `sf org auth show-access-token`, **not** the redacted `sf org display`. Plus a typed `BootEnv` (`accessToken`/`instanceUrl` + `extraEnv`) and `bootEnvToDockerArgs`.
- **`seed.ts`** — `seedWorkspace(handle)` writing **both** post-boot exec writes as one concern: `coder.json` (point code-server at the bind-mounted fixture) + the workspace-trust setting (so the Salesforce extensions activate). The fixture path is passed via `docker exec -e` (a single argv token — injection-safe for any path).

All use the injectable `CommandRunner` seam, so they unit-test with no real docker or `sf`.

**Verification:** 12 new Jest tests (run/restart/teardown argv + readiness fold + timeout-with-logs; token-from-show-access-token not the redacted display + error cases; seed passes the path as an env token and writes both files). `tsc`/`eslint`/full pre-commit clean. 50 tests pass across the codeBuilder suite.

Design: `docs/plans/code-builder-e2e-toolkit.md` §7. ⚠ The container org model is an open question (§16 OQ3) — token injection is today's baseline; `resolveOrgBootEnv` may be superseded later.

### What issues does this PR fix or reference?

@W-23898521@

### Functionality Before

No importable container lifecycle/auth/seed; #7718 had these as standalone scripts + inline workflow steps (two curl-poll loops, a separate trust step).

### Functionality After

`pull` → `run(bootEnv, mount)` → `seedWorkspace` → (`swap`) → `restart` → (`verify`) → `teardown`, composed from typed importable functions.

---

> **Stacked PR:** based on `jh/W-23898518-cb-e2e-swap` (story 2), which is based on `jh/W-23898517-cb-e2e-verify-gate` (PR #8009). Merge #8009 then the swap PR first; this diff shows only the lifecycle/auth/seed addition.
