### PR TITLE
feat(soql): migrate Fields selection to Lit - W-23928680

### DIFF
--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/lit/index.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/lit/index.ts
@@ -20,13 +20,16 @@ const serviceLayer = VscodeSoqlBuilderServiceLive.pipe(Layer.provide(VscodeMessa
 const main = document.querySelector('#main') ?? document.body.appendChild(document.createElement('main'));
 const app = new SoqlBuilderElement();
 app.labels = {
+  clearAllFields: messages.action_clear_all_fields,
+  count: messages.label_count,
   fields: messages.label_fields,
   from: messages.label_from,
   inputs: messages.label_soql_query_inputs,
   loading: messages.label_loading,
   noDefaultOrg: messages.label_no_default_org,
   noResults: messages.label_no_results_found,
-  query: messages.label_soql_query
+  query: messages.label_soql_query,
+  selectAllFields: messages.action_select_all_fields
 };
 app.lifecycle = new SoqlBuilderApplication(app, serviceLayer);
 main.append(app);

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/messages/i18n.ts
@@ -49,6 +49,9 @@ export const messages = {
   action_add: 'Add',
 
   // fields
+  action_clear_all_fields: 'Clear All',
+  action_select_all_fields: 'Select All',
+  label_count: 'COUNT()',
   label_fields: 'Fields',
 
   // from

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-builder-ui/lit/vscodeSoqlBuilderService.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-builder-ui/lit/vscodeSoqlBuilderService.test.ts
@@ -173,6 +173,48 @@ describe('VscodeSoqlBuilderService', () => {
     expect(state.notificationsDismissed).toBe(true);
   });
 
+  it('publishes COUNT and bulk field-selection actions through the host contract', async () => {
+    const harness = makeMessageHarness();
+    const metadata = {
+      ...accountMetadata,
+      fields: [
+        ...accountMetadata.fields,
+        {
+          ...accountMetadata.fields[0],
+          label: 'Account Name',
+          name: 'Name',
+          type: 'string'
+        }
+      ]
+    } as const;
+
+    await runWithService(harness.layer, service =>
+      Effect.gen(function* () {
+        yield* service.dispatch({ _tag: 'ObjectSelected', objectName: 'Account' });
+        harness.emit({ type: MessageType.SOBJECT_METADATA_RESPONSE, payload: metadata });
+        yield* Effect.sleep(Duration.millis(10));
+
+        yield* service.dispatch({ _tag: 'FieldsSelected', fieldNames: ['COUNT()'] });
+        const countState = yield* service.initialState;
+        expect(countState.query.fields).toEqual(['COUNT()']);
+        const countQuery = harness.messages.findLast(message => message.type === MessageType.UI_SOQL_CHANGED)?.payload;
+        expect(countQuery?.replace(/\s+/gu, ' ').trim()).toBe('SELECT COUNT() FROM Account');
+
+        yield* service.dispatch({ _tag: 'AllFieldsSelected' });
+        const allFieldsState = yield* service.initialState;
+        expect(allFieldsState.query.fields).toEqual(['Id', 'Name']);
+        const allFieldsQuery = harness.messages.findLast(
+          message => message.type === MessageType.UI_SOQL_CHANGED
+        )?.payload;
+        expect(allFieldsQuery?.replace(/\s+/gu, ' ').trim()).toBe('SELECT Id, Name FROM Account');
+
+        yield* service.dispatch({ _tag: 'AllFieldsCleared' });
+        const clearedState = yield* service.initialState;
+        expect(clearedState.query.fields).toEqual([]);
+      })
+    );
+  });
+
   it('resets dependent clauses and requests metadata once when From changes', async () => {
     const harness = makeMessageHarness({
       originalSoqlStatement:

--- a/packages/soql-builder-ui/src/components/soqlBuilderActionEvent.ts
+++ b/packages/soql-builder-ui/src/components/soqlBuilderActionEvent.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { SOQL_BUILDER_ACTION_EVENT, type SoqlBuilderAction } from '../domain.js';
+
+export class SoqlBuilderActionEvent extends CustomEvent<SoqlBuilderAction> {
+  constructor(action: SoqlBuilderAction) {
+    super(SOQL_BUILDER_ACTION_EVENT, {
+      bubbles: true,
+      composed: true,
+      detail: action
+    });
+  }
+}

--- a/packages/soql-builder-ui/src/components/soqlBuilderElement.styles.ts
+++ b/packages/soql-builder-ui/src/components/soqlBuilderElement.styles.ts
@@ -34,10 +34,12 @@ export const soqlBuilderElementStyles = css`
     grid-template-columns: 72px minmax(0, 1fr);
   }
 
+  soql-builder-fields,
   soql-builder-from {
     display: contents;
   }
 
+  soql-builder-fields .input,
   soql-builder-from .input {
     display: grid;
     gap: 4px;
@@ -52,6 +54,18 @@ export const soqlBuilderElementStyles = css`
   soql-builder-from .status {
     color: var(--vscode-descriptionForeground, inherit);
     font-size: 0.92em;
+  }
+
+  soql-builder-fields .status {
+    color: var(--vscode-descriptionForeground, inherit);
+    font-size: 0.92em;
+  }
+
+  .field-actions {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
   }
 
   label,

--- a/packages/soql-builder-ui/src/components/soqlBuilderElement.ts
+++ b/packages/soql-builder-ui/src/components/soqlBuilderElement.ts
@@ -5,19 +5,17 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { VscodeMultiSelect } from '@vscode-elements/elements/dist/vscode-multi-select/index.js';
-import '@vscode-elements/elements/dist/vscode-option/index.js';
 import { html, LitElement, nothing } from 'lit';
 import { property } from 'lit/decorators/property.js';
-import {
-  SOQL_BUILDER_ACTION_EVENT,
-  createInitialSoqlBuilderState,
-  type SoqlBuilderAction,
-  type SoqlBuilderState
-} from '../domain.js';
+import { createInitialSoqlBuilderState, type SoqlBuilderState } from '../domain.js';
+import { SoqlBuilderActionEvent } from './soqlBuilderActionEvent.js';
 import { soqlBuilderElementStyles } from './soqlBuilderElement.styles.js';
 
+export { SoqlBuilderActionEvent } from './soqlBuilderActionEvent.js';
+
 export type SoqlBuilderLabels = {
+  readonly clearAllFields: string;
+  readonly count: string;
   readonly fields: string;
   readonly from: string;
   readonly inputs: string;
@@ -25,22 +23,13 @@ export type SoqlBuilderLabels = {
   readonly noDefaultOrg: string;
   readonly noResults: string;
   readonly query: string;
+  readonly selectAllFields: string;
 };
 
 export type SoqlBuilderLifecycle = {
   readonly connect: () => void;
   readonly disconnect: () => Promise<void> | void;
 };
-
-export class SoqlBuilderActionEvent extends CustomEvent<SoqlBuilderAction> {
-  constructor(action: SoqlBuilderAction) {
-    super(SOQL_BUILDER_ACTION_EVENT, {
-      bubbles: true,
-      composed: true,
-      detail: action
-    });
-  }
-}
 
 export class SoqlBuilderElement extends LitElement {
   public static styles = soqlBuilderElementStyles;
@@ -72,6 +61,9 @@ export class SoqlBuilderElement extends LitElement {
     const hasRecoverableFromError = state.query.parseErrors.some(error =>
       ['EMPTY', 'INCOMPLETEFROM', 'NOFROM'].includes(error.type)
     );
+    const hasRecoverableFieldsError = state.query.parseErrors.some(error =>
+      ['EMPTY', 'NOSELECT', 'NOSELECTIONS'].includes(error.type)
+    );
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- an empty statement must still render as `nothing`, unlike a merely-unset one; `??` would not collapse ''
     const queryPreview = state.query.originalSoqlStatement ? state.query.originalSoqlStatement : nothing;
     return html`
@@ -100,22 +92,21 @@ export class SoqlBuilderElement extends LitElement {
                     ></soql-builder-from>
                   </div>
                   <div class="control">
-                    <label for="soql-fields">${this.labels.fields}</label>
-                    <vscode-multi-select
-                      id="soql-fields"
-                      name="fields"
-                      tabindex="0"
-                      combobox
-                      filter="startsWithPerTerm"
-                      label=${this.labels.fields}
-                      ?disabled=${state.isFieldsLoading || state.query.sObject === undefined}
-                      .value=${state.query.fields}
-                      @change=${this.handleFieldsChange}
-                    >
-                      ${state.metadata.fields.map(
-                        field => html`<vscode-option value=${field.name}>${field.label}</vscode-option>`
-                      )}
-                    </vscode-multi-select>
+                    <soql-builder-fields
+                      .disabled=${state.query.sObject === undefined}
+                      .fields=${state.metadata.fields}
+                      .invalid=${hasRecoverableFieldsError}
+                      .isLoading=${state.isFieldsLoading}
+                      .labels=${{
+                        clearAll: this.labels.clearAllFields,
+                        count: this.labels.count,
+                        fields: this.labels.fields,
+                        loading: this.labels.loading,
+                        noResults: this.labels.noResults,
+                        selectAll: this.labels.selectAllFields
+                      }}
+                      .selectedFieldNames=${state.query.fields}
+                    ></soql-builder-fields>
                   </div>
                 </form>
                 <section class="preview" role="status" aria-live="polite">
@@ -127,18 +118,6 @@ export class SoqlBuilderElement extends LitElement {
       </main>
     `;
   }
-
-  private readonly handleFieldsChange = (event: Event): void => {
-    const select = event.currentTarget;
-    if (select instanceof VscodeMultiSelect) {
-      this.dispatchEvent(
-        new SoqlBuilderActionEvent({
-          _tag: 'FieldsSelected',
-          fieldNames: [...select.value]
-        })
-      );
-    }
-  };
 
   private readonly preventSubmit = (event: SubmitEvent): void => event.preventDefault();
 }

--- a/packages/soql-builder-ui/src/components/soqlFieldsElement.ts
+++ b/packages/soql-builder-ui/src/components/soqlFieldsElement.ts
@@ -19,7 +19,7 @@ import { SoqlBuilderActionEvent } from './soqlBuilderActionEvent.js';
 
 const SELECT_COUNT = 'COUNT()';
 
-export type SoqlFieldsLabels = {
+type SoqlFieldsLabels = {
   readonly clearAll: string;
   readonly count: string;
   readonly fields: string;

--- a/packages/soql-builder-ui/src/components/soqlFieldsElement.ts
+++ b/packages/soql-builder-ui/src/components/soqlFieldsElement.ts
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import type { SoqlBuilderState } from '../domain.js';
+import '@vscode-elements/elements/dist/vscode-button/index.js';
+import { VscodeCheckbox } from '@vscode-elements/elements/dist/vscode-checkbox/index.js';
+import { VscodeMultiSelect } from '@vscode-elements/elements/dist/vscode-multi-select/index.js';
+import '@vscode-elements/elements/dist/vscode-option/index.js';
+import { html, LitElement, nothing } from 'lit';
+import { property } from 'lit/decorators/property.js';
+import { query } from 'lit/decorators/query.js';
+import { state } from 'lit/decorators/state.js';
+import { repeat } from 'lit/directives/repeat.js';
+import { SoqlBuilderActionEvent } from './soqlBuilderActionEvent.js';
+
+const SELECT_COUNT = 'COUNT()';
+
+export type SoqlFieldsLabels = {
+  readonly clearAll: string;
+  readonly count: string;
+  readonly fields: string;
+  readonly loading: string;
+  readonly noResults: string;
+  readonly selectAll: string;
+};
+
+const normalize = (value: string): string => value.trim().toLocaleLowerCase();
+
+const matchesFieldsFilter = (field: SoqlBuilderState['metadata']['fields'][number], filterValue: string): boolean => {
+  const pattern = normalize(filterValue);
+  if (!pattern) return true;
+
+  return [field.label, field.name].some(value =>
+    normalize(value)
+      .split(/\s+/u)
+      .some(term => term.startsWith(pattern))
+  );
+};
+
+export class SoqlFieldsElement extends LitElement {
+  @property({ type: Boolean })
+  public accessor disabled = false;
+
+  @property({ attribute: false })
+  public accessor fields: SoqlBuilderState['metadata']['fields'] = [];
+
+  @property({ type: Boolean })
+  public accessor invalid = false;
+
+  @property({ type: Boolean })
+  public accessor isLoading = false;
+
+  @property({ attribute: false })
+  public accessor labels!: SoqlFieldsLabels;
+
+  @property({ attribute: false })
+  public accessor selectedFieldNames: readonly string[] = [];
+
+  @state()
+  private accessor filterValue = '';
+
+  @query('vscode-multi-select')
+  private accessor select: VscodeMultiSelect | null = null;
+
+  protected override createRenderRoot(): HTMLElement | DocumentFragment {
+    // Keep the form-associated VSCode controls in the builder form's tree. A nested shadow root would prevent
+    // ElementInternals from discovering that outer form.
+    return this;
+  }
+
+  protected override updated(): void {
+    const select = this.select;
+    if (!select) return;
+
+    // Option slot changes can clear vscode-multi-select's pending value when metadata and restored selections arrive
+    // together. Reapply the controlled value after the nested control has populated its option controller.
+    void select.updateComplete.then(() => {
+      select.value = this.selectedFieldNames.filter(fieldName => normalize(fieldName) !== normalize(SELECT_COUNT));
+      this.syncComboboxAriaState();
+    });
+  }
+
+  protected override render() {
+    const controlsDisabled = this.disabled || this.isLoading;
+    const ordinarySelections = this.selectedFieldNames.filter(
+      fieldName => normalize(fieldName) !== normalize(SELECT_COUNT)
+    );
+    const countSelected = this.selectedFieldNames.some(fieldName => normalize(fieldName) === normalize(SELECT_COUNT));
+    const hasNoResults =
+      !controlsDisabled &&
+      (this.fields.length === 0 || !this.fields.some(field => matchesFieldsFilter(field, this.filterValue)));
+    const status = this.isLoading ? this.labels.loading : hasNoResults ? this.labels.noResults : nothing;
+
+    return html`
+      <label class="label" for="soql-fields">
+        ${this.labels.fields}${this.invalid ? html`<span class="required" aria-hidden="true">*</span>` : nothing}
+      </label>
+      <div class="input fields-input">
+        <vscode-multi-select
+          id="soql-fields"
+          name="fields"
+          tabindex="0"
+          combobox
+          filter="startsWithPerTerm"
+          label=${this.labels.fields}
+          aria-busy=${this.isLoading ? 'true' : 'false'}
+          aria-invalid=${this.invalid ? 'true' : 'false'}
+          ?disabled=${controlsDisabled}
+          .invalid=${this.invalid}
+          .value=${ordinarySelections}
+          @change=${this.handleFieldsChange}
+          @focusin=${this.handleFilterFocus}
+          @input=${this.handleFilterInput}
+        >
+          ${repeat(
+            this.fields,
+            field => field.name,
+            field =>
+              html`<vscode-option value=${field.name}
+                >${field.name === field.label ? field.name : `${field.name} — ${field.label}`}</vscode-option
+              >`
+          )}
+        </vscode-multi-select>
+        <div class="field-actions">
+          <vscode-checkbox
+            name="count"
+            value=${SELECT_COUNT}
+            ?checked=${countSelected}
+            ?disabled=${controlsDisabled}
+            @change=${this.handleCountChange}
+            >${this.labels.count}</vscode-checkbox
+          >
+          <vscode-button
+            type="button"
+            secondary
+            ?disabled=${controlsDisabled || this.fields.length === 0}
+            @click=${this.handleSelectAll}
+            >${this.labels.selectAll}</vscode-button
+          >
+          <vscode-button
+            type="button"
+            secondary
+            ?disabled=${controlsDisabled || this.selectedFieldNames.length === 0}
+            @click=${this.handleClearAll}
+            >${this.labels.clearAll}</vscode-button
+          >
+        </div>
+        ${status === nothing ? nothing : html`<span class="status" role="status" aria-live="polite">${status}</span>`}
+      </div>
+    `;
+  }
+
+  private readonly handleFilterInput = (event: Event): void => {
+    // The public select does not expose its filter text. Native input events cross its shadow boundary,
+    // so read the originating combobox while keeping the implementation detail inside this adapter.
+    const [source] = event.composedPath();
+    if (source instanceof HTMLInputElement) this.filterValue = source.value;
+  };
+
+  private readonly handleFilterFocus = (): void => {
+    // VSCode Elements clears its private filter when the combobox regains focus without emitting input.
+    this.filterValue = '';
+  };
+
+  private syncComboboxAriaState(): void {
+    const combobox = this.select?.shadowRoot?.querySelector('.combobox-input');
+    if (!(combobox instanceof HTMLInputElement)) return;
+
+    combobox.setAttribute('aria-busy', this.isLoading ? 'true' : 'false');
+    combobox.setAttribute('aria-invalid', this.invalid ? 'true' : 'false');
+  }
+
+  private readonly handleFieldsChange = (event: Event): void => {
+    const select = event.currentTarget;
+    if (select instanceof VscodeMultiSelect) {
+      this.filterValue = '';
+      this.dispatchEvent(
+        new SoqlBuilderActionEvent({
+          _tag: 'FieldsSelected',
+          fieldNames: [...select.value]
+        })
+      );
+    }
+  };
+
+  private readonly handleCountChange = (event: Event): void => {
+    const checkbox = event.currentTarget;
+    if (checkbox instanceof VscodeCheckbox) {
+      this.dispatchEvent(
+        new SoqlBuilderActionEvent({
+          _tag: 'FieldsSelected',
+          fieldNames: checkbox.checked ? [SELECT_COUNT] : []
+        })
+      );
+    }
+  };
+
+  private readonly handleSelectAll = (): void => {
+    this.dispatchEvent(new SoqlBuilderActionEvent({ _tag: 'AllFieldsSelected' }));
+  };
+
+  private readonly handleClearAll = (): void => {
+    this.dispatchEvent(new SoqlBuilderActionEvent({ _tag: 'AllFieldsCleared' }));
+  };
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'soql-builder-fields': SoqlFieldsElement;
+  }
+}

--- a/packages/soql-builder-ui/src/components/soqlFromElement.ts
+++ b/packages/soql-builder-ui/src/components/soqlFromElement.ts
@@ -5,28 +5,19 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import type { SoqlBuilderState } from '../domain.js';
 import { VscodeSingleSelect } from '@vscode-elements/elements/dist/vscode-single-select/index.js';
 import '@vscode-elements/elements/dist/vscode-option/index.js';
 import { html, LitElement, nothing } from 'lit';
 import { property } from 'lit/decorators/property.js';
 import { state } from 'lit/decorators/state.js';
 import { repeat } from 'lit/directives/repeat.js';
-import { SOQL_BUILDER_ACTION_EVENT, type SoqlBuilderAction, type SoqlBuilderState } from '../domain.js';
+import { SoqlBuilderActionEvent } from './soqlBuilderActionEvent.js';
 
 export type SoqlFromLabels = {
   readonly from: string;
   readonly loading: string;
   readonly noResults: string;
-};
-
-const dispatchAction = (target: EventTarget, action: SoqlBuilderAction): void => {
-  target.dispatchEvent(
-    new CustomEvent(SOQL_BUILDER_ACTION_EVENT, {
-      bubbles: true,
-      composed: true,
-      detail: action
-    })
-  );
 };
 
 const normalize = (value: string): string => value.trim().toLocaleLowerCase();
@@ -140,10 +131,12 @@ export class SoqlFromElement extends LitElement {
     const select = event.currentTarget;
     if (select instanceof VscodeSingleSelect && select.value) {
       this.filterValue = '';
-      dispatchAction(this, {
-        _tag: 'ObjectSelected',
-        objectName: select.value
-      });
+      this.dispatchEvent(
+        new SoqlBuilderActionEvent({
+          _tag: 'ObjectSelected',
+          objectName: select.value
+        })
+      );
     }
   };
 }

--- a/packages/soql-builder-ui/src/register.ts
+++ b/packages/soql-builder-ui/src/register.ts
@@ -6,9 +6,13 @@
  */
 
 import { SoqlBuilderElement } from './components/soqlBuilderElement.js';
+import { SoqlFieldsElement } from './components/soqlFieldsElement.js';
 import { SoqlFromElement } from './components/soqlFromElement.js';
 
 export const registerSoqlBuilderElements = (): void => {
+  if (!customElements.get('soql-builder-fields')) {
+    customElements.define('soql-builder-fields', SoqlFieldsElement);
+  }
   if (!customElements.get('soql-builder-from')) {
     customElements.define('soql-builder-from', SoqlFromElement);
   }

--- a/packages/soql-builder-ui/test/browser/fixture.ts
+++ b/packages/soql-builder-ui/test/browser/fixture.ts
@@ -163,13 +163,16 @@ window.soqlBuilderHarness = {
     fake = Effect.runSync(makeFakeSoqlBuilderService(latestState));
     element = document.createElement('soql-builder-app');
     element.labels = {
+      clearAllFields: 'Clear All',
+      count: 'COUNT()',
       fields: 'Fields',
       from: 'From',
       inputs: 'Query inputs',
       loading: 'Loading...',
       noDefaultOrg: 'No default org',
       noResults: 'No results found.',
-      query: 'Query preview'
+      query: 'Query preview',
+      selectAllFields: 'Select All'
     };
     application = new SoqlBuilderApplication(element, fake.layer);
     element.lifecycle = application;

--- a/packages/soql-builder-ui/test/browser/helpers.ts
+++ b/packages/soql-builder-ui/test/browser/helpers.ts
@@ -6,6 +6,7 @@
  */
 
 import { expect, type Locator, type Page } from '@playwright/test';
+import type { SoqlBuilderState } from '../../src/domain.js';
 import type { SoqlBuilderBrowserHarness } from './fixture.js';
 
 type StateOverrides = NonNullable<Parameters<SoqlBuilderBrowserHarness['mount']>[0]>;
@@ -21,6 +22,32 @@ export const builder = (page: Page): Locator => page.locator('soql-builder-app')
 export const fromSelect = (page: Page): Locator => builder(page).locator('vscode-single-select[name="sObject"]');
 
 export const fieldsSelect = (page: Page): Locator => builder(page).locator('vscode-multi-select[name="fields"]');
+
+export const countCheckbox = (page: Page): Locator => builder(page).locator('vscode-checkbox[name="count"]');
+
+export const clearAllFieldsButton = (page: Page): Locator =>
+  builder(page).locator('vscode-button').filter({ hasText: 'Clear All' });
+
+export const selectAllFieldsButton = (page: Page): Locator =>
+  builder(page).locator('vscode-button').filter({ hasText: 'Select All' });
+
+export const makeField = (name: string, label: string): SoqlBuilderState['metadata']['fields'][number] => ({
+  aggregatable: true,
+  custom: false,
+  defaultValue: null,
+  extraTypeInfo: null,
+  filterable: true,
+  groupable: true,
+  inlineHelpText: null,
+  label,
+  name,
+  nillable: true,
+  picklistValues: [],
+  referenceTo: [],
+  relationshipName: null,
+  sortable: true,
+  type: 'string'
+});
 
 /**
  * Drives the documented public value/change contract of VSCode Elements. Component tests should use this instead of

--- a/packages/soql-builder-ui/test/browser/soqlFieldsSearch.spec.ts
+++ b/packages/soql-builder-ui/test/browser/soqlFieldsSearch.spec.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect, test } from '@playwright/test';
+import { makeField, mountBuilder } from './helpers.js';
+
+test('searches and keyboard-selects a field from a large catalog', async ({ page }) => {
+  const fields = Array.from({ length: 3000 }, (_, index) =>
+    makeField(`GeneratedField${index}__c`, `Generated Field ${String(index).padStart(4, '0')}`)
+  );
+  fields.push(makeField('TargetField__c', 'Target Field'));
+
+  await mountBuilder(page, { metadata: { fields }, query: { sObject: 'Account' } });
+  const fieldsCombobox = page.getByRole('combobox', { name: 'Fields' });
+
+  await test.step('announces a search with no matching fields', async () => {
+    await fieldsCombobox.fill('DoesNotExist');
+    await expect(page.getByText('No results found.', { exact: true })).toBeVisible();
+  });
+
+  await test.step('clears the announcement when the control resets its filter on focus', async () => {
+    await fieldsCombobox.blur();
+    await fieldsCombobox.focus();
+    await expect(page.getByText('No results found.', { exact: true })).toBeHidden();
+  });
+
+  await test.step('filters by API name or label', async () => {
+    await fieldsCombobox.fill('TargetField__c');
+    await expect(page.getByRole('option', { name: 'TargetField__c — Target Field' })).toBeVisible();
+  });
+
+  await test.step('selects the filtered field without a pointer', async () => {
+    await fieldsCombobox.press('ArrowDown');
+    await fieldsCombobox.press('Enter');
+    await expect
+      .poll(() => page.evaluate(() => window.soqlBuilderHarness.recordedActions()))
+      .toEqual([{ _tag: 'FieldsSelected', fieldNames: ['TargetField__c'] }]);
+  });
+});

--- a/packages/soql-builder-ui/test/browser/soqlFieldsSelection.spec.ts
+++ b/packages/soql-builder-ui/test/browser/soqlFieldsSelection.spec.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect, test } from '@playwright/test';
+import {
+  clearAllFieldsButton,
+  countCheckbox,
+  emitState,
+  fieldsSelect,
+  mountBuilder,
+  selectAllFieldsButton,
+  selectValue
+} from './helpers.js';
+
+test('selects, removes, selects all, clears all, and keeps COUNT() mutually exclusive', async ({ page }) => {
+  await mountBuilder(page, { query: { sObject: 'Account' } });
+
+  await test.step('selects ordinary fields', async () => {
+    await selectValue(fieldsSelect(page), ['Id', 'Name']);
+    await expect
+      .poll(() => page.evaluate(() => window.soqlBuilderHarness.recordedActions()))
+      .toEqual([{ _tag: 'FieldsSelected', fieldNames: ['Id', 'Name'] }]);
+    await emitState(page, { query: { fields: ['Id', 'Name'], sObject: 'Account' } });
+  });
+
+  await test.step('removes an ordinary field', async () => {
+    await selectValue(fieldsSelect(page), ['Name']);
+    await expect
+      .poll(() => page.evaluate(() => window.soqlBuilderHarness.recordedActions()))
+      .toEqual([
+        { _tag: 'FieldsSelected', fieldNames: ['Id', 'Name'] },
+        { _tag: 'FieldsSelected', fieldNames: ['Name'] }
+      ]);
+    await emitState(page, { query: { fields: ['Name'], sObject: 'Account' } });
+  });
+
+  await test.step('replaces ordinary fields with COUNT()', async () => {
+    await countCheckbox(page).click();
+    await expect
+      .poll(() => page.evaluate(() => window.soqlBuilderHarness.recordedActions()))
+      .toEqual([
+        { _tag: 'FieldsSelected', fieldNames: ['Id', 'Name'] },
+        { _tag: 'FieldsSelected', fieldNames: ['Name'] },
+        { _tag: 'FieldsSelected', fieldNames: ['COUNT()'] }
+      ]);
+    await emitState(page, { query: { fields: ['COUNT()'], sObject: 'Account' } });
+    await expect(countCheckbox(page)).toHaveJSProperty('checked', true);
+    await expect(fieldsSelect(page)).toHaveJSProperty('value', []);
+  });
+
+  await test.step('replaces COUNT() with an ordinary field', async () => {
+    await selectValue(fieldsSelect(page), ['Name']);
+    await expect
+      .poll(() => page.evaluate(() => window.soqlBuilderHarness.recordedActions()))
+      .toEqual([
+        { _tag: 'FieldsSelected', fieldNames: ['Id', 'Name'] },
+        { _tag: 'FieldsSelected', fieldNames: ['Name'] },
+        { _tag: 'FieldsSelected', fieldNames: ['COUNT()'] },
+        { _tag: 'FieldsSelected', fieldNames: ['Name'] }
+      ]);
+    await emitState(page, { query: { fields: ['Name'], sObject: 'Account' } });
+    await expect(countCheckbox(page)).toHaveJSProperty('checked', false);
+  });
+
+  await test.step('dispatches the bulk field actions', async () => {
+    await selectAllFieldsButton(page).click();
+    await clearAllFieldsButton(page).click();
+    await expect
+      .poll(() => page.evaluate(() => window.soqlBuilderHarness.recordedActions()))
+      .toEqual([
+        { _tag: 'FieldsSelected', fieldNames: ['Id', 'Name'] },
+        { _tag: 'FieldsSelected', fieldNames: ['Name'] },
+        { _tag: 'FieldsSelected', fieldNames: ['COUNT()'] },
+        { _tag: 'FieldsSelected', fieldNames: ['Name'] },
+        { _tag: 'AllFieldsSelected' },
+        { _tag: 'AllFieldsCleared' }
+      ]);
+  });
+});

--- a/packages/soql-builder-ui/test/browser/soqlFieldsStates.spec.ts
+++ b/packages/soql-builder-ui/test/browser/soqlFieldsStates.spec.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect, test } from '@playwright/test';
+import { countCheckbox, emitState, fieldsSelect, makeField, mountBuilder, selectAllFieldsButton } from './helpers.js';
+
+test('renders Fields loading, empty, recoverable-error, restored, and external-update states', async ({ page }) => {
+  await test.step('disables Fields until an object is selected', async () => {
+    await mountBuilder(page, { metadata: { fields: [] } });
+    await expect(fieldsSelect(page)).toHaveAttribute('disabled', '');
+    await expect(countCheckbox(page)).toHaveAttribute('disabled', '');
+    await expect(selectAllFieldsButton(page)).toHaveAttribute('disabled', '');
+  });
+
+  await test.step('announces loading while object metadata is pending', async () => {
+    await emitState(page, { isFieldsLoading: true, query: { sObject: 'Account' } });
+    await expect(fieldsSelect(page)).toHaveAttribute('aria-busy', 'true');
+    await expect(page.getByRole('combobox', { name: 'Fields' })).toHaveAttribute('aria-busy', 'true');
+    await expect(page.getByText('Loading...', { exact: true })).toBeVisible();
+  });
+
+  await test.step('keeps COUNT() available when the ordinary field list is empty', async () => {
+    await emitState(page, {
+      isFieldsLoading: false,
+      metadata: { fields: [] },
+      query: { sObject: 'Account' }
+    });
+    await expect(fieldsSelect(page)).not.toHaveAttribute('disabled', '');
+    await expect(countCheckbox(page)).not.toHaveAttribute('disabled', '');
+    await expect(page.getByText('No results found.', { exact: true })).toBeVisible();
+  });
+
+  await test.step('marks a recoverable missing SELECT clause invalid', async () => {
+    await emitState(page, {
+      metadata: { fields: [makeField('Id', 'Record ID')] },
+      query: {
+        parseErrors: [
+          {
+            charInLine: 7,
+            lineNumber: 1,
+            message: 'Expected at least one selected field',
+            type: 'NOSELECT'
+          }
+        ],
+        sObject: 'Account'
+      }
+    });
+    await expect(fieldsSelect(page)).toHaveAttribute('aria-invalid', 'true');
+    await expect(page.getByRole('combobox', { name: 'Fields' })).toHaveAttribute('aria-invalid', 'true');
+    await expect(page.getByText('Fields*', { exact: true })).toBeVisible();
+  });
+
+  await test.step('restores ordinary fields and reflects an external COUNT() update', async () => {
+    await emitState(page, {
+      metadata: { fields: [makeField('Id', 'Record ID'), makeField('Name', 'Account Name')] },
+      query: { fields: ['Id', 'Name'], parseErrors: [], sObject: 'Account' }
+    });
+    await expect(fieldsSelect(page)).toHaveJSProperty('value', ['Id', 'Name']);
+
+    await emitState(page, { query: { fields: ['COUNT()'], sObject: 'Account' } });
+    await expect(fieldsSelect(page)).toHaveJSProperty('value', []);
+    await expect(countCheckbox(page)).toHaveJSProperty('checked', true);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

- Stacks the Fields migration on #8053.
- Migrates SOQL Builder field selection to a dedicated Lit component.
- Supports API-name and label search, individual and bulk selection, and mutually exclusive COUNT().
- Preserves loading, empty, invalid, restored, external-update, accessibility, and form-association behavior.
- Shares the typed action-event contract across the From and Fields controls.
- Adds browser and host-contract coverage for large field catalogs and selection workflows.

### What issues does this PR fix or reference?

@W-23928680@

### Functionality Before

The migration-only Lit view provided a basic field multi-select without COUNT(), bulk actions, search status, or complete loading and validation states.

### Functionality After

The migration-only Lit view provides the accepted searchable Fields workflow. Normal release builds continue to use the LWC view while the migration remains gated.