### PR TITLE
ci: approve PRs on /ai-auto approve via svc-idee-bot - W-24030619

### DIFF
--- a/.github/workflows/aiAutoApprove.yml
+++ b/.github/workflows/aiAutoApprove.yml
@@ -1,0 +1,31 @@
+name: AI Auto Approve
+
+# PR author on @forcedotcom/ide-experience comments exactly `/ai-auto approve`.
+# svc-idee-bot (IDEE_GH_TOKEN) submits APPROVE on the current head when CI is green.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: read
+  statuses: read
+
+jobs:
+  approve:
+    if: github.event.issue.pull_request && github.event.comment.body == '/ai-auto approve'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
+      - name: Decide and approve
+        env:
+          IDEE_GH_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node scripts/ai-auto-approve-cli.mjs

--- a/.github/workflows/aiAutoApprove.yml
+++ b/.github/workflows/aiAutoApprove.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
   checks: read
   statuses: read
 

--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
       ]
     },
     "test:ai-safeguards": {
-      "command": "node --test test/ai-safeguards.test.mjs",
+      "command": "node --test test/ai-safeguards.test.mjs test/ai-auto-approve.test.mjs",
       "files": [
         ".claude/hooks/block-no-verify.sh",
         ".claude/hooks/block-push-no-deps.sh",
@@ -286,7 +286,10 @@
         ".opencode/plugins/safeguards.ts",
         "scripts/ai-safeguards.mjs",
         "scripts/ai-safeguards-cli.mjs",
-        "test/ai-safeguards.test.mjs"
+        "scripts/ai-auto-approve.mjs",
+        "scripts/ai-auto-approve-cli.mjs",
+        "test/ai-safeguards.test.mjs",
+        "test/ai-auto-approve.test.mjs"
       ],
       "output": []
     },

--- a/scripts/ai-auto-approve-cli.mjs
+++ b/scripts/ai-auto-approve-cli.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+import { decideAiAutoApprove, BOT_LOGIN, TEAM_ORG, TEAM_SLUG } from './ai-auto-approve.mjs';
+
+const gh = async (path, { method = 'GET', body, token } = {}) => {
+  const response = await fetch(`https://api.github.com${path}`, {
+    method,
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+      ...(body ? { 'Content-Type': 'application/json' } : {})
+    },
+    body: body ? JSON.stringify(body) : undefined
+  });
+  const text = await response.text();
+  const json = text ? JSON.parse(text) : {};
+  if (!response.ok) {
+    const error = new Error(`${method} ${path} ${response.status}: ${json.message ?? text}`);
+    error.status = response.status;
+    throw error;
+  }
+  return json;
+};
+
+const teamMembershipState = async ({ token, login }) => {
+  try {
+    const membership = await gh(`/orgs/${TEAM_ORG}/teams/${TEAM_SLUG}/memberships/${login}`, { token });
+    return membership.state ?? 'none';
+  } catch (error) {
+    if (error.status === 404) return 'none';
+    throw error;
+  }
+};
+
+const listReviews = async ({ token, owner, repo, pullNumber }) => {
+  const reviews = await gh(`/repos/${owner}/${repo}/pulls/${pullNumber}/reviews?per_page=100`, { token });
+  return reviews.map(review => ({
+    authorLogin: review.user?.login,
+    state: review.state,
+    commitOid: review.commit_id
+  }));
+};
+
+const listChecks = async ({ token, owner, repo, headSha }) => {
+  const [combined, checkRuns] = await Promise.all([
+    gh(`/repos/${owner}/${repo}/commits/${headSha}/status`, { token }),
+    gh(`/repos/${owner}/${repo}/commits/${headSha}/check-runs?per_page=100`, { token })
+  ]);
+  const statuses = (combined.statuses ?? []).map(status => ({
+    name: status.context,
+    state: status.state,
+    conclusion: status.state
+  }));
+  const runs = (checkRuns.check_runs ?? []).map(run => ({
+    name: run.name,
+    status: run.status,
+    conclusion: run.conclusion
+  }));
+  return [...statuses, ...runs];
+};
+
+const main = async () => {
+  const token = process.env.IDEE_GH_TOKEN;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!token) throw new Error('IDEE_GH_TOKEN is required');
+  if (!eventPath) throw new Error('GITHUB_EVENT_PATH is required');
+
+  const event = JSON.parse(await (await import('node:fs/promises')).readFile(eventPath, 'utf8'));
+  const comment = event.comment;
+  const issue = event.issue;
+  if (!comment || !issue) {
+    console.log('skip: no comment/issue on event');
+    return;
+  }
+
+  const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+  const isPullRequestComment = Boolean(issue.pull_request);
+  const commenterLogin = comment.user?.login;
+  const commentBody = comment.body ?? '';
+
+  if (!isPullRequestComment) {
+    console.log('skip: not a pull request comment');
+    return;
+  }
+
+  const pullNumber = issue.number;
+  const pr = await gh(`/repos/${owner}/${repo}/pulls/${pullNumber}`, { token });
+  const headSha = pr.head?.sha ?? '';
+  const [membership, reviews, checks] = await Promise.all([
+    teamMembershipState({ token, login: commenterLogin }),
+    listReviews({ token, owner, repo, pullNumber }),
+    listChecks({ token, owner, repo, headSha })
+  ]);
+
+  const decision = decideAiAutoApprove({
+    isPullRequestComment,
+    commentBody,
+    commenterLogin,
+    prAuthorLogin: pr.user?.login,
+    teamMembershipState: membership,
+    prState: pr.state,
+    prDraft: Boolean(pr.draft),
+    headSha,
+    checks,
+    reviews,
+    botLogin: BOT_LOGIN
+  });
+
+  console.log(`decision: ${decision.action} (${decision.reason})`);
+  if (decision.action !== 'approve') return;
+
+  await gh(`/repos/${owner}/${repo}/pulls/${pullNumber}/reviews`, {
+    method: 'POST',
+    token,
+    body: {
+      commit_id: headSha,
+      event: 'APPROVE',
+      body: 'Approved by svc-idee-bot after `/ai-auto approve` from the PR author (@forcedotcom/ide-experience).'
+    }
+  });
+  console.log(`approved ${owner}/${repo}#${pullNumber} at ${headSha}`);
+};
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/ai-auto-approve.mjs
+++ b/scripts/ai-auto-approve.mjs
@@ -1,0 +1,58 @@
+/**
+ * Gates for `/ai-auto approve` → svc-idee-bot APPROVE.
+ * Pure: no GitHub I/O. Workflow supplies facts; this decides skip vs approve.
+ */
+
+export const APPROVE_TOKEN = '/ai-auto approve';
+export const TEAM_SLUG = 'ide-experience';
+export const TEAM_ORG = 'forcedotcom';
+export const BOT_LOGIN = 'svc-idee-bot';
+
+/** Standalone `/ai-auto approve` — whole body, optional trailing whitespace/newlines only. */
+export const isStandaloneAiAutoApprove = body => /^\/ai-auto approve\s*$/.test(String(body ?? '').trim());
+
+const FAIL_CONCLUSIONS = new Set(['FAILURE', 'CANCELLED', 'TIMED_OUT', 'ERROR', 'ACTION_REQUIRED', 'STARTUP_FAILURE']);
+
+const RUNNING = new Set(['IN_PROGRESS', 'QUEUED', 'PENDING', 'WAITING', 'REQUESTED', 'EXPECTED']);
+
+const outcome = check => String(check.conclusion ?? check.state ?? 'PENDING').toUpperCase();
+const status = check => String(check.status ?? '').toUpperCase();
+
+export const isCheckGreen = check => {
+  const o = outcome(check);
+  if (FAIL_CONCLUSIONS.has(o)) return false;
+  if (RUNNING.has(status(check)) || RUNNING.has(o)) return false;
+  return o === 'SUCCESS' || o === 'SKIPPED' || o === 'NEUTRAL';
+};
+
+export const allChecksGreen = checks => checks.length > 0 && checks.every(isCheckGreen);
+
+export const hasBotApprovalOnHead = (reviews, headSha, botLogin = BOT_LOGIN) =>
+  Boolean(headSha) &&
+  reviews.some(
+    review => review.authorLogin === botLogin && review.state === 'APPROVED' && review.commitOid === headSha
+  );
+
+/**
+ * @returns {{ action: 'skip' | 'approve', reason: string }}
+ */
+export const decideAiAutoApprove = input => {
+  if (!input.isPullRequestComment) return { action: 'skip', reason: 'not a pull request comment' };
+  if (!isStandaloneAiAutoApprove(input.commentBody)) {
+    return { action: 'skip', reason: 'comment is not standalone /ai-auto approve' };
+  }
+  if (input.commenterLogin !== input.prAuthorLogin) {
+    return { action: 'skip', reason: 'commenter is not the pull request author' };
+  }
+  if (input.teamMembershipState !== 'active') {
+    return { action: 'skip', reason: 'commenter is not an active @forcedotcom/ide-experience member' };
+  }
+  if (input.prState !== 'open') return { action: 'skip', reason: 'pull request is not open' };
+  if (input.prDraft) return { action: 'skip', reason: 'pull request is a draft' };
+  if (!input.headSha) return { action: 'skip', reason: 'missing head sha' };
+  if (!allChecksGreen(input.checks)) return { action: 'skip', reason: 'CI is not green on head' };
+  if (hasBotApprovalOnHead(input.reviews, input.headSha, input.botLogin ?? BOT_LOGIN)) {
+    return { action: 'skip', reason: 'bot already approved this head' };
+  }
+  return { action: 'approve', reason: 'gates passed' };
+};

--- a/scripts/ai-auto-approve.mjs
+++ b/scripts/ai-auto-approve.mjs
@@ -3,13 +3,14 @@
  * Pure: no GitHub I/O. Workflow supplies facts; this decides skip vs approve.
  */
 
-export const APPROVE_TOKEN = '/ai-auto approve';
+const APPROVE_TOKEN = '/ai-auto approve';
 export const TEAM_SLUG = 'ide-experience';
 export const TEAM_ORG = 'forcedotcom';
 export const BOT_LOGIN = 'svc-idee-bot';
 
 /** Standalone `/ai-auto approve` — whole body, optional trailing whitespace/newlines only. */
-export const isStandaloneAiAutoApprove = body => /^\/ai-auto approve\s*$/.test(String(body ?? '').trim());
+export const isStandaloneAiAutoApprove = body =>
+  new RegExp(`^${APPROVE_TOKEN.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*$`).test(String(body ?? '').trim());
 
 const FAIL_CONCLUSIONS = new Set(['FAILURE', 'CANCELLED', 'TIMED_OUT', 'ERROR', 'ACTION_REQUIRED', 'STARTUP_FAILURE']);
 
@@ -18,7 +19,7 @@ const RUNNING = new Set(['IN_PROGRESS', 'QUEUED', 'PENDING', 'WAITING', 'REQUEST
 const outcome = check => String(check.conclusion ?? check.state ?? 'PENDING').toUpperCase();
 const status = check => String(check.status ?? '').toUpperCase();
 
-export const isCheckGreen = check => {
+const isCheckGreen = check => {
   const o = outcome(check);
   if (FAIL_CONCLUSIONS.has(o)) return false;
   if (RUNNING.has(status(check)) || RUNNING.has(o)) return false;

--- a/test/ai-auto-approve.test.mjs
+++ b/test/ai-auto-approve.test.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  allChecksGreen,
+  decideAiAutoApprove,
+  hasBotApprovalOnHead,
+  isStandaloneAiAutoApprove
+} from '../scripts/ai-auto-approve.mjs';
+
+const green = { status: 'completed', conclusion: 'SUCCESS' };
+const base = {
+  isPullRequestComment: true,
+  commentBody: '/ai-auto approve',
+  commenterLogin: 'mshanemc',
+  prAuthorLogin: 'mshanemc',
+  teamMembershipState: 'active',
+  prState: 'open',
+  prDraft: false,
+  headSha: 'abc123',
+  checks: [green],
+  reviews: []
+};
+
+test('token is exact standalone /ai-auto approve', () => {
+  assert.equal(isStandaloneAiAutoApprove('/ai-auto approve'), true);
+  assert.equal(isStandaloneAiAutoApprove('/ai-auto approve\n'), true);
+  assert.equal(isStandaloneAiAutoApprove('  /ai-auto approve  '), true);
+  assert.equal(isStandaloneAiAutoApprove('/ai-auto approve please'), false);
+  assert.equal(isStandaloneAiAutoApprove('please /ai-auto approve'), false);
+  assert.equal(isStandaloneAiAutoApprove('/ai-auto  approve'), false);
+  assert.equal(isStandaloneAiAutoApprove('/ai-autoapprove'), false);
+  assert.equal(isStandaloneAiAutoApprove('/AI-AUTO APPROVE'), false);
+});
+
+test('approves when all gates pass', () => {
+  assert.deepEqual(decideAiAutoApprove(base), { action: 'approve', reason: 'gates passed' });
+});
+
+test('skips issue comments that are not on a pull request', () => {
+  assert.equal(decideAiAutoApprove({ ...base, isPullRequestComment: false }).action, 'skip');
+});
+
+test('skips when commenter is not the PR author', () => {
+  const decision = decideAiAutoApprove({ ...base, commenterLogin: 'other' });
+  assert.equal(decision.action, 'skip');
+  assert.match(decision.reason, /not the pull request author/);
+});
+
+test('skips when commenter is not an active ide-experience member', () => {
+  assert.equal(decideAiAutoApprove({ ...base, teamMembershipState: 'none' }).action, 'skip');
+  assert.equal(decideAiAutoApprove({ ...base, teamMembershipState: 'pending' }).action, 'skip');
+});
+
+test('skips draft and closed PRs', () => {
+  assert.equal(decideAiAutoApprove({ ...base, prDraft: true }).action, 'skip');
+  assert.equal(decideAiAutoApprove({ ...base, prState: 'closed' }).action, 'skip');
+});
+
+test('skips when CI is empty, pending, or failed', () => {
+  assert.equal(allChecksGreen([]), false);
+  assert.equal(decideAiAutoApprove({ ...base, checks: [] }).action, 'skip');
+  assert.equal(decideAiAutoApprove({ ...base, checks: [{ status: 'in_progress', conclusion: null }] }).action, 'skip');
+  assert.equal(
+    decideAiAutoApprove({ ...base, checks: [{ status: 'completed', conclusion: 'FAILURE' }] }).action,
+    'skip'
+  );
+});
+
+test('treats skipped and neutral as green', () => {
+  assert.equal(allChecksGreen([{ status: 'completed', conclusion: 'SKIPPED' }]), true);
+  assert.equal(allChecksGreen([{ status: 'completed', conclusion: 'NEUTRAL' }]), true);
+});
+
+test('skips when bot already approved this head', () => {
+  const reviews = [{ authorLogin: 'svc-idee-bot', state: 'APPROVED', commitOid: 'abc123' }];
+  assert.equal(hasBotApprovalOnHead(reviews, 'abc123'), true);
+  assert.equal(hasBotApprovalOnHead(reviews, 'other'), false);
+  assert.equal(decideAiAutoApprove({ ...base, reviews }).action, 'skip');
+});


### PR DESCRIPTION
### What does this PR do?

When a PR author on `@forcedotcom/ide-experience` comments exactly `/ai-auto approve`, a workflow runs Node gates and, if they pass, `svc-idee-bot` (`IDEE_GH_TOKEN`) submits `APPROVE` pinned to the current head SHA.

Gates (pure `decideAiAutoApprove`, unit-tested):
- comment body is standalone `/ai-auto approve`
- commenter is the PR author
- commenter is an active `@forcedotcom/ide-experience` member
- PR is open and not a draft
- CI is green on head (at least one check; pending/fail skip)
- bot has not already APPROVED this head

### What issues does this PR fix or reference?

@W-24030619@