### PR TITLE
chore: 3 Enforce consistent-type-imports eslint rule for playwright-vscode-ext - W-23370906

### DIFF
--- a/.claude/plans/W-23370906.md
+++ b/.claude/plans/W-23370906.md
@@ -1,0 +1,33 @@
+# W-23370906: Enforce consistent type imports in playwright-vscode-ext
+
+## Context
+
+Enforce `@typescript-eslint/consistent-type-imports` for `packages/playwright-vscode-ext/**/*.ts` so type-only dependencies are explicit and lint prevents regressions. Match the existing repository configuration: `prefer: 'type-imports'` with `fixStyle: 'inline-type-imports'`.
+
+A temporary rule run found violations in:
+
+- `packages/playwright-vscode-ext/src/pages/commands.ts`
+- `packages/playwright-vscode-ext/src/pages/nativeCommands.ts`
+- `packages/playwright-vscode-ext/src/pages/settings.ts`
+- `packages/playwright-vscode-ext/src/shared/screenshotUtils.ts`
+
+## Phases
+
+### Phase 1: Enforce and satisfy the rule
+
+- Add a `packages/playwright-vscode-ext/**/*.ts` override to `eslint.config.mjs` enabling `@typescript-eslint/consistent-type-imports` with the repository's inline type-import style.
+- Convert the reported imports in the 4 files above to inline `type` specifiers; no runtime changes.
+- Commit: `chore: enforce consistent type imports in playwright-vscode-ext - W-23370906`
+
+## Skills to apply
+
+- `concise`: keep plan and comments minimal.
+- `typescript`: preserve import semantics and repository TypeScript conventions.
+- `verification`: run package compile, lint, and required Playwright checks.
+
+## Verification
+
+- `npm run compile -w @salesforce/playwright-vscode-ext`
+- `npm run lint -w @salesforce/playwright-vscode-ext`
+- `npm run test:web -w @salesforce/playwright-vscode-ext -- --retries 0`
+- `npm run test:desktop -w @salesforce/playwright-vscode-ext -- --retries 0`

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -850,6 +850,16 @@ export default [
     }
   },
   {
+    // consistent-type-imports for playwright-vscode-ext (inline to avoid no-duplicate-imports; W-23370906)
+    files: ['packages/playwright-vscode-ext/**/*.ts'],
+    rules: {
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        { prefer: 'type-imports', fixStyle: 'inline-type-imports' }
+      ]
+    }
+  },
+  {
     // class-methods-use-this for packages not yet using Effect
     // (apex-oas + apex-testing omitted: covered by the Effect-services block above, which sets both rules)
     files: ['packages/salesforcedx-vscode-soql/**/*.ts', 'packages/soql-common/**/*.ts', 'packages/soql-model/**/*.ts'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -46894,7 +46894,7 @@
     },
     "packages/salesforcedx-vscode-services-types": {
       "name": "@salesforce/vscode-services",
-      "version": "67.17.2",
+      "version": "67.17.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.43",

--- a/packages/playwright-vscode-ext/src/pages/commands.ts
+++ b/packages/playwright-vscode-ext/src/pages/commands.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { expect, Page } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 import {
   dismissAllQuickInputWidgets,
   dismissSignInWalkthroughDialog,

--- a/packages/playwright-vscode-ext/src/pages/nativeCommands.ts
+++ b/packages/playwright-vscode-ext/src/pages/nativeCommands.ts
@@ -6,7 +6,7 @@
  */
 
 import { type Page } from '@playwright/test';
-import { executeCommandWithCommandPalette, OpenCommandPaletteOptions } from './commands';
+import { executeCommandWithCommandPalette, type OpenCommandPaletteOptions } from './commands';
 
 /**
  * Named wrappers for VS Code built-in (native) command-palette commands.

--- a/packages/playwright-vscode-ext/src/pages/settings.ts
+++ b/packages/playwright-vscode-ext/src/pages/settings.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { Locator, Page, expect } from '@playwright/test';
+import { type Locator, type Page, expect } from '@playwright/test';
 import type { AuthFields } from '@salesforce/core';
 import { ACCESS_TOKEN_KEY, API_VERSION_KEY, CODE_BUILDER_WEB_SECTION, INSTANCE_URL_KEY } from '../constants';
 import { saveScreenshot } from '../shared/screenshotUtils';

--- a/packages/playwright-vscode-ext/src/shared/screenshotUtils.ts
+++ b/packages/playwright-vscode-ext/src/shared/screenshotUtils.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Page } from '@playwright/test';
+import { type Page } from '@playwright/test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-23370906@

### What changed and why?
- Enabled `@typescript-eslint/consistent-type-imports` for `playwright-vscode-ext` using inline type imports.
- Updated type-only imports in four Playwright files without changing runtime behavior.
- Aligned the lockfile package version metadata.

### Verification
- Compile passed.
- Lint passed.
- Web Playwright checks passed.
- Desktop Playwright checks passed. Wireit reported all scripts up to date.
