### PR TITLE
fix: cancel org operations when target orgId changes - W-23953278

### DIFF
--- a/packages/salesforcedx-vscode-metadata/src/commands/deleteSourcePath.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/deleteSourcePath.ts
@@ -12,6 +12,7 @@ import { URI } from 'vscode-uri';
 import { detectConflicts, handleConflictWithRetry } from '../conflict/conflictFlow';
 import { nls } from '../messages';
 import { messages } from '../messages/i18n';
+import { preventOrgChanges } from '../services/extensionProvider';
 import { deleteComponentSet } from '../shared/delete/deleteComponentSet';
 import { type DeleteSourceFailedError } from '../shared/delete/deleteErrors';
 import { formatDeployOutput } from '../shared/deploy/formatDeployOutput';
@@ -86,5 +87,6 @@ export const deleteSourcePathsCommand = Effect.fn('deleteSourcePaths')(
     Effect.sync(() => {
       void vscode.window.showErrorMessage(nls.localize('delete_source_select_file_or_directory'));
     })
-  )
+  ),
+  preventOrgChanges
 );

--- a/packages/salesforcedx-vscode-metadata/src/commands/deployManifest.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/deployManifest.ts
@@ -11,6 +11,7 @@ import { URI } from 'vscode-uri';
 import { detectConflicts, handleConflictWithRetry } from '../conflict/conflictFlow';
 import { nls } from '../messages';
 import { messages } from '../messages/i18n';
+import { preventOrgChanges } from '../services/extensionProvider';
 import { deployComponentSet } from '../shared/deploy/deployComponentSet';
 import { type ProgressAndSuccessCommandKey } from '../utils/notificationMode';
 import { withPreparationProgress } from '../utils/withPreparationProgress';
@@ -47,5 +48,6 @@ export const deployManifestCommand = Effect.fn('deployManifestCommand')(
   Effect.catchTag(
     'NoActiveEditorError',
     () => new ManifestSelectionRequiredError({ message: nls.localize('deploy_select_manifest') })
-  )
+  ),
+  preventOrgChanges
 );

--- a/packages/salesforcedx-vscode-metadata/src/commands/deploySourcePath.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/deploySourcePath.ts
@@ -12,6 +12,7 @@ import { URI } from 'vscode-uri';
 import { detectConflicts, handleConflictWithRetry } from '../conflict/conflictFlow';
 import { nls } from '../messages';
 import { messages } from '../messages/i18n';
+import { preventOrgChanges } from '../services/extensionProvider';
 import { deployComponentSet } from '../shared/deploy/deployComponentSet';
 import { type ProgressAndSuccessCommandKey } from '../utils/notificationMode';
 import { withPreparationProgress } from '../utils/withPreparationProgress';
@@ -56,7 +57,8 @@ export const deployActiveEditorCommand = Effect.fn('deploySourcePath.deployActiv
     Effect.promise(() => vscode.window.showErrorMessage(nls.localize('deploy_select_file_or_directory'))).pipe(
       Effect.as(undefined)
     )
-  )
+  ),
+  preventOrgChanges
 );
 
 // When a single file is selected and "Deploy Source from Org" is executed,
@@ -78,11 +80,10 @@ export const deploySourcePathsCommand = Effect.fn('deploySourcePath.deploySource
   yield* Effect.annotateCurrentSpan({ sourceUri, uris });
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const notificationMode = yield* api.services.NotificationModeService;
-  const urisSet = new Set([sourceUri, ...uris]);
-  const result = yield* deployUris(urisSet);
+  const result = yield* deployUris(new Set([sourceUri, ...uris]));
   yield* notificationMode.showSuccessNotification(
     COMMAND,
     nls.localize('command_succeeded_text', nls.localize('deploy_this_source_text'))
   );
   return result;
-});
+}, preventOrgChanges);

--- a/packages/salesforcedx-vscode-metadata/src/commands/projectDeployStart.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/projectDeployStart.ts
@@ -10,6 +10,7 @@ import * as Effect from 'effect/Effect';
 import { detectConflicts, handleConflictWithRetry } from '../conflict/conflictFlow';
 import { nls } from '../messages';
 import { messages } from '../messages/i18n';
+import { preventOrgChanges } from '../services/extensionProvider';
 import { deployComponentSet } from '../shared/deploy/deployComponentSet';
 import { type ProgressAndSuccessCommandKey } from '../utils/notificationMode';
 import { withPreparationProgress } from '../utils/withPreparationProgress';
@@ -26,31 +27,30 @@ const deployEffect = Effect.fn('projectDeploy.deployEffect')(function* (ignoreCo
 });
 
 /** Deploy local changes to the default org */
-export const projectDeployStartCommand = (ignoreConflicts = false) =>
-  Effect.gen(function* () {
-    const api = yield* (yield* ExtensionProviderService).getServicesApi;
-    const notificationMode = yield* api.services.NotificationModeService;
-    return yield* deployEffect(ignoreConflicts).pipe(
-      Effect.catchTag('ConflictsDetectedError', err =>
-        handleConflictWithRetry({
-          pairs: err.pairs,
-          operationType: err.operationType,
-          retryOperation: deployEffect(true)
-        })
-      ),
-      Effect.tap(() =>
-        notificationMode.showSuccessNotification(
-          COMMAND,
-          nls.localize(
-            'command_succeeded_text',
-            ignoreConflicts
-              ? nls.localize('project_deploy_start_ignore_conflicts_default_org_text')
-              : nls.localize('project_deploy_start_default_org_text')
-          )
+export const projectDeployStartCommand = Effect.fn('projectDeployStartCommand')(function* (ignoreConflicts = false) {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const notificationMode = yield* api.services.NotificationModeService;
+  return yield* deployEffect(ignoreConflicts).pipe(
+    Effect.catchTag('ConflictsDetectedError', err =>
+      handleConflictWithRetry({
+        pairs: err.pairs,
+        operationType: err.operationType,
+        retryOperation: deployEffect(true)
+      })
+    ),
+    Effect.tap(() =>
+      notificationMode.showSuccessNotification(
+        COMMAND,
+        nls.localize(
+          'command_succeeded_text',
+          ignoreConflicts
+            ? nls.localize('project_deploy_start_ignore_conflicts_default_org_text')
+            : nls.localize('project_deploy_start_default_org_text')
         )
-      ),
-      Effect.catchTag('EmptyComponentSetError', () =>
-        notificationMode.showSuccessNotification(COMMAND, nls.localize('no_local_changes_to_deploy'))
       )
-    );
-  });
+    ),
+    Effect.catchTag('EmptyComponentSetError', () =>
+      notificationMode.showSuccessNotification(COMMAND, nls.localize('no_local_changes_to_deploy'))
+    )
+  );
+}, preventOrgChanges);

--- a/packages/salesforcedx-vscode-metadata/src/commands/retrieveManifest.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/retrieveManifest.ts
@@ -11,6 +11,7 @@ import { URI } from 'vscode-uri';
 import { detectConflicts, handleConflictWithRetry } from '../conflict/conflictFlow';
 import { nls } from '../messages';
 import { messages } from '../messages/i18n';
+import { preventOrgChanges } from '../services/extensionProvider';
 import { retrieveComponentSet } from '../shared/retrieve/retrieveComponentSet';
 import { type ProgressAndSuccessCommandKey } from '../utils/notificationMode';
 import { withPreparationProgress } from '../utils/withPreparationProgress';
@@ -51,5 +52,6 @@ export const retrieveManifestCommand = Effect.fn('retrieveManifestCommand')(
   Effect.catchTag(
     'NoActiveEditorError',
     () => new ManifestSelectionRequiredError({ message: nls.localize('retrieve_select_manifest') })
-  )
+  ),
+  preventOrgChanges
 );

--- a/packages/salesforcedx-vscode-metadata/src/commands/retrieveSourcePath.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/retrieveSourcePath.ts
@@ -12,6 +12,7 @@ import { URI } from 'vscode-uri';
 import { detectConflicts, handleConflictWithRetry } from '../conflict/conflictFlow';
 import { nls } from '../messages';
 import { messages } from '../messages/i18n';
+import { preventOrgChanges } from '../services/extensionProvider';
 import { retrieveComponentSet } from '../shared/retrieve/retrieveComponentSet';
 import { type ProgressAndSuccessCommandKey } from '../utils/notificationMode';
 import { withPreparationProgress } from '../utils/withPreparationProgress';
@@ -68,5 +69,6 @@ export const retrieveSourcePathsCommand = Effect.fn('retrieveSourcePathsCommand'
     Effect.promise(() => vscode.window.showErrorMessage(nls.localize('retrieve_select_file_or_directory'))).pipe(
       Effect.as(undefined)
     )
-  )
+  ),
+  preventOrgChanges
 );

--- a/packages/salesforcedx-vscode-metadata/src/commands/retrieveStart/projectRetrieveStart.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/retrieveStart/projectRetrieveStart.ts
@@ -10,6 +10,7 @@ import * as Effect from 'effect/Effect';
 import { detectConflicts, handleConflictWithRetry } from '../../conflict/conflictFlow';
 import { nls } from '../../messages';
 import { messages } from '../../messages/i18n';
+import { preventOrgChanges } from '../../services/extensionProvider';
 import { formatRetrieveOutput } from '../../shared/retrieve/formatRetrieveOutput';
 import { retrieveComponentSet } from '../../shared/retrieve/retrieveComponentSet';
 import { type ProgressAndSuccessCommandKey } from '../../utils/notificationMode';
@@ -79,24 +80,25 @@ const retrieveEffect = Effect.fn('retrieveEffect')(
 );
 
 /** Retrieve remote changes from the default org */
-export const projectRetrieveStartCommand = (ignoreConflicts: boolean) =>
-  Effect.gen(function* () {
-    const api = yield* (yield* ExtensionProviderService).getServicesApi;
-    const notificationMode = yield* api.services.NotificationModeService;
-    return yield* retrieveEffect(ignoreConflicts).pipe(
-      Effect.tap(() =>
-        notificationMode.showSuccessNotification(
-          COMMAND,
-          nls.localize(
-            'command_succeeded_text',
-            ignoreConflicts
-              ? nls.localize('project_retrieve_start_ignore_conflicts_default_org_text')
-              : nls.localize('project_retrieve_start_default_org_text')
-          )
+export const projectRetrieveStartCommand = Effect.fn('projectRetrieveStartCommand')(function* (
+  ignoreConflicts: boolean
+) {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const notificationMode = yield* api.services.NotificationModeService;
+  return yield* retrieveEffect(ignoreConflicts).pipe(
+    Effect.tap(() =>
+      notificationMode.showSuccessNotification(
+        COMMAND,
+        nls.localize(
+          'command_succeeded_text',
+          ignoreConflicts
+            ? nls.localize('project_retrieve_start_ignore_conflicts_default_org_text')
+            : nls.localize('project_retrieve_start_default_org_text')
         )
-      ),
-      Effect.catchTag('EmptyComponentSetError', () =>
-        notificationMode.showSuccessNotification(COMMAND, nls.localize('no_remote_changes_to_retrieve'))
       )
-    );
-  });
+    ),
+    Effect.catchTag('EmptyComponentSetError', () =>
+      notificationMode.showSuccessNotification(COMMAND, nls.localize('no_remote_changes_to_retrieve'))
+    )
+  );
+}, preventOrgChanges);

--- a/packages/salesforcedx-vscode-metadata/src/index.ts
+++ b/packages/salesforcedx-vscode-metadata/src/index.ts
@@ -39,6 +39,7 @@ import {
   buildAllServicesLayer,
   disposeMetadataRuntime,
   getMetadataRuntime,
+  preventOrgChanges,
   setAllServicesLayer
 } from './services/extensionProvider';
 import { createSourceTrackingStatusBar } from './statusBar/sourceTrackingStatusBar';
@@ -92,8 +93,12 @@ export const activateEffect = Effect.fn(`activation:${EXTENSION_NAME}`)(function
       ),
       registerCommand('sf.metadata.project.retrieve.start', () => projectRetrieveStartCommand(false)),
       registerCommand('sf.metadata.project.retrieve.start.ignore.conflicts', () => projectRetrieveStartCommand(true)),
-      registerCommand('sf.metadata.project.deploy.then.retrieve', () =>
-        projectDeployStartCommand(false).pipe(Effect.andThen(() => projectRetrieveStartCommand(false)))
+      registerCommand(
+        'sf.metadata.project.deploy.then.retrieve',
+        Effect.fn('projectDeployThenRetrieveCommand')(function* () {
+          yield* projectDeployStartCommand(false);
+          yield* projectRetrieveStartCommand(false);
+        }, preventOrgChanges)
       ),
       registerCommand('sf.metadata.retrieve.current.source.file', () =>
         retrieveSourcePathsCommand(undefined, undefined)

--- a/packages/salesforcedx-vscode-metadata/src/services/extensionProvider.ts
+++ b/packages/salesforcedx-vscode-metadata/src/services/extensionProvider.ts
@@ -5,11 +5,22 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { buildAllServicesLayer as buildSharedServicesLayer, getServicesApi } from '@salesforce/effect-ext-utils';
+import {
+  buildAllServicesLayer as buildSharedServicesLayer,
+  ExtensionProviderService,
+  getServicesApi
+} from '@salesforce/effect-ext-utils';
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
 import * as ManagedRuntime from 'effect/ManagedRuntime';
 import type { ExtensionContext } from 'vscode';
+
+/** Apply the Services-owned target-org guard. */
+export const preventOrgChanges = <A, E, R>(command: Effect.Effect<A, E, R>) =>
+  ExtensionProviderService.pipe(
+    Effect.flatMap(provider => provider.getServicesApi),
+    Effect.flatMap(api => api.services.preventOrgChanges(command))
+  );
 
 export const buildAllServicesLayer = (context: ExtensionContext) =>
   Layer.unwrapEffect(

--- a/packages/salesforcedx-vscode-org-browser/src/commands/retrieveMetadata.ts
+++ b/packages/salesforcedx-vscode-org-browser/src/commands/retrieveMetadata.ts
@@ -12,6 +12,7 @@ import * as Match from 'effect/Match';
 import { isNotUndefined } from 'effect/Predicate';
 import { nls } from '../messages';
 import { messages } from '../messages/i18n';
+import { preventOrgChanges } from '../services/extensionProvider';
 import { OrgBrowserRetrieveService } from '../services/orgBrowserMetadataRetrieveService';
 import { OrgBrowserTreeItem, getIconPath } from '../tree/orgBrowserNode';
 import { type ProgressAndSuccessCommandKey } from '../utils/notificationMode';
@@ -31,17 +32,12 @@ export const retrieveEffect = Effect.fn('RetrieveMetadata.retrieveEffect')(funct
     return yield* Effect.void;
   }
   const members = yield* getRetrieveMembers(node, treeProvider);
-  if (members.length === 0) {
-    return yield* Effect.void;
-  }
+  if (members.length === 0) return yield* Effect.void;
 
   yield* Effect.annotateCurrentSpan({ memberCount: members.length });
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const notificationMode = yield* api.services.NotificationModeService;
-
-  const projectComponentSet = yield* api.services.ComponentSetService.getComponentSetFromProjectDirectories();
-
-  yield* confirmOverwrite(projectComponentSet, members);
+  yield* confirmOverwrite(yield* api.services.ComponentSetService.getComponentSetFromProjectDirectories(), members);
 
   return yield* OrgBrowserRetrieveService.retrieve(members, members.length === 1, {
     progressLocation: yield* notificationMode.getProgressLocation(COMMAND)
@@ -64,7 +60,7 @@ export const retrieveEffect = Effect.fn('RetrieveMetadata.retrieveEffect')(funct
       )
     )
   );
-});
+}, preventOrgChanges);
 
 const getRetrieveMembers = (node: OrgBrowserTreeItem, treeProvider: MetadataTypeTreeProvider) =>
   Match.value(node).pipe(

--- a/packages/salesforcedx-vscode-org-browser/src/services/extensionProvider.ts
+++ b/packages/salesforcedx-vscode-org-browser/src/services/extensionProvider.ts
@@ -5,12 +5,23 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { buildAllServicesLayer as buildSharedServicesLayer, getServicesApi } from '@salesforce/effect-ext-utils';
+import {
+  buildAllServicesLayer as buildSharedServicesLayer,
+  ExtensionProviderService,
+  getServicesApi
+} from '@salesforce/effect-ext-utils';
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
 import * as ManagedRuntime from 'effect/ManagedRuntime';
 import type { ExtensionContext } from 'vscode';
 import { OrgBrowserRetrieveService } from './orgBrowserMetadataRetrieveService';
+
+/** Apply the Services-owned target-org guard. */
+export const preventOrgChanges = <A, E, R>(command: Effect.Effect<A, E, R>) =>
+  ExtensionProviderService.pipe(
+    Effect.flatMap(provider => provider.getServicesApi),
+    Effect.flatMap(api => api.services.preventOrgChanges(command))
+  );
 
 /**
  * Factory for a Layer that provides all shared services plus the org-browser-specific

--- a/packages/salesforcedx-vscode-services/src/core/configFileWatcher.ts
+++ b/packages/salesforcedx-vscode-services/src/core/configFileWatcher.ts
@@ -8,12 +8,15 @@ import { Config } from '@salesforce/core/config';
 import { Global } from '@salesforce/core/global';
 import * as Duration from 'effect/Duration';
 import * as Effect from 'effect/Effect';
+import * as Option from 'effect/Option';
 import * as Stream from 'effect/Stream';
+import * as SubscriptionRef from 'effect/SubscriptionRef';
 import { join, normalize, sep } from 'node:path';
 import { FileChangePubSub } from '../vscode/fileChangePubSub';
+import { AliasService } from './alias';
 import { ConfigService } from './configService';
 import { ConnectionService } from './connectionService';
-import { clearDefaultOrgRef } from './defaultOrgRef';
+import { clearDefaultOrgRef, getDefaultOrgRef } from './defaultOrgRef';
 
 /** Check if a file path is a config file (global or project-specific) */
 const isConfigFile = (path: string, globalConfigPath: string, projectConfigPattern: string): boolean => {
@@ -28,14 +31,28 @@ const isConfigFile = (path: string, globalConfigPath: string, projectConfigPatte
  * */
 export const watchConfigFiles = Effect.fn('watchConfigFiles')(function* () {
   const configFileName = Config.getFileName();
-  const globalConfigPath = normalize(join(Global.DIR, configFileName));
+  const globalConfigPath = normalize(join(Global.SF_DIR, configFileName));
   const projectConfigPattern = `${Global.SF_STATE_FOLDER}${sep}${configFileName}`;
+  const aliasFilePath = normalize(join(Global.SFDX_DIR, 'alias.json'));
 
   const fileChangePubSub = yield* FileChangePubSub;
 
-  // Subscribe to file changes and clear defaultOrgRef when config files change
   yield* Stream.fromPubSub(fileChangePubSub).pipe(
-    Stream.filter(event => isConfigFile(event.uri.fsPath, globalConfigPath, projectConfigPattern)),
+    Stream.filterEffect(event => {
+      if (isConfigFile(event.uri.fsPath, globalConfigPath, projectConfigPattern)) return Effect.succeed(true);
+      if (normalize(event.uri.fsPath) !== aliasFilePath) return Effect.succeed(false);
+
+      return Effect.gen(function* () {
+        const [targetOrg, currentOrg] = yield* Effect.all([
+          ConfigService.getTargetOrg(),
+          getDefaultOrgRef().pipe(Effect.flatMap(SubscriptionRef.get))
+        ]);
+        if (!targetOrg || targetOrg === currentOrg.username) return false;
+
+        const resolvedUsername = yield* AliasService.getUsernameFromAlias(targetOrg);
+        return Option.getOrUndefined(resolvedUsername) !== currentOrg.username;
+      });
+    }),
     Stream.debounce(Duration.millis(5)),
     Stream.tap(() => ConfigService.invalidateConfigAggregator()),
     Stream.tap(() => ConnectionService.invalidateCachedConnections()),

--- a/packages/salesforcedx-vscode-services/src/core/connectionService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/connectionService.ts
@@ -334,14 +334,13 @@ export class ConnectionService extends Effect.Service<ConnectionService>()('Conn
                   () => new NoTargetOrgConfiguredError({ message: 'No target org configured' })
                 )
               ));
-            const resolved = yield* aliasService
-              .getUsernameFromAlias(usernameOrAlias)
-              .pipe(Effect.map(Option.getOrElse(() => usernameOrAlias)));
-            const desktopConn = yield* connectionCache.get(resolved);
             // Session-ID orgs can't silently refresh; validate before returning so ALL consumers
             // see reauth modal on expired token. No-op for refreshable flows.
-            yield* validateAccessTokenOrPromptReauth(desktopConn);
-            return desktopConn;
+            return yield* aliasService.getUsernameFromAlias(usernameOrAlias).pipe(
+              Effect.map(Option.getOrElse(() => usernameOrAlias)),
+              Effect.flatMap(resolved => connectionCache.get(resolved)),
+              Effect.tap(validateAccessTokenOrPromptReauth)
+            );
           });
 
       // Update the org ref in the background only for the default org (no explicit username).
@@ -366,7 +365,7 @@ export class ConnectionService extends Effect.Service<ConnectionService>()('Conn
       const observedOrgId = connection.getAuthInfoFields().orgId;
       if (observedOrgId === expectedOrgId) return connection;
       return yield* new InactiveOrgOperationError({
-        message: `The active org changed while an operation for '${expectedOrgId}' was in progress`,
+        message: nls.localize('org_operation_target_changed', expectedOrgId),
         expectedOrgId,
         ...(observedOrgId ? { observedOrgId } : {})
       });

--- a/packages/salesforcedx-vscode-services/src/core/sourceTrackingService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/sourceTrackingService.ts
@@ -91,37 +91,34 @@ export class SourceTrackingService extends Effect.Service<SourceTrackingService>
     const getOrCreateTracking = Effect.fn('SourceTrackingService.getOrCreateTracking')(function* (
       expectedOrgId?: string
     ) {
-      return yield* trackingCreationSemaphore.withPermits(1)(
-        Effect.gen(function* () {
-          const cached = yield* Ref.get(trackingRef);
-          const ref = yield* SubscriptionRef.get(yield* getDefaultOrgRef());
-          const currentOrgId = expectedOrgId ?? ref.orgId;
+      const cached = yield* Ref.get(trackingRef);
+      const currentOrgId = expectedOrgId ?? (yield* SubscriptionRef.get(yield* getDefaultOrgRef())).orgId;
 
-          // Check if cached instance matches current org
-          if (Option.isSome(cached) && cached.value.orgId === currentOrgId) {
-            return cached.value.tracking;
-          }
+      // Check if cached instance matches current org
+      if (Option.isSome(cached) && cached.value.orgId === currentOrgId) {
+        return cached.value.tracking;
+      }
 
-          // Source Tracking's local ShadowRepo singleton is keyed only by project
-          // path. Release it before constructing tracking for a different org.
-          const projectPath = normalize((yield* projectService.getSfProject()).getPath());
-          const releasedShadowRepo = yield* Effect.sync(() => releaseSourceTrackingShadowRepo(projectPath));
-          yield* Effect.annotateCurrentSpan({ currentOrgId, releasedShadowRepo });
-
-          // Different org or no cache - create new instance
-          const tracking = yield* getTracking(undefined, expectedOrgId);
-          if (!tracking) {
-            return yield* new SourceTrackingNotEnabledError({ message: 'Source tracking is not enabled' });
-          }
-
-          // Cache it with current org ID
-          if (currentOrgId) {
-            yield* Ref.set(trackingRef, Option.some({ tracking, orgId: currentOrgId }));
-          }
-          return tracking;
-        })
+      // Source Tracking's local ShadowRepo singleton is keyed only by project
+      // path. Release it before constructing tracking for a different org.
+      yield* projectService.getSfProject().pipe(
+        Effect.map(project => normalize(project.getPath())),
+        Effect.flatMap(projectPath => Effect.sync(() => releaseSourceTrackingShadowRepo(projectPath))),
+        Effect.tap(releasedShadowRepo => Effect.annotateCurrentSpan({ currentOrgId, releasedShadowRepo }))
       );
-    });
+
+      // Different org or no cache - create new instance
+      const tracking = yield* getTracking(undefined, expectedOrgId);
+      if (!tracking) {
+        return yield* new SourceTrackingNotEnabledError({ message: 'Source tracking is not enabled' });
+      }
+
+      // Cache it with current org ID
+      if (currentOrgId) {
+        yield* Ref.set(trackingRef, Option.some({ tracking, orgId: currentOrgId }));
+      }
+      return tracking;
+    }, trackingCreationSemaphore.withPermits(1));
 
     /** Creates a SourceTracking instance with optional configuration.  Returns undefined if source tracking is not enabled */
     const getTracking = Effect.fn('SourceTrackingService.getTracking')(function* (
@@ -196,88 +193,80 @@ export class SourceTrackingService extends Effect.Service<SourceTrackingService>
       Effect.all([rereadLocal(tracking), rereadRemote(tracking)], { concurrency: 'unbounded' });
 
     /** Get local changes as ComponentSet array (local tracking files only) */
-    const getLocalChangesAsComponentSet = Effect.fn('SourceTrackingService.getLocalChangesAsComponentSet')(
-      function* () {
-        const tracking = yield* getOrCreateTracking();
-
-        return yield* localSemaphore.withPermits(1)(
-          Effect.gen(function* () {
-            yield* rereadLocal(tracking);
-            return yield* Effect.tryPromise({
-              try: () => tracking.localChangesAsComponentSet(false),
-              catch: toSourceTrackingError
-            }).pipe(Effect.withSpan('STL.LocalChangesAsComponentSet'));
-          })
-        );
-      }
+    const getLocalChangesAsComponentSet = Effect.fn('SourceTrackingService.getLocalChangesAsComponentSet')(() =>
+      getOrCreateTracking().pipe(
+        Effect.tap(rereadLocal),
+        Effect.flatMap(tracking =>
+          Effect.tryPromise({
+            try: () => tracking.localChangesAsComponentSet(false),
+            catch: toSourceTrackingError
+          }).pipe(Effect.withSpan('STL.LocalChangesAsComponentSet'))
+        ),
+        localSemaphore.withPermits(1)
+      )
     );
 
     /** Get remote non-deletes as ComponentSet (remote tracking files only) */
     const getRemoteNonDeletesAsComponentSet = Effect.fn('SourceTrackingService.getRemoteNonDeletesAsComponentSet')(
-      function* (options: { applyIgnore: boolean }) {
-        const tracking = yield* getOrCreateTracking();
-
-        return yield* remoteSemaphore.withPermits(1)(
-          Effect.gen(function* () {
-            yield* rereadRemote(tracking);
-            return yield* Effect.tryPromise({
+      (options: { applyIgnore: boolean }) =>
+        getOrCreateTracking().pipe(
+          Effect.tap(rereadRemote),
+          Effect.flatMap(tracking =>
+            Effect.tryPromise({
               try: () => tracking.remoteNonDeletesAsComponentSet(options),
               catch: toSourceTrackingError
-            }).pipe(Effect.withSpan('STL.RemoteNonDeletesAsComponentSet'));
-          })
-        );
-      }
+            }).pipe(Effect.withSpan('STL.RemoteNonDeletesAsComponentSet'))
+          ),
+          remoteSemaphore.withPermits(1)
+        )
     );
 
     /** Get remote deletes as ComponentSet (remote tracking files only).
      * Uses ChangeResult format (not SourceComponent) so it returns entries even when local files don't exist. */
-    const getRemoteDeletesAsComponentSet = Effect.fn('SourceTrackingService.getRemoteDeletesAsComponentSet')(
-      function* () {
-        const tracking = yield* getOrCreateTracking();
-        const registry = yield* metadataRegistryService.getRegistryAccess();
-
-        return yield* remoteSemaphore.withPermits(1)(
-          Effect.gen(function* () {
-            yield* rereadRemote(tracking);
-            const changeResults = yield* Effect.tryPromise({
-              try: () => tracking.getChanges({ origin: 'remote', state: 'delete', format: 'ChangeResult' }),
-              catch: toSourceTrackingError
-            }).pipe(Effect.withSpan('STL.RemoteDeletesAsComponentSet'));
-            return new ComponentSet(
-              changeResults.filter(isResolvedChangeResult).map(c => ({ type: c.type, fullName: c.name })),
-              registry
-            );
-          })
-        );
-      }
+    const getRemoteDeletesAsComponentSet = Effect.fn('SourceTrackingService.getRemoteDeletesAsComponentSet')(() =>
+      metadataRegistryService.getRegistryAccess().pipe(
+        Effect.flatMap(registry =>
+          getOrCreateTracking().pipe(
+            Effect.tap(rereadRemote),
+            Effect.flatMap(tracking =>
+              Effect.tryPromise({
+                try: () => tracking.getChanges({ origin: 'remote', state: 'delete', format: 'ChangeResult' }),
+                catch: toSourceTrackingError
+              }).pipe(Effect.withSpan('STL.RemoteDeletesAsComponentSet'))
+            ),
+            Effect.map(
+              changeResults =>
+                new ComponentSet(
+                  changeResults.filter(isResolvedChangeResult).map(c => ({ type: c.type, fullName: c.name })),
+                  registry
+                )
+            ),
+            remoteSemaphore.withPermits(1)
+          )
+        )
+      )
     );
 
     /** Reset remote tracking (remote tracking files only) */
-    const resetRemoteTracking = Effect.fn('SourceTrackingService.resetRemoteTracking')(function* () {
-      const tracking = yield* getOrCreateTracking();
-
-      return yield* remoteSemaphore.withPermits(1)(
-        Effect.tryPromise({
-          try: () => tracking.resetRemoteTracking(),
-          catch: toSourceTrackingError
-        }).pipe(Effect.withSpan('STL.ResetRemoteTracking'))
-      );
-    });
+    const resetRemoteTracking = Effect.fn('SourceTrackingService.resetRemoteTracking')(() =>
+      getOrCreateTracking().pipe(
+        Effect.flatMap(tracking =>
+          Effect.tryPromise({
+            try: () => tracking.resetRemoteTracking(),
+            catch: toSourceTrackingError
+          }).pipe(Effect.withSpan('STL.ResetRemoteTracking'))
+        ),
+        remoteSemaphore.withPermits(1)
+      )
+    );
 
     /** Read status and revision-bearing remote observations from one tracking refresh. */
-    const getStatusWithRemoteChanges = Effect.fn('SourceTrackingService.getStatusWithRemoteChanges')(function* (
-      options: { local: true; remote?: never } | { remote: true; local?: never } | { local: true; remote: true },
-      expectedOrgId?: string
-    ) {
-      // Take only the permits we need, concurrently
-      yield* Effect.all(
-        [options.local ? localSemaphore.take(1) : Effect.void, options.remote ? remoteSemaphore.take(1) : Effect.void],
-        { concurrency: 'unbounded' }
-      );
-
-      const tracking = yield* getOrCreateTracking(expectedOrgId);
-
-      return yield* Effect.gen(function* () {
+    const getStatusWithRemoteChanges = Effect.fn('SourceTrackingService.getStatusWithRemoteChanges')(
+      function* (
+        options: { local: true; remote?: never } | { remote: true; local?: never } | { local: true; remote: true },
+        expectedOrgId?: string
+      ) {
+        const tracking = yield* getOrCreateTracking(expectedOrgId);
         yield* Effect.all(
           [...(options.local ? [rereadLocal(tracking)] : []), ...(options.remote ? [rereadRemote(tracking)] : [])],
           { concurrency: 'unbounded' }
@@ -304,18 +293,27 @@ export class SourceTrackingService extends Effect.Service<SourceTrackingService>
           : Effect.succeed<SourceTrackingRemoteChange[]>([]);
         yield* Effect.annotateCurrentSpan({ remoteChangeRows: remoteChanges.length, statusRows: status.length });
         return { remoteChanges, status };
-      }).pipe(
-        Effect.ensuring(
+      },
+      (effect, options) =>
+        Effect.acquireUseRelease(
           Effect.all(
             [
-              options.local ? localSemaphore.release(1) : Effect.void,
-              options.remote ? remoteSemaphore.release(1) : Effect.void
+              options.local ? localSemaphore.take(1) : Effect.void,
+              options.remote ? remoteSemaphore.take(1) : Effect.void
             ],
             { concurrency: 'unbounded' }
-          )
+          ),
+          () => effect,
+          () =>
+            Effect.all(
+              [
+                options.local ? localSemaphore.release(1) : Effect.void,
+                options.remote ? remoteSemaphore.release(1) : Effect.void
+              ],
+              { concurrency: 'unbounded' }
+            )
         )
-      );
-    });
+    );
 
     /** Get status of local and/or remote changes (acquires semaphores based on options). */
     const getStatus = Effect.fn('SourceTrackingService.getStatus')(function* (
@@ -344,72 +342,73 @@ export class SourceTrackingService extends Effect.Service<SourceTrackingService>
     const maybeApplyRemoteDeletesToLocal = Effect.fn('SourceTrackingService.maybeApplyRemoteDeletesToLocal')(
       function* () {
         const tracking = yield* getOrCreateTracking();
+        yield* rereadBoth(tracking);
 
-        return yield* Effect.gen(function* () {
-          yield* rereadBoth(tracking);
+        // Get all remote deletes as ChangeResult before applying — works even when local files don't exist
+        const allRemoteDeletes = yield* Effect.tryPromise({
+          try: () => tracking.getChanges({ origin: 'remote', state: 'delete', format: 'ChangeResult' }),
+          catch: toSourceTrackingError
+        });
 
-          // Get all remote deletes as ChangeResult before applying — works even when local files don't exist
-          const allRemoteDeletes = yield* Effect.tryPromise({
-            try: () => tracking.getChanges({ origin: 'remote', state: 'delete', format: 'ChangeResult' }),
+        const result = yield* Effect.tryPromise({
+          try: () => tracking.maybeApplyRemoteDeletesToLocal(true),
+          catch: toSourceTrackingError
+        }).pipe(Effect.withSpan('STL.MaybeApplyRemoteDeletesToLocal'));
+
+        // STL only calls updateRemoteTracking for deletes it could resolve to local files.
+        // For deletes with no local file, manually acknowledge them so they leave tracking.
+        const handledTypeNames = HashSet.fromIterable(
+          result.fileResponsesFromDelete.map(r => Data.struct({ type: r.type, fullName: r.fullName }))
+        );
+
+        const unhandled = allRemoteDeletes
+          .filter(isResolvedChangeResult)
+          .filter(c => !HashSet.has(handledTypeNames, Data.struct({ type: c.type, fullName: c.name })));
+
+        if (unhandled.length > 0) {
+          yield* Effect.tryPromise({
+            try: () =>
+              tracking.updateRemoteTracking(
+                unhandled.map(c => ({ type: c.type, fullName: c.name, state: ComponentStatus.Deleted })),
+                true // skipPolling — same as STL's deleteFilesAndUpdateTracking
+              ),
             catch: toSourceTrackingError
-          });
+          }).pipe(Effect.withSpan('STL.AcknowledgeUnhandledRemoteDeletes'));
+        }
 
-          const result = yield* Effect.tryPromise({
-            try: () => tracking.maybeApplyRemoteDeletesToLocal(true),
-            catch: toSourceTrackingError
-          }).pipe(Effect.withSpan('STL.MaybeApplyRemoteDeletesToLocal'));
+        // Surface unhandled deletes as synthetic FileResponse entries so the output channel
+        // shows them even when there was no local file to delete.
+        // filePath is empty string (falsy) so formatRetrieveOutput falls back to fullName for display.
+        const syntheticDeletes: FileResponse[] = unhandled.map(c => ({
+          type: c.type,
+          fullName: c.name,
+          state: ComponentStatus.Deleted,
+          filePath: ''
+        }));
 
-          // STL only calls updateRemoteTracking for deletes it could resolve to local files.
-          // For deletes with no local file, manually acknowledge them so they leave tracking.
-          const handledTypeNames = HashSet.fromIterable(
-            result.fileResponsesFromDelete.map(r => Data.struct({ type: r.type, fullName: r.fullName }))
-          );
-
-          const unhandled = allRemoteDeletes
-            .filter(isResolvedChangeResult)
-            .filter(c => !HashSet.has(handledTypeNames, Data.struct({ type: c.type, fullName: c.name })));
-
-          if (unhandled.length > 0) {
-            yield* Effect.tryPromise({
-              try: () =>
-                tracking.updateRemoteTracking(
-                  unhandled.map(c => ({ type: c.type, fullName: c.name, state: ComponentStatus.Deleted })),
-                  true // skipPolling — same as STL's deleteFilesAndUpdateTracking
-                ),
-              catch: toSourceTrackingError
-            }).pipe(Effect.withSpan('STL.AcknowledgeUnhandledRemoteDeletes'));
-          }
-
-          // Surface unhandled deletes as synthetic FileResponse entries so the output channel
-          // shows them even when there was no local file to delete.
-          // filePath is empty string (falsy) so formatRetrieveOutput falls back to fullName for display.
-          const syntheticDeletes: FileResponse[] = unhandled.map(c => ({
-            type: c.type,
-            fullName: c.name,
-            state: ComponentStatus.Deleted,
-            filePath: ''
-          }));
-
-          return {
-            componentSetFromNonDeletes: result.componentSetFromNonDeletes,
-            fileResponsesFromDelete: [...result.fileResponsesFromDelete, ...syntheticDeletes]
-          };
-        }).pipe(remoteSemaphore.withPermits(1), localSemaphore.withPermits(1));
-      }
+        return {
+          componentSetFromNonDeletes: result.componentSetFromNonDeletes,
+          fileResponsesFromDelete: [...result.fileResponsesFromDelete, ...syntheticDeletes]
+        };
+      },
+      remoteSemaphore.withPermits(1),
+      localSemaphore.withPermits(1)
     );
 
     /** Get conflicts without UI side effects (both tracking files) */
-    const getConflicts = Effect.fn('SourceTrackingService.getConflicts')(function* (expectedOrgId?: string) {
-      const tracking = yield* getOrCreateTracking(expectedOrgId);
-
-      return yield* Effect.gen(function* () {
-        yield* rereadBoth(tracking);
-        return yield* Effect.tryPromise({
-          try: () => tracking.getConflicts(),
-          catch: toSourceTrackingError
-        }).pipe(Effect.withSpan('STL.GetConflicts'));
-      }).pipe(remoteSemaphore.withPermits(1), localSemaphore.withPermits(1));
-    });
+    const getConflicts = Effect.fn('SourceTrackingService.getConflicts')((expectedOrgId?: string) =>
+      getOrCreateTracking(expectedOrgId).pipe(
+        Effect.tap(rereadBoth),
+        Effect.flatMap(tracking =>
+          Effect.tryPromise({
+            try: () => tracking.getConflicts(),
+            catch: toSourceTrackingError
+          }).pipe(Effect.withSpan('STL.GetConflicts'))
+        ),
+        remoteSemaphore.withPermits(1),
+        localSemaphore.withPermits(1)
+      )
+    );
 
     /** Check for conflicts and display them in the channel, failing if conflicts are found (both tracking files) */
     const checkConflicts = Effect.fn('SourceTrackingService.checkConflicts')(function* (expectedOrgId?: string) {
@@ -440,55 +439,63 @@ export class SourceTrackingService extends Effect.Service<SourceTrackingService>
 
     /** Maybe update tracking from retrieve result (both tracking files). No-op if tracking is not enabled. */
     const maybeUpdateTrackingFromRetrieve = Effect.fn('SourceTrackingService.maybeUpdateTrackingFromRetrieve')(
-      function* (result: RetrieveResult, expectedOrgId?: string) {
-        yield* Effect.annotateCurrentSpan({ files: result.getFileResponses().map(r => r.filePath) });
-
-        // Check if tracking is enabled before attempting to get instance
-        const enabled = yield* hasTracking(expectedOrgId);
-        if (!enabled) {
-          return yield* Effect.void;
-        }
-
-        const tracking = yield* getOrCreateTracking(expectedOrgId);
-        return yield* Effect.tryPromise({
-          try: () => tracking.updateTrackingFromRetrieve(result),
-          catch: toSourceTrackingError
-        }).pipe(
-          Effect.withSpan('STL.UpdateTrackingFromRetrieve'),
-          Effect.tapError(error => Effect.logError(error)),
-          remoteSemaphore.withPermits(1),
-          localSemaphore.withPermits(1)
-        );
-      }
+      (result: RetrieveResult, expectedOrgId?: string) =>
+        Effect.annotateCurrentSpan({ files: result.getFileResponses().map(r => r.filePath) }).pipe(
+          Effect.zipRight(
+            hasTracking(expectedOrgId).pipe(
+              Effect.flatMap(enabled =>
+                enabled
+                  ? getOrCreateTracking(expectedOrgId).pipe(
+                      Effect.flatMap(tracking =>
+                        Effect.tryPromise({
+                          try: () => tracking.updateTrackingFromRetrieve(result),
+                          catch: toSourceTrackingError
+                        }).pipe(
+                          Effect.withSpan('STL.UpdateTrackingFromRetrieve'),
+                          Effect.tapError(error => Effect.logError(error))
+                        )
+                      )
+                    )
+                  : Effect.void
+              ),
+              Effect.asVoid,
+              remoteSemaphore.withPermits(1),
+              localSemaphore.withPermits(1)
+            )
+          )
+        )
     );
 
     /** Maybe update tracking from deploy result (both tracking files). No-op if tracking is not enabled. */
-    const maybeUpdateTrackingFromDeploy = Effect.fn('SourceTrackingService.maybeUpdateTrackingFromDeploy')(function* (
-      result: DeployResult
-    ) {
-      // Check if tracking is enabled before attempting to get instance
-      const enabled = yield* hasTracking();
-      if (!enabled) {
-        return yield* Effect.void;
-      }
-
-      const tracking = yield* getOrCreateTracking();
-      return yield* Effect.all(
-        [
-          Effect.tryPromise({
-            try: () => tracking.updateTrackingFromDeploy(result),
-            catch: toSourceTrackingError
-          }).pipe(
-            Effect.withSpan('STL.UpdateTrackingFromDeploy'),
-            Effect.tapError(error => Effect.logError(error)),
-            remoteSemaphore.withPermits(1),
-            localSemaphore.withPermits(1)
+    const maybeUpdateTrackingFromDeploy = Effect.fn('SourceTrackingService.maybeUpdateTrackingFromDeploy')(
+      (result: DeployResult) =>
+        hasTracking().pipe(
+          Effect.flatMap(enabled =>
+            enabled
+              ? getOrCreateTracking().pipe(
+                  Effect.flatMap(tracking =>
+                    Effect.all(
+                      [
+                        Effect.tryPromise({
+                          try: () => tracking.updateTrackingFromDeploy(result),
+                          catch: toSourceTrackingError
+                        }).pipe(
+                          Effect.withSpan('STL.UpdateTrackingFromDeploy'),
+                          Effect.tapError(error => Effect.logError(error))
+                        ),
+                        Effect.annotateCurrentSpan({ files: result.getFileResponses().map(r => r.filePath) })
+                      ],
+                      { concurrency: 'unbounded' }
+                    )
+                  )
+                )
+              : Effect.void
           ),
-          Effect.annotateCurrentSpan({ files: result.getFileResponses().map(r => r.filePath) })
-        ],
-        { concurrency: 'unbounded' }
-      );
-    });
+          Effect.asVoid,
+          remoteSemaphore.withPermits(1),
+          localSemaphore.withPermits(1)
+        )
+    );
 
     return {
       /** Check if source tracking is enabled for the current org without creating a tracking instance */

--- a/packages/salesforcedx-vscode-services/src/core/targetOrgGuard.ts
+++ b/packages/salesforcedx-vscode-services/src/core/targetOrgGuard.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Effect from 'effect/Effect';
+import * as Option from 'effect/Option';
+import { isNotUndefined } from 'effect/Predicate';
+import * as Sink from 'effect/Sink';
+import * as Stream from 'effect/Stream';
+import { nls } from '../messages';
+import { ConnectionService, InactiveOrgOperationError, NoTargetOrgConfiguredError } from './connectionService';
+import { getDefaultOrgRef } from './defaultOrgRef';
+
+/** Prevent a command from continuing after its target org changes. */
+export const preventOrgChanges = <A, E, R>(command: Effect.Effect<A, E, R>) =>
+  Effect.gen(function* () {
+    const targetOrgRef = yield* getDefaultOrgRef();
+    // Subscribe before resolving the connection so no target-org update can occur between the snapshot and stream.
+    const [, changes] = yield* targetOrgRef.changes.pipe(Stream.peel(Sink.head()));
+    const expectedOrgId = yield* ConnectionService.getConnection().pipe(
+      Effect.map(connection => connection.getAuthInfoFields().orgId),
+      Effect.filterOrFail(isNotUndefined, () => new NoTargetOrgConfiguredError({ message: 'No target org configured' }))
+    );
+
+    const targetOrgChanged = changes.pipe(
+      Stream.map(org => org.orgId),
+      Stream.changes,
+      Stream.filter(orgId => orgId !== expectedOrgId),
+      Stream.runHead,
+      Effect.flatMap(
+        Option.match({
+          onNone: () => Effect.never,
+          onSome: observedOrgId =>
+            Effect.fail(
+              new InactiveOrgOperationError({
+                message: nls.localize('org_operation_target_changed', expectedOrgId),
+                expectedOrgId,
+                ...(observedOrgId ? { observedOrgId } : {})
+              })
+            )
+        })
+      )
+    );
+
+    return yield* Effect.raceFirst(command, targetOrgChanged);
+  }).pipe(Effect.scoped);

--- a/packages/salesforcedx-vscode-services/src/index.ts
+++ b/packages/salesforcedx-vscode-services/src/index.ts
@@ -38,6 +38,7 @@ import { retrieveOnLoadEffect } from './core/retrieveOnLoad';
 import { TraceFlagItemStruct } from './core/schemas/traceFlagSchemas';
 import { watchSfProjectFile } from './core/sfProjectFileWatcher';
 import { SourceTrackingService } from './core/sourceTrackingService';
+import { preventOrgChanges } from './core/targetOrgGuard';
 import { TemplateService, TemplateType } from './core/templateService';
 import { TraceFlagService } from './core/traceFlagService';
 import { TransmogrifierService } from './core/transmogrifierService';
@@ -129,6 +130,7 @@ export type SalesforceVSCodeServicesApi = {
     LightningComponentService: typeof LightningComponentService;
     ConfigService: typeof ConfigService;
     ConnectionService: typeof ConnectionService;
+    preventOrgChanges: typeof preventOrgChanges;
     registerCommandWithRuntime: typeof registerCommandWithRuntime;
     ExecuteAnonymousService: typeof ExecuteAnonymousService;
     EditorService: typeof EditorService;
@@ -504,6 +506,7 @@ export const activate = async (context: vscode.ExtensionContext): Promise<Salesf
         LightningComponentService,
         ConfigService,
         ConnectionService,
+        preventOrgChanges,
         ExecuteAnonymousService,
         registerCommandWithRuntime,
         EditorService,

--- a/packages/salesforcedx-vscode-services/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-services/src/messages/i18n.ts
@@ -51,6 +51,7 @@ export const messages = {
   org_metadata_catalog_state_missing:
     'No persisted OrgMetadataCatalog state exists yet. Use Org Browser, Apex Tests, SOQL, or Refresh SObject Definitions first.',
   org_metadata_catalog_state_open_failed: 'Failed to open persisted OrgMetadataCatalog state: %s',
+  org_operation_target_changed: "The active org changed while an operation for '%s' was in progress.",
   org_operation_superseded: 'The active org changed before this operation finished. Run it again for the current org.'
 } as const;
 

--- a/packages/salesforcedx-vscode-services/src/vscode/fileChangePubSub.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/fileChangePubSub.ts
@@ -14,7 +14,7 @@ export type FileChangeEvent = {
   readonly uri: URI;
 };
 
-/** PubSub that broadcasts all workspace file-system change events.
+/** PubSub that broadcasts observed file-system change events.
  * The VS Code wiring (FileWatcherLayer) writes to this; consumers subscribe read-only. */
 export class FileChangePubSub extends Effect.Service<FileChangePubSub>()('FileChangePubSub', {
   scoped: PubSub.sliding<FileChangeEvent>(10_000)

--- a/packages/salesforcedx-vscode-services/src/vscode/fileWatcherService.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/fileWatcherService.ts
@@ -5,11 +5,13 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { Config, Global } from '@salesforce/core';
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
 import * as PubSub from 'effect/PubSub';
 import * as Stream from 'effect/Stream';
 import * as vscode from 'vscode';
+import { URI } from 'vscode-uri';
 import { ChannelService } from './channelService';
 import { FileChangePubSub, type FileChangeEvent } from './fileChangePubSub';
 
@@ -18,18 +20,33 @@ export const FileWatcherLayer = Layer.scopedDiscard(
     const pubsub = yield* FileChangePubSub;
     const channel = yield* ChannelService;
 
-    yield* Effect.acquireUseRelease(
-      Effect.sync(() => vscode.workspace.createFileSystemWatcher('**/*')),
-      watcher =>
-        Stream.async<FileChangeEvent>(emit => {
-          watcher.onDidCreate(uri => emit.single({ type: 'create', uri }));
-          watcher.onDidChange(uri => emit.single({ type: 'change', uri }));
-          watcher.onDidDelete(uri => emit.single({ type: 'delete', uri }));
-        }).pipe(Stream.runForEach(event => PubSub.publish(pubsub, event))),
-      watcher =>
-        Effect.sync(() => {
-          watcher.dispose();
-        }).pipe(Effect.withSpan('disposing file watcher'))
+    const patterns: vscode.GlobPattern[] = [
+      '**/*',
+      ...(process.env.ESBUILD_PLATFORM === 'web'
+        ? []
+        : [
+            new vscode.RelativePattern(URI.file(Global.SF_DIR), Config.getFileName()),
+            new vscode.RelativePattern(URI.file(Global.SFDX_DIR), 'alias.json')
+          ])
+    ];
+
+    yield* Effect.forEach(
+      patterns,
+      pattern =>
+        Effect.acquireUseRelease(
+          Effect.sync(() => vscode.workspace.createFileSystemWatcher(pattern)),
+          watcher =>
+            Stream.async<FileChangeEvent>(emit => {
+              watcher.onDidCreate(uri => emit.single({ type: 'create', uri }));
+              watcher.onDidChange(uri => emit.single({ type: 'change', uri }));
+              watcher.onDidDelete(uri => emit.single({ type: 'delete', uri }));
+            }).pipe(Stream.runForEach(event => PubSub.publish(pubsub, event))),
+          watcher =>
+            Effect.sync(() => {
+              watcher.dispose();
+            }).pipe(Effect.withSpan('disposing file watcher'))
+        ),
+      { concurrency: 'unbounded' }
     ).pipe(Effect.forkScoped);
 
     yield* channel.appendToChannel('FileWatcherService started successfully');

--- a/packages/salesforcedx-vscode-services/test/jest/core/configFileWatcher.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/configFileWatcher.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Effect from 'effect/Effect';
+import * as Fiber from 'effect/Fiber';
+import * as Layer from 'effect/Layer';
+import * as Option from 'effect/Option';
+import * as PubSub from 'effect/PubSub';
+import * as SubscriptionRef from 'effect/SubscriptionRef';
+import { URI } from 'vscode-uri';
+import { AliasService } from '../../../src/core/alias';
+import { ConfigService } from '../../../src/core/configService';
+import { watchConfigFiles } from '../../../src/core/configFileWatcher';
+import { ConnectionService } from '../../../src/core/connectionService';
+import { getDefaultOrgRef } from '../../../src/core/defaultOrgRef';
+import { FileChangePubSub, type FileChangeEvent } from '../../../src/vscode/fileChangePubSub';
+
+jest.mock('@salesforce/core/global', () => ({
+  ...jest.requireActual('@salesforce/core/global'),
+  Global: {
+    SF_DIR: '/Users/test/.sf',
+    SFDX_DIR: '/Users/test/.sfdx',
+    SF_STATE_FOLDER: '.sf'
+  }
+}));
+
+describe('watchConfigFiles', () => {
+  const makeLayer = (pubsub: PubSub.PubSub<FileChangeEvent>, resolvedUsername: string) => {
+    const invalidateConfigAggregator = jest.fn(() => Effect.void);
+    const invalidateCachedConnections = jest.fn(() => Effect.void);
+    const getConnection = jest.fn(() => Effect.succeed({} as never));
+    const layer = Layer.mergeAll(
+      Layer.succeed(FileChangePubSub, pubsub as unknown as FileChangePubSub),
+      Layer.succeed(
+        AliasService,
+        AliasService.make({
+          getAllAliases: () => Effect.succeed({}),
+          getAliasesFromUsername: () => Effect.succeed([]),
+          getUsernameFromAlias: () => Effect.succeed(Option.some(resolvedUsername)),
+          unsetAliases: () => Effect.void
+        })
+      ),
+      Layer.succeed(
+        ConfigService,
+        ConfigService.make({
+          getTargetOrg: () => Effect.succeed('configured-alias'),
+          invalidateConfigAggregator
+        } as never)
+      ),
+      Layer.succeed(ConnectionService, ConnectionService.make({ invalidateCachedConnections, getConnection } as never))
+    );
+    return { getConnection, invalidateCachedConnections, invalidateConfigAggregator, layer };
+  };
+
+  beforeEach(async () => {
+    await Effect.runPromise(
+      getDefaultOrgRef().pipe(
+        Effect.flatMap(ref => SubscriptionRef.set(ref, { username: 'current@example.com', orgId: '00D-current' }))
+      )
+    );
+  });
+
+  it('refreshes the effective target org when its alias resolves to another username', async () => {
+    const pubsub = await Effect.runPromise(PubSub.sliding<FileChangeEvent>(10));
+    const { getConnection, invalidateCachedConnections, invalidateConfigAggregator, layer } = makeLayer(
+      pubsub,
+      'replacement@example.com'
+    );
+
+    const fiber = Effect.runFork(Effect.provide(watchConfigFiles(), layer));
+    await Effect.runPromise(Effect.sleep(10));
+    await Effect.runPromise(
+      PubSub.publish(pubsub, { type: 'change' as const, uri: URI.file('/Users/test/.sfdx/alias.json') })
+    );
+    await Effect.runPromise(Effect.sleep(100));
+    await Effect.runPromise(Fiber.interrupt(fiber));
+
+    expect(invalidateConfigAggregator).toHaveBeenCalledTimes(1);
+    expect(invalidateCachedConnections).toHaveBeenCalledTimes(1);
+    expect(getConnection).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores alias changes that retain the configured target-org resolution', async () => {
+    const pubsub = await Effect.runPromise(PubSub.sliding<FileChangeEvent>(10));
+    const { getConnection, invalidateCachedConnections, invalidateConfigAggregator, layer } = makeLayer(
+      pubsub,
+      'current@example.com'
+    );
+
+    const fiber = Effect.runFork(Effect.provide(watchConfigFiles(), layer));
+    await Effect.runPromise(Effect.sleep(10));
+    await Effect.runPromise(
+      PubSub.publish(pubsub, { type: 'change' as const, uri: URI.file('/Users/test/.sfdx/alias.json') })
+    );
+    await Effect.runPromise(Effect.sleep(100));
+    await Effect.runPromise(Fiber.interrupt(fiber));
+
+    expect(invalidateConfigAggregator).not.toHaveBeenCalled();
+    expect(invalidateCachedConnections).not.toHaveBeenCalled();
+    expect(getConnection).not.toHaveBeenCalled();
+  });
+});

--- a/packages/salesforcedx-vscode-services/test/jest/core/connectionService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/connectionService.test.ts
@@ -21,10 +21,12 @@ import { ConfigService } from '../../../src/core/configService';
 import {
   ConnectionService,
   InactiveOrgOperationError,
+  NoTargetOrgConfiguredError,
   updateDefaultOrgIdentity
 } from '../../../src/core/connectionService';
 import { getDefaultOrgRef } from '../../../src/core/defaultOrgRef';
 import { DefaultOrgInfoSchema } from '../../../src/core/schemas/defaultOrgInfo';
+import { preventOrgChanges } from '../../../src/core/targetOrgGuard';
 import { SettingsService } from '../../../src/vscode/settingsService';
 
 jest.mock('@salesforce/core', () => ({
@@ -118,12 +120,83 @@ describe('ConnectionService.getConnectionForOrg', () => {
     expect(exit).toEqual(
       Exit.fail(
         new InactiveOrgOperationError({
-          message: "The active org changed while an operation for '00D-expected' was in progress",
+          message: "The active org changed while an operation for '00D-expected' was in progress.",
           expectedOrgId: '00D-expected',
           observedOrgId: '00D-observed'
         })
       )
     );
+  });
+});
+
+describe('preventOrgChanges', () => {
+  const prepareConnection = async (orgId: string | undefined) => {
+    await Effect.runPromise(ConnectionService.invalidateCachedConnections().pipe(Effect.provide(buildLayer())));
+    await Effect.runPromise(getDefaultOrgRef().pipe(Effect.flatMap(ref => SubscriptionRef.set(ref, {}))));
+    jest.mocked(AuthInfo.create).mockResolvedValue({ getFields: () => ({}) } as unknown as AuthInfo);
+    jest.mocked(Connection.create).mockResolvedValue(makeConn({ isAccessTokenFlow: false, orgId }));
+  };
+
+  it('runs the command when the target org does not change', async () => {
+    await prepareConnection('00D-original');
+
+    await expect(
+      Effect.runPromise(preventOrgChanges(Effect.succeed('complete')).pipe(Effect.provide(buildLayer())))
+    ).resolves.toBe('complete');
+  });
+
+  it('keeps an observed target-org change cancelled after switching back', async () => {
+    await prepareConnection('00D-original');
+
+    const exit = await Effect.runPromiseExit(
+      preventOrgChanges(
+        Effect.gen(function* () {
+          const ref = yield* getDefaultOrgRef();
+          yield* SubscriptionRef.set(ref, { orgId: '00D-replacement' });
+          yield* SubscriptionRef.set(ref, { orgId: '00D-original' });
+          yield* Effect.sleep(Duration.millis(1));
+        })
+      ).pipe(Effect.provide(buildLayer()))
+    );
+
+    expect(exit).toEqual(
+      Exit.fail(
+        new InactiveOrgOperationError({
+          message: "The active org changed while an operation for '00D-original' was in progress.",
+          expectedOrgId: '00D-original',
+          observedOrgId: '00D-replacement'
+        })
+      )
+    );
+  });
+
+  it('ignores target-org updates that retain the same org ID', async () => {
+    await prepareConnection('00D-original');
+
+    await expect(
+      Effect.runPromise(
+        preventOrgChanges(
+          Effect.gen(function* () {
+            yield* SubscriptionRef.set(yield* getDefaultOrgRef(), {
+              orgId: '00D-original',
+              username: 'replacement@example.com'
+            });
+            yield* Effect.sleep(Duration.millis(1));
+            return 'complete';
+          })
+        ).pipe(Effect.provide(buildLayer()))
+      )
+    ).resolves.toBe('complete');
+  });
+
+  it('fails before the command when the connection has no org ID', async () => {
+    await prepareConnection(undefined);
+
+    const exit = await Effect.runPromiseExit(
+      preventOrgChanges(Effect.succeed('not run')).pipe(Effect.provide(buildLayer()))
+    );
+
+    expect(exit).toEqual(Exit.fail(new NoTargetOrgConfiguredError({ message: 'No target org configured' })));
   });
 });
 

--- a/packages/salesforcedx-vscode-services/test/jest/vscode/fileWatcherService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/vscode/fileWatcherService.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Effect from 'effect/Effect';
+import * as Fiber from 'effect/Fiber';
+import * as Layer from 'effect/Layer';
+import * as vscode from 'vscode';
+import { ChannelService } from '../../../src/vscode/channelService';
+import { FileChangePubSub } from '../../../src/vscode/fileChangePubSub';
+import { FileWatcherLayer } from '../../../src/vscode/fileWatcherService';
+
+jest.mock('@salesforce/core', () => ({
+  ...jest.requireActual('@salesforce/core'),
+  Config: { getFileName: () => 'config.json' },
+  Global: {
+    SF_DIR: '/Users/test/.sf',
+    SFDX_DIR: '/Users/test/.sfdx'
+  }
+}));
+
+describe('FileWatcherLayer', () => {
+  it('watches the workspace and external Salesforce config files', async () => {
+    const watchers = Array.from({ length: 3 }, () => ({
+      onDidCreate: jest.fn(),
+      onDidChange: jest.fn(),
+      onDidDelete: jest.fn(),
+      dispose: jest.fn()
+    }));
+    jest
+      .mocked(vscode.workspace.createFileSystemWatcher)
+      .mockImplementation(() => watchers.shift() as unknown as vscode.FileSystemWatcher);
+
+    const layer = FileWatcherLayer.pipe(
+      Layer.provide(Layer.mergeAll(FileChangePubSub.Default, ChannelService.Default))
+    );
+    const fiber = Effect.runFork(Layer.launch(layer));
+    await Effect.runPromise(Effect.sleep(10));
+
+    const patterns = jest.mocked(vscode.workspace.createFileSystemWatcher).mock.calls.map(([pattern]) => pattern);
+    await Effect.runPromise(Fiber.interrupt(fiber));
+
+    expect(patterns[0]).toBe('**/*');
+    expect(patterns[1]).toMatchObject({ base: { path: '/Users/test/.sf' }, pattern: 'config.json' });
+    expect(patterns[2]).toMatchObject({ base: { path: '/Users/test/.sfdx' }, pattern: 'alias.json' });
+  });
+});

--- a/scripts/setup-jest.ts
+++ b/scripts/setup-jest.ts
@@ -4,6 +4,9 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+// Azure Monitor exporter ctor starts a 15s Statsbeat timer that dynamic-imports after Jest teardown (exit 1).
+process.env.APPLICATION_INSIGHTS_NO_STATSBEAT = 'true';
+
 class EventEmitter {
   private listeners: any[] = [];
   constructor() {}


### PR DESCRIPTION
### What does this PR do?

Cancel in-flight deploy/retrieve/delete when the target org's `orgId` changes.

- command races `TargetOrgRef.changes` on `orgId` only (username/alias/unrelated config writes do not invalidate)
- file events refresh `TargetOrgRef`; they do not cancel commands directly
- desktop watches `~/.sf/config.json` and `~/.sfdx/alias.json`
- alias writes refresh only when configured `target-org` is that alias and it now resolves to a different username
- toast stays `org_operation_superseded`; tagged error detail is `org_operation_target_changed`

Replaces per-call polling/`ensureOrgHasNotChanged`.

### What issues does this PR fix or reference?

@W-23953278@

Related rewrite of #8075.