### PR TITLE
build: exclude apex-node from synchronized version bump [skip-validate-pr]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45947,7 +45947,7 @@
     },
     "packages/salesforcedx-apex": {
       "name": "@salesforce/apex-node",
-      "version": "67.17.2",
+      "version": "9.0.7",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/core": "^9.1.9",

--- a/packages/salesforcedx-apex/package.json
+++ b/packages/salesforcedx-apex/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@salesforce/apex-node",
   "description": "Salesforce JS library for Apex",
-  "version": "67.17.2",
+  "version": "9.0.7",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/salesforcedx-apex/issues",
   "main": "out/src/index.js",
   "types": "out/src/index.d.ts",
+  "private": true,
   "exports": {
     ".": {
       "types": "./out/src/index.d.ts",
@@ -54,6 +55,7 @@
     "test:compile": "wireit",
     "test": "wireit"
   },
+  "versionedIndependently": true,
   "wireit": {
     "compile": {
       "command": "tsc --pretty",


### PR DESCRIPTION
Add property "versionedIndependently": true to pjson
Reset version to 9.0.7
Set pjson property "private": true to exclude from npm publish