### PR TITLE
chore: Rewrite retrieveLineBreakpointInfo as Effect - W-24073904

### DIFF
--- a/.claude/plans/W-24073904.md
+++ b/.claude/plans/W-24073904.md
@@ -1,0 +1,33 @@
+# W-24073904: Rewrite retrieveLineBreakpointInfo as Effect
+
+## Context
+
+`retrieveLineBreakpointInfo` in `packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts` is an async `Promise<boolean>` function. It activates the Apex extension, polls language-client readiness, reports timeout or missing-data errors, retrieves line-breakpoint data, and updates breakpoint mappings.
+
+Rewrite it as an Effect so this workflow composes with the package's existing Effect runtime and the checkpoint update workflow no longer converts this operation through `await`.
+
+## Phases
+
+### 1. Convert line-breakpoint retrieval to Effect
+
+- Rewrite `retrieveLineBreakpointInfo` in `packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts` with a named `Effect.fn`.
+- Express Apex extension activation, readiness polling, delay, failure detection, line-breakpoint retrieval, output reporting, and mapping updates with Effect operations.
+- Preserve the current outcomes: failed initialization rejects, timeout returns `false`, successful readiness returns `true`, and existing messages/mapping behavior remain unchanged.
+- Remove `imposeSlightDelay` after polling no longer uses the Promise helper.
+- Update `packages/salesforcedx-vscode-apex-replay-debugger/src/breakpoints/checkpointService.ts` to compose `retrieveLineBreakpointInfo()` directly inside the existing Effect workflow.
+
+Commit: `refactor: rewrite retrieveLineBreakpointInfo as Effect`
+
+## Skills to apply
+
+- `effect-best-practices`: named `Effect.fn`, typed composition, Effect-managed delay and Promise boundaries.
+- `typescript`: preserve inferred error and success types; follow repository import and naming conventions.
+- `verification`: run package checks and Effect diagnostics after implementation.
+
+## Verification
+
+- Run `npx effect-language-service diagnostics --project packages/salesforcedx-vscode-apex-replay-debugger/tsconfig.json`.
+- Run `npm run compile -w salesforcedx-vscode-apex-replay-debugger`.
+- Run `npm run lint -w salesforcedx-vscode-apex-replay-debugger`.
+- Run `npm test -w salesforcedx-vscode-apex-replay-debugger`.
+- Review the final diff to confirm only the Effect rewrite and caller composition changed, with no message or breakpoint-mapping behavior changes.

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/breakpoints/checkpointService.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/breakpoints/checkpointService.ts
@@ -554,99 +554,105 @@ export const sfCreateCheckpoints = async (): Promise<boolean> => {
   try {
     // The lock is necessary here to prevent the user from deleting the underlying breakpoint
     // attached to the checkpoint while they're being uploaded into the org.
-    await Effect.promise(async () => {
-      writeToDebuggerOutputWindow(`${nls.localize('long_command_start')} ${localizedProgressMessage}`);
-      await vscode.window.withProgress(
-        {
-          location: progressLocation,
-          title: localizedProgressMessage,
-          cancellable: false
-        },
+    await Effect.gen(function* () {
+      yield* Effect.sync(() =>
+        writeToDebuggerOutputWindow(`${nls.localize('long_command_start')} ${localizedProgressMessage}`)
+      );
+      yield* Effect.promise(() =>
+        vscode.window.withProgress(
+          {
+            location: progressLocation,
+            title: localizedProgressMessage,
+            cancellable: false
+          },
 
-        async (progress, _token) => {
-          writeToDebuggerOutputWindow(
-            `${localizedProgressMessage}, ${nls.localize('checkpoint_creation_status_org_info')}`
-          );
-          progress.report({
-            increment: 0,
-            message: localizedProgressMessage
-          });
-          const connection = await getConnection();
-          if (!connection) {
-            updateError = true;
-            return false;
-          }
+          (progress, _token) =>
+            getRuntime().runPromise(
+              Effect.gen(function* () {
+                writeToDebuggerOutputWindow(
+                  `${localizedProgressMessage}, ${nls.localize('checkpoint_creation_status_org_info')}`
+                );
+                progress.report({
+                  increment: 0,
+                  message: localizedProgressMessage
+                });
+                const connection = yield* Effect.promise(getConnection);
+                if (!connection) {
+                  updateError = true;
+                  return false;
+                }
 
-          writeToDebuggerOutputWindow(
-            `${localizedProgressMessage}, ${nls.localize('checkpoint_creation_status_source_line_info')}`
-          );
-          progress.report({
-            increment: 20,
-            message: localizedProgressMessage
-          });
-          const sourceLineInfoRetrieved: boolean = await retrieveLineBreakpointInfo();
-          // If we didn't get the source line information that'll be reported at that time, just return
-          if (!sourceLineInfoRetrieved) {
-            updateError = true;
-            return false;
-          }
+                writeToDebuggerOutputWindow(
+                  `${localizedProgressMessage}, ${nls.localize('checkpoint_creation_status_source_line_info')}`
+                );
+                progress.report({
+                  increment: 20,
+                  message: localizedProgressMessage
+                });
+                const sourceLineInfoRetrieved = yield* retrieveLineBreakpointInfo();
+                // If we didn't get the source line information that'll be reported at that time, just return
+                if (!sourceLineInfoRetrieved) {
+                  updateError = true;
+                  return false;
+                }
 
-          // There can be a max of five active checkpoints
-          if (!checkpointService.hasFiveOrLessActiveCheckpoints()) {
-            updateError = true;
-            return false;
-          }
+                // There can be a max of five active checkpoints
+                if (!checkpointService.hasFiveOrLessActiveCheckpoints()) {
+                  updateError = true;
+                  return false;
+                }
 
-          writeToDebuggerOutputWindow(
-            `${localizedProgressMessage}, ${nls.localize('checkpoint_creation_status_setting_typeref')}`
-          );
-          progress.report({
-            increment: 50,
-            message: localizedProgressMessage
-          });
-          // For the active checkpoints set the typeRefs using the source/line info
-          if (!setTypeRefsForEnabledCheckpoints()) {
-            updateError = true;
-            return false;
-          }
+                writeToDebuggerOutputWindow(
+                  `${localizedProgressMessage}, ${nls.localize('checkpoint_creation_status_setting_typeref')}`
+                );
+                progress.report({
+                  increment: 50,
+                  message: localizedProgressMessage
+                });
+                // For the active checkpoints set the typeRefs using the source/line info
+                if (!setTypeRefsForEnabledCheckpoints()) {
+                  updateError = true;
+                  return false;
+                }
 
-          writeToDebuggerOutputWindow(
-            `${localizedProgressMessage}, ${nls.localize('checkpoint_creation_status_clearing_existing_checkpoints')}`
-          );
-          progress.report({
-            increment: 50,
-            message: localizedProgressMessage
-          });
-          // remove any existing checkpoints on the server
-          const allRemoved: boolean = await clearExistingCheckpoints();
-          if (!allRemoved) {
-            updateError = true;
-            return false;
-          }
+                writeToDebuggerOutputWindow(
+                  `${localizedProgressMessage}, ${nls.localize('checkpoint_creation_status_clearing_existing_checkpoints')}`
+                );
+                progress.report({
+                  increment: 50,
+                  message: localizedProgressMessage
+                });
+                // remove any existing checkpoints on the server
+                const allRemoved = yield* Effect.promise(clearExistingCheckpoints);
+                if (!allRemoved) {
+                  updateError = true;
+                  return false;
+                }
 
-          writeToDebuggerOutputWindow(
-            `${localizedProgressMessage}, ${nls.localize('checkpoint_creation_status_uploading_checkpoints')}`
-          );
-          progress.report({
-            increment: 70,
-            message: localizedProgressMessage
-          });
-          updateError = (
-            await Promise.allSettled(
-              (checkpointService.getChildren() as CheckpointNode[])
-                .filter(cpNode => cpNode.isCheckpointEnabled())
-                .map(cpNode => executeCreateApexExecutionOverlayActionCommand(cpNode))
+                writeToDebuggerOutputWindow(
+                  `${localizedProgressMessage}, ${nls.localize('checkpoint_creation_status_uploading_checkpoints')}`
+                );
+                progress.report({
+                  increment: 70,
+                  message: localizedProgressMessage
+                });
+                const [failedCheckpointUploads] = yield* Effect.partition(
+                  (checkpointService.getChildren() as CheckpointNode[]).filter(cpNode => cpNode.isCheckpointEnabled()),
+                  cpNode => Effect.tryPromise(() => executeCreateApexExecutionOverlayActionCommand(cpNode)),
+                  { concurrency: 'unbounded' }
+                );
+                updateError = failedCheckpointUploads.length > 0;
+
+                progress.report({
+                  increment: 100,
+                  message: localizedProgressMessage
+                });
+                writeToDebuggerOutputWindow(
+                  `${localizedProgressMessage}, ${nls.localize('checkpoint_creation_status_processing_complete_success')}`
+                );
+              })
             )
-          ).some(promise => promise.status === 'rejected');
-
-          progress.report({
-            increment: 100,
-            message: localizedProgressMessage
-          });
-          writeToDebuggerOutputWindow(
-            `${localizedProgressMessage}, ${nls.localize('checkpoint_creation_status_processing_complete_success')}`
-          );
-        }
+        )
       );
     }).pipe(lock.withPermits(1), Effect.runPromise);
   } finally {

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
@@ -41,6 +41,7 @@ import {
   LIVESHARE_DEBUG_TYPE_REQUEST,
   LIVESHARE_DEBUGGER_TYPE
 } from './debuggerConstants';
+import { waitForLanguageClientReady } from './languageClientReady';
 import { nls } from './messages';
 import { buildAllServicesLayer, setAllServicesLayer } from './services/extensionProvider';
 import { disposeRuntime, getRuntime } from './services/runtime';
@@ -219,47 +220,35 @@ export const activateEffect = Effect.fn('activation:salesforcedx-vscode-apex-rep
   yield* Effect.promise(() => TelemetryService.getInstance().initializeService(extensionContext));
 });
 
-export const retrieveLineBreakpointInfo = async (): Promise<boolean> => {
+export const retrieveLineBreakpointInfo = Effect.fn('ApexReplayDebugger.retrieveLineBreakpointInfo')(function* () {
   if (!salesforceApexExtension.isActive) {
-    await salesforceApexExtension.activate();
+    yield* Effect.promise(() => salesforceApexExtension.activate());
   }
   if (salesforceApexExtension) {
-    let expired = false;
-    let i = 0;
-    while (!salesforceApexExtension.exports.languageClientManager.getStatus().isReady() && !expired) {
-      if (salesforceApexExtension.exports.languageClientManager.getStatus().failedToInitialize()) {
-        throw Error(salesforceApexExtension.exports.languageClientManager.getStatus().getStatusMessage());
-      }
-
-      await imposeSlightDelay(100);
-      if (i >= 30) {
-        expired = true;
-      }
-      i++;
-    }
-    if (expired) {
+    const isReady = yield* waitForLanguageClientReady(() =>
+      salesforceApexExtension.exports.languageClientManager.getStatus()
+    );
+    if (!isReady) {
       const errorMessage = nls.localize('language_client_not_ready');
-      writeToDebuggerOutputWindow(errorMessage, true, VSCodeWindowTypeEnum.Error);
+      yield* Effect.sync(() => writeToDebuggerOutputWindow(errorMessage, true, VSCodeWindowTypeEnum.Error));
       return false;
     } else {
-      const lineBpInfo = await salesforceApexExtension.exports.getLineBreakpointInfo();
+      const lineBpInfo = yield* Effect.promise(() => salesforceApexExtension.exports.getLineBreakpointInfo());
       if (lineBpInfo?.length) {
-        console.log(nls.localize('line_breakpoint_information_success'));
-        breakpointUtil.createMappingsFromLineBreakpointInfo(lineBpInfo);
+        yield* Effect.log(nls.localize('line_breakpoint_information_success'));
+        yield* Effect.sync(() => breakpointUtil.createMappingsFromLineBreakpointInfo(lineBpInfo));
       } else {
         const errorMessage = nls.localize('no_line_breakpoint_information_for_current_project');
-        writeToDebuggerOutputWindow(errorMessage, true, VSCodeWindowTypeEnum.Error);
+        yield* Effect.sync(() => writeToDebuggerOutputWindow(errorMessage, true, VSCodeWindowTypeEnum.Error));
       }
       return true;
     }
   } else {
     const errorMessage = nls.localize('session_language_server_error_text');
-    writeToDebuggerOutputWindow(errorMessage, true, VSCodeWindowTypeEnum.Error);
+    yield* Effect.sync(() => writeToDebuggerOutputWindow(errorMessage, true, VSCodeWindowTypeEnum.Error));
     return false;
   }
-};
-
-const imposeSlightDelay = (ms = 0) => new Promise(r => setTimeout(r, ms));
+});
 
 export const writeToDebuggerOutputWindow = (
   output: string,

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/languageClientReady.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/languageClientReady.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Duration from 'effect/Duration';
+import * as Effect from 'effect/Effect';
+import * as Schedule from 'effect/Schedule';
+import * as Schema from 'effect/Schema';
+
+type LanguageClientStatus = {
+  readonly isReady: () => boolean;
+  readonly failedToInitialize: () => boolean;
+  readonly getStatusMessage: () => string;
+};
+
+export class LanguageClientInitializationError extends Schema.TaggedError<LanguageClientInitializationError>()(
+  'LanguageClientInitializationError',
+  { message: Schema.String }
+) {}
+
+class LanguageClientNotReadyError extends Schema.TaggedError<LanguageClientNotReadyError>()(
+  'LanguageClientNotReadyError',
+  {}
+) {}
+
+const LANGUAGE_CLIENT_READY_SCHEDULE = Schedule.fixed(Duration.millis(100)).pipe(
+  Schedule.intersect(Schedule.recurs(30))
+);
+
+export const waitForLanguageClientReady = Effect.fn('ApexReplayDebugger.waitForLanguageClientReady')(function* (
+  getStatus: () => LanguageClientStatus
+) {
+  const checkStatus = Effect.gen(function* () {
+    const status = yield* Effect.sync(getStatus);
+    if (status.failedToInitialize()) {
+      return yield* new LanguageClientInitializationError({ message: status.getStatusMessage() });
+    }
+    if (!status.isReady()) {
+      return yield* new LanguageClientNotReadyError();
+    }
+    return true;
+  });
+
+  return yield* checkStatus.pipe(
+    Effect.retry({
+      schedule: LANGUAGE_CLIENT_READY_SCHEDULE,
+      while: error => error._tag === 'LanguageClientNotReadyError'
+    }),
+    Effect.catchTag('LanguageClientNotReadyError', () => Effect.succeed(false))
+  );
+});

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/languageClientReady.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/languageClientReady.ts
@@ -33,18 +33,16 @@ const LANGUAGE_CLIENT_READY_SCHEDULE = Schedule.fixed(Duration.millis(100)).pipe
 export const waitForLanguageClientReady = Effect.fn('ApexReplayDebugger.waitForLanguageClientReady')(function* (
   getStatus: () => LanguageClientStatus
 ) {
-  const checkStatus = Effect.gen(function* () {
-    const status = yield* Effect.sync(getStatus);
-    if (status.failedToInitialize()) {
-      return yield* new LanguageClientInitializationError({ message: status.getStatusMessage() });
-    }
-    if (!status.isReady()) {
-      return yield* new LanguageClientNotReadyError();
-    }
-    return true;
-  });
-
-  return yield* checkStatus.pipe(
+  return yield* Effect.sync(getStatus).pipe(
+    Effect.filterOrFail(
+      status => !status.failedToInitialize(),
+      status => new LanguageClientInitializationError({ message: status.getStatusMessage() })
+    ),
+    Effect.filterOrFail(
+      status => status.isReady(),
+      () => new LanguageClientNotReadyError()
+    ),
+    Effect.as(true),
     Effect.retry({
       schedule: LANGUAGE_CLIENT_READY_SCHEDULE,
       while: error => error._tag === 'LanguageClientNotReadyError'

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/jest/languageClientReady.test.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/jest/languageClientReady.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Duration from 'effect/Duration';
+import * as Effect from 'effect/Effect';
+import * as Exit from 'effect/Exit';
+import * as Fiber from 'effect/Fiber';
+import * as TestClock from 'effect/TestClock';
+import * as TestContext from 'effect/TestContext';
+import { LanguageClientInitializationError, waitForLanguageClientReady } from '../../src/languageClientReady';
+
+const status = (ready: boolean, failed: boolean, message = '') => ({
+  isReady: () => ready,
+  failedToInitialize: () => failed,
+  getStatusMessage: () => message
+});
+
+describe('waitForLanguageClientReady', () => {
+  it('fails with the language-client initialization status message', async () => {
+    const exit = await Effect.runPromiseExit(waitForLanguageClientReady(() => status(false, true, 'Java is invalid')));
+
+    expect(exit).toEqual(Exit.fail(new LanguageClientInitializationError({ message: 'Java is invalid' })));
+  });
+
+  it('returns false after language-client readiness polling expires', async () => {
+    const getStatus = jest.fn(() => status(false, false));
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fiber = yield* Effect.fork(waitForLanguageClientReady(getStatus));
+        yield* TestClock.adjust(Duration.seconds(4));
+        return yield* Fiber.join(fiber);
+      }).pipe(Effect.provide(TestContext.TestContext))
+    );
+
+    expect(result).toBe(false);
+    expect(getStatus).toHaveBeenCalledTimes(31);
+  });
+});


### PR DESCRIPTION
### What issues does this PR fix or reference?

@W-24073904@

### What changed and why?

- Rewrote `retrieveLineBreakpointInfo` as a named Effect workflow.
- Moved language-client readiness polling into a reusable Effect with managed delays, retries, timeout handling, and initialization failure propagation.
- Wrapped extension activation, breakpoint retrieval, output reporting, and mapping updates in Effect operations.
- Updated checkpoint creation to compose `retrieveLineBreakpointInfo()` directly instead of converting it through `await`.
- Added focused tests for initialization failures and readiness timeout behavior using `TestClock`.
- Removed the Promise-based delay helper while preserving existing success, timeout, error-message, and breakpoint-mapping behavior.

This makes line-breakpoint retrieval composable with the package's existing Effect runtime and avoids unnecessary Promise boundaries in checkpoint updates.
