### PR TITLE
fix(services): persist later web memfs writes to IndexedDB - W-24062740

### DIFF
--- a/packages/salesforcedx-vscode-services/src/virtualFsProvider/README.md
+++ b/packages/salesforcedx-vscode-services/src/virtualFsProvider/README.md
@@ -4,6 +4,10 @@ on the web, we don't have local fs. So we're going to use memfs as an in-memory 
 
 It doesn't have persistence, so we need to write transactions to browser storage (IndexDB).
 
+## IDB Transaction Settlement
+
+IDB transactions must wait for `transaction.oncomplete` (or `onabort`/`onerror`), not just `request.onsuccess`. Waiting only on request success can hang follow-up transactions in the extension-host worker. `settleIdbTransaction` enforces this with a 5-second timeout that aborts the hung transaction so the next write is not blocked.
+
 ## Big picture
 
 ```mermaid
@@ -32,21 +36,23 @@ graph TD
 
 ### User edits a file
 
-Every change by the user generates a VSCode onDidChange event. When the user saves a file, we did the onDidChange event
-
-The change flows from top to bottom:
+Every change generates onDidChange. Explorer event fires immediately, IDB persist happens asynchronously.
 
 ```mermaid
 graph TD
     A["User types a character<br/>in vscode editor"]
     B["FileSystemProvider<br/>(updates memfs)"]
     C["memfsWatcher<br/>(Detects file system change)"]
-    D["IndexedDB<br/>(File persisted to<br/>browser storage)"]
+    D["Explorer<br/>(File change UI)"]
+    E["IndexedDB<br/>(File persisted to<br/>browser storage)"]
 
     A --> |"onDidChange event"| B
     B --> |"File change event<br/>(rename/change)"| C
-    C --> |"Persistence operation<br/>(saveFile call)"| D
+    C --> |"Fire explorer event immediately"| D
+    C --> |"Async IDB persist<br/>(saveFile/deleteFile)"| E
 ```
+
+**Note**: IDB persist failures are caught; don't kill the watch stream.
 
 ### Rehydrating the project
 

--- a/packages/salesforcedx-vscode-services/src/virtualFsProvider/idbTransaction.ts
+++ b/packages/salesforcedx-vscode-services/src/virtualFsProvider/idbTransaction.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import * as Duration from 'effect/Duration';
+import * as Effect from 'effect/Effect';
+import { unknownToErrorCause } from '../core/shared';
+import { VirtualFsProviderError } from './virtualFsProviderError';
+
+const IDB_TRANSACTION_TIMEOUT = Duration.seconds(5);
+
+type IdbRequestHandlers<A> = Pick<IDBRequest<A>, 'result' | 'error' | 'onsuccess' | 'onerror'>;
+type IdbTransactionHandlers = Pick<IDBTransaction, 'error' | 'oncomplete' | 'onabort' | 'onerror' | 'abort'>;
+
+/** Wait for the IDB transaction to complete (not just request.onsuccess). A follow-up
+ * transaction started from onsuccess can hang in the extension-host worker. Timeout aborts
+ * the transaction so the next `db.transaction()` is not blocked. */
+export const settleIdbTransaction = <A>(
+  transaction: IdbTransactionHandlers,
+  request: IdbRequestHandlers<A>,
+  mode: IDBTransactionMode,
+  timeout: Duration.DurationInput = IDB_TRANSACTION_TIMEOUT
+) =>
+  Effect.async<A, VirtualFsProviderError>(resume => {
+    const fail = (error: unknown, message: string): void => {
+      resume(Effect.fail(new VirtualFsProviderError({ ...unknownToErrorCause(error), message })));
+    };
+    request.onerror = (): void => {
+      fail(request.error, `Transaction failed with mode "${mode}"`);
+    };
+    transaction.oncomplete = (): void => {
+      resume(Effect.succeed(request.result));
+    };
+    transaction.onabort = (): void => {
+      fail(transaction.error, `Transaction aborted with mode "${mode}"`);
+    };
+    transaction.onerror = (): void => {
+      fail(transaction.error, `Transaction failed with mode "${mode}"`);
+    };
+    return Effect.sync(() => {
+      // eslint-disable-next-line functional/no-try-statements
+      try {
+        transaction.abort();
+      } catch {
+        // already complete — abort() throws InvalidStateError
+      }
+    });
+  }).pipe(
+    Effect.timeoutFail({
+      duration: timeout,
+      onTimeout: () =>
+        new VirtualFsProviderError({
+          message: `IndexedDB ${mode} transaction timed out`
+        })
+    })
+  );

--- a/packages/salesforcedx-vscode-services/src/virtualFsProvider/indexedDbStorage.ts
+++ b/packages/salesforcedx-vscode-services/src/virtualFsProvider/indexedDbStorage.ts
@@ -18,6 +18,7 @@ import {
   SerializedEntryWithPath,
   SerializedFileWithPath
 } from './fsTypes';
+import { settleIdbTransaction } from './idbTransaction';
 import { VirtualFsProviderError } from './virtualFsProviderError';
 
 const SALESFORCE_DOMAIN_SUFFIXES = [
@@ -85,35 +86,17 @@ export class IndexedDBStorageService extends Effect.Service<IndexedDBStorageServ
     );
 
     const withStore = <A>(mode: IDBTransactionMode, f: (store: IDBObjectStore) => IDBRequest<A>) =>
-      Effect.async<A, VirtualFsProviderError>(resume => {
+      Effect.suspend(() => {
         // eslint-disable-next-line functional/no-try-statements
         try {
           const transaction = db.transaction(STORE_NAME, mode);
-          const store = transaction.objectStore(STORE_NAME);
-          const request = f(store);
-
-          request.onsuccess = (): void => {
-            resume(Effect.succeed(request.result));
-          };
-
-          request.onerror = (): void => {
-            resume(
-              Effect.fail(
-                new VirtualFsProviderError({
-                  ...unknownToErrorCause(request.error),
-                  message: `Transaction failed with mode "${mode}"`
-                })
-              )
-            );
-          };
+          return settleIdbTransaction(transaction, f(transaction.objectStore(STORE_NAME)), mode);
         } catch (error: unknown) {
-          resume(
-            Effect.fail(
-              new VirtualFsProviderError({
-                ...unknownToErrorCause(error),
-                message: `Transaction failed with mode "${mode}"`
-              })
-            )
+          return Effect.fail(
+            new VirtualFsProviderError({
+              ...unknownToErrorCause(error),
+              message: `Transaction failed with mode "${mode}"`
+            })
           );
         }
       });

--- a/packages/salesforcedx-vscode-services/src/virtualFsProvider/memfsWatcher.ts
+++ b/packages/salesforcedx-vscode-services/src/virtualFsProvider/memfsWatcher.ts
@@ -21,36 +21,42 @@ import { VirtualFsProviderError } from './virtualFsProviderError';
 // we need an emitter to send events to the fileSystemProvider using the vscode API
 export const emitter = new vscode.EventEmitter<vscode.FileChangeEvent[]>();
 
-const updateIDB = (storage: IndexedDBStorageService) =>
-  Effect.fn('updateIDB')(function* (event: FileChangeInfo<string>) {
+export const updateIDB = Effect.fn('updateIDB')(
+  function* (event: FileChangeInfo<string>) {
     if (!event.filename) {
       return;
     }
 
+    const storage = yield* IndexedDBStorageService;
     const { fsPath, uri: rootUri } = yield* getProjectRoot();
     const fullPath = `${fsPath}/${event.filename}`;
     const uri = URI.parse(`${rootUri}/${event.filename}`);
+    yield* Effect.annotateCurrentSpan({ filename: event.filename, eventType: event.eventType, path: fullPath });
 
-    if (event.eventType === 'rename') {
-      if (fs.existsSync(fullPath)) {
-        yield* storage.saveFile(fullPath);
-        emitter.fire([{ type: vscode.FileChangeType.Created, uri }]);
-      } else {
-        yield* storage.deleteFile(fullPath);
-        emitter.fire([{ type: vscode.FileChangeType.Deleted, uri }]);
-      }
-    } else if (event.eventType === 'change') {
-      yield* storage.saveFile(fullPath);
-      emitter.fire([{ type: vscode.FileChangeType.Changed, uri }]);
+    if (event.eventType !== 'rename' && event.eventType !== 'change') {
+      return;
     }
-  });
+
+    const exists = fs.existsSync(fullPath);
+    const createdOrChanged =
+      event.eventType === 'rename' ? vscode.FileChangeType.Created : vscode.FileChangeType.Changed;
+    emitter.fire([{ type: exists ? createdOrChanged : vscode.FileChangeType.Deleted, uri }]);
+    return exists ? yield* storage.saveFile(fullPath) : yield* storage.deleteFile(fullPath);
+  },
+  Effect.catchTag('VirtualFsProviderError', error =>
+    Effect.logWarning('updateIDB failed').pipe(
+      Effect.annotateLogs({ message: error.message }),
+      Effect.andThen(
+        Effect.flatMap(ChannelService, channel => channel.appendToChannel(`IndexedDB persist failed: ${error.message}`))
+      )
+    )
+  )
+);
 
 /** Starts watching the memfs for file changes */
 export const startWatch = Effect.fn('startWatch')(
   function* () {
     const channelService = yield* ChannelService;
-    const updater = updateIDB(yield* IndexedDBStorageService);
-
     const projectPath = (yield* getProjectRoot()).fsPath;
     yield* channelService.appendToChannel(`Starting file watcher for ${projectPath}`);
     // Ensure the directory exists before watching
@@ -69,7 +75,7 @@ export const startWatch = Effect.fn('startWatch')(
         duration: '10 millis',
         units: 1
       }),
-      Stream.mapEffect(updater),
+      Stream.mapEffect(updateIDB),
       Stream.runDrain,
       Effect.forkScoped // Run in a daemon fiber that won't block
     );

--- a/packages/salesforcedx-vscode-services/test/jest/virtualFsProvider/idbTransaction.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/virtualFsProvider/idbTransaction.test.ts
@@ -12,20 +12,26 @@ import * as Exit from 'effect/Exit';
 import * as Fiber from 'effect/Fiber';
 import { settleIdbTransaction } from '../../../src/virtualFsProvider/idbTransaction';
 
+type IdbHandler = ((ev: Event) => void) | null;
+
+const fire = (handler: IdbHandler, type: string): void => {
+  handler?.(new Event(type));
+};
+
 const fakeIdb = (result = 'saved-key') => {
   const abort = jest.fn();
   const transaction = {
     error: null as DOMException | null,
-    oncomplete: null as IDBTransaction['oncomplete'],
-    onabort: null as IDBTransaction['onabort'],
-    onerror: null as IDBTransaction['onerror'],
+    oncomplete: null as IdbHandler,
+    onabort: null as IdbHandler,
+    onerror: null as IdbHandler,
     abort
   };
   const request = {
     result,
     error: null as DOMException | null,
-    onsuccess: null as IDBRequest['onsuccess'],
-    onerror: null as IDBRequest['onerror']
+    onsuccess: null as IdbHandler,
+    onerror: null as IdbHandler
   };
   return { transaction, request, abort };
 };
@@ -38,7 +44,7 @@ describe('settleIdbTransaction', () => {
         const fiber = yield* Effect.fork(settleIdbTransaction(transaction, request, 'readwrite'));
         yield* Effect.yieldNow();
         yield* Effect.sync(() => {
-          transaction.oncomplete?.(new Event('complete'));
+          fire(transaction.oncomplete, 'complete');
         });
         return yield* Fiber.join(fiber);
       })
@@ -53,7 +59,7 @@ describe('settleIdbTransaction', () => {
         const fiber = yield* Effect.fork(settleIdbTransaction(transaction, request, 'readwrite'));
         yield* Effect.yieldNow();
         yield* Effect.sync(() => {
-          transaction.onabort?.(new Event('abort'));
+          fire(transaction.onabort, 'abort');
         });
         return yield* Fiber.await(fiber);
       })
@@ -71,7 +77,7 @@ describe('settleIdbTransaction', () => {
     const hung = fakeIdb();
     const next = fakeIdb('second-key');
     hung.abort.mockImplementation(() => {
-      hung.transaction.onabort?.(new Event('abort'));
+      fire(hung.transaction.onabort, 'abort');
     });
 
     const hungExit = await Effect.runPromise(
@@ -91,7 +97,7 @@ describe('settleIdbTransaction', () => {
         const nextFiber = yield* Effect.fork(settleIdbTransaction(next.transaction, next.request, 'readwrite'));
         yield* Effect.yieldNow();
         yield* Effect.sync(() => {
-          next.transaction.oncomplete?.(new Event('complete'));
+          fire(next.transaction.oncomplete, 'complete');
         });
         return yield* Fiber.join(nextFiber);
       })

--- a/packages/salesforcedx-vscode-services/test/jest/virtualFsProvider/idbTransaction.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/virtualFsProvider/idbTransaction.test.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Cause from 'effect/Cause';
+import * as Duration from 'effect/Duration';
+import * as Effect from 'effect/Effect';
+import * as Exit from 'effect/Exit';
+import * as Fiber from 'effect/Fiber';
+import { settleIdbTransaction } from '../../../src/virtualFsProvider/idbTransaction';
+
+const fakeIdb = (result = 'saved-key') => {
+  const abort = jest.fn();
+  const transaction = {
+    error: null as DOMException | null,
+    oncomplete: null as IDBTransaction['oncomplete'],
+    onabort: null as IDBTransaction['onabort'],
+    onerror: null as IDBTransaction['onerror'],
+    abort
+  };
+  const request = {
+    result,
+    error: null as DOMException | null,
+    onsuccess: null as IDBRequest['onsuccess'],
+    onerror: null as IDBRequest['onerror']
+  };
+  return { transaction, request, abort };
+};
+
+describe('settleIdbTransaction', () => {
+  it('succeeds when the transaction completes', async () => {
+    const { transaction, request } = fakeIdb();
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fiber = yield* Effect.fork(settleIdbTransaction(transaction, request, 'readwrite'));
+        yield* Effect.yieldNow();
+        yield* Effect.sync(() => {
+          transaction.oncomplete?.(new Event('complete'));
+        });
+        return yield* Fiber.join(fiber);
+      })
+    );
+    expect(result).toBe('saved-key');
+  });
+
+  it('fails when the transaction aborts', async () => {
+    const { transaction, request } = fakeIdb();
+    const exit = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fiber = yield* Effect.fork(settleIdbTransaction(transaction, request, 'readwrite'));
+        yield* Effect.yieldNow();
+        yield* Effect.sync(() => {
+          transaction.onabort?.(new Event('abort'));
+        });
+        return yield* Fiber.await(fiber);
+      })
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      expect(Cause.squash(exit.cause)).toMatchObject({
+        _tag: 'VirtualFsProviderError',
+        message: 'Transaction aborted with mode "readwrite"'
+      });
+    }
+  });
+
+  it('aborts the transaction on timeout and unblocks a second write', async () => {
+    const hung = fakeIdb();
+    const next = fakeIdb('second-key');
+    hung.abort.mockImplementation(() => {
+      hung.transaction.onabort?.(new Event('abort'));
+    });
+
+    const hungExit = await Effect.runPromise(
+      settleIdbTransaction(hung.transaction, hung.request, 'readwrite', Duration.millis(20)).pipe(Effect.exit)
+    );
+    expect(hung.abort).toHaveBeenCalledTimes(1);
+    expect(Exit.isFailure(hungExit)).toBe(true);
+    if (Exit.isFailure(hungExit)) {
+      expect(Cause.squash(hungExit.cause)).toMatchObject({
+        _tag: 'VirtualFsProviderError',
+        message: 'IndexedDB readwrite transaction timed out'
+      });
+    }
+
+    const secondResult = await Effect.runPromise(
+      Effect.gen(function* () {
+        const nextFiber = yield* Effect.fork(settleIdbTransaction(next.transaction, next.request, 'readwrite'));
+        yield* Effect.yieldNow();
+        yield* Effect.sync(() => {
+          next.transaction.oncomplete?.(new Event('complete'));
+        });
+        return yield* Fiber.join(nextFiber);
+      })
+    );
+    expect(secondResult).toBe('second-key');
+  });
+});

--- a/packages/salesforcedx-vscode-services/test/jest/virtualFsProvider/memfsWatcher.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/virtualFsProvider/memfsWatcher.test.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { fs, resetFs, setFs } from '@salesforce/core/fs';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+import { createFsFromVolume, Volume } from 'memfs';
+import { URI } from 'vscode-uri';
+import { IndexedDBStorageService } from '../../../src/virtualFsProvider/indexedDbStorage';
+import { updateIDB } from '../../../src/virtualFsProvider/memfsWatcher';
+import { VirtualFsProviderError } from '../../../src/virtualFsProvider/virtualFsProviderError';
+import { ChannelService } from '../../../src/vscode/channelService';
+import { WorkspaceService } from '../../../src/vscode/workspaceService';
+
+const workspaceLayer = Layer.succeed(
+  WorkspaceService,
+  new WorkspaceService({
+    getWorkspaceInfo: () =>
+      Effect.succeed({
+        uri: URI.parse(''),
+        path: '',
+        fsPath: '',
+        isEmpty: true,
+        isVirtualFs: true,
+        cwd: '/'
+      })
+  } as unknown as WorkspaceService)
+);
+
+describe('updateIDB', () => {
+  beforeEach(() => {
+    setFs(
+      createFsFromVolume(
+        Volume.fromJSON({
+          '/dx-project/Foo.cls': 'public class Foo {}',
+          '/dx-project/Bar.cls': 'public class Bar {}'
+        })
+      ) as unknown as typeof fs
+    );
+  });
+
+  afterEach(() => {
+    resetFs();
+  });
+
+  it('continues after a persist error so the next event is saved', async () => {
+    const persistLines: string[] = [];
+    const saveFile = jest
+      .fn()
+      .mockReturnValueOnce(Effect.fail(new VirtualFsProviderError({ message: 'idb down' })))
+      .mockReturnValueOnce(Effect.succeed('ok'));
+
+    const layer = Layer.mergeAll(
+      workspaceLayer,
+      Layer.succeed(
+        IndexedDBStorageService,
+        new IndexedDBStorageService({
+          loadState: () => Effect.succeed([]),
+          saveFile,
+          deleteFile: () => Effect.void,
+          loadFile: () => Effect.void
+        })
+      ),
+      Layer.succeed(
+        ChannelService,
+        new ChannelService({
+          getChannel: Effect.void as never,
+          showChannel: Effect.void,
+          clearChannel: Effect.void,
+          appendToChannel: (message: string) =>
+            Effect.sync(() => {
+              persistLines.push(message);
+            })
+        })
+      )
+    );
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* updateIDB({ eventType: 'change', filename: 'Foo.cls' });
+        yield* updateIDB({ eventType: 'change', filename: 'Bar.cls' });
+      }).pipe(Effect.provide(layer))
+    );
+
+    expect(saveFile).toHaveBeenCalledTimes(2);
+    expect(saveFile).toHaveBeenNthCalledWith(1, '/dx-project/Foo.cls');
+    expect(saveFile).toHaveBeenNthCalledWith(2, '/dx-project/Bar.cls');
+    expect(persistLines).toEqual(['IndexedDB persist failed: idb down']);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Web Console memfs watcher stopped persisting after the first IndexedDB write. Later creates/deploys/retrieves showed in Explorer but vanished on reload.

- Settle IDB on `transaction.oncomplete`/`onabort` (not `request.onsuccess`)
- 5s timeout aborts a hung transaction so the next write can start
- Catch persist errors so the watch stream keeps running
- Tests: complete/abort, timeout abort unblocks the next write, persist error does not skip the next event

### What issues does this PR fix or reference?
@W-24062740@
