### PR TITLE
fix: gate promote-nightly on nightly build success, not unit-tests W-24093729

### DIFF
--- a/.github/workflows/promote-nightly-to-prerelease.yml
+++ b/.github/workflows/promote-nightly-to-prerelease.yml
@@ -26,6 +26,7 @@ permissions:
   contents: write
   packages: write
   actions: read
+  checks: read
 
 jobs:
   # Step 1: Find nightly candidate (THIS REPO CONTROLS CRITERIA)

--- a/.github/workflows/promote-nightly-to-prerelease.yml
+++ b/.github/workflows/promote-nightly-to-prerelease.yml
@@ -44,11 +44,17 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check CI status
+        # Gate on the nightly's own build/release success, NOT unit-tests/build-all.
+        # Unit + e2e tests already ran on the PR (via validatePR.yml) before the change
+        # merged to develop. Those PR check-runs live on the PR head commit, which no longer
+        # exists after squash-merge, so they can't be found on the develop nightly commit.
+        # The meaningful, available signals here are that the nightly compiled/packaged the
+        # VSIXs and published the GitHub release cleanly.
         uses: salesforcecli/github-workflows/.github/actions/vscode/check-ci-status@main
         with:
           commit-sha: ${{ needs.find-nightly.outputs.commit-sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          required-checks: '["unit-tests", "build-all"]'
+          required-checks: '["nightly-release / package / Package", "nightly-release / Create GitHub Releases"]'
 
   # Step 3: Promote to prerelease (only runs if gate-check passed)
   promote:

--- a/CI-TESTING-PLAN.md
+++ b/CI-TESTING-PLAN.md
@@ -136,8 +136,8 @@ git ls-remote ci-testing | grep release-staging && echo "❌ Staging branch exis
 4. Run workflow
 
 **Expected Results:**
-- ✅ Stage 1 (find-nightly): Finds nightly ≥7 days old
-- ✅ Stage 2 (gate-check): Verifies all CI checks passed on nightly commit
+- ✅ Stage 1 (find-nightly): Finds most recent nightly (min-tag-age: 0 days)
+- ✅ Stage 2 (gate-check): Verifies nightly's build/release success (checks: `nightly-release / package / Package`, `nightly-release / Create GitHub Releases`)
 - ✅ Stage 3 (promote): Creates tracking tag `marketplace-prerelease-salesforcedx-vscode-vX.Y.Z` (skipped on ci-testing due to no secrets)
 - ✅ Workflow completes successfully even without publish secrets
 

--- a/contributing/publishing.md
+++ b/contributing/publishing.md
@@ -84,7 +84,7 @@ Published releases extract extension names from VSIX filenames in release assets
 
 ### Pre-release Promotion
 
-**Pre-release promotion:** `promote-nightly-to-prerelease.yml` (Wednesdays 7 AM UTC) runs 3-stage pipeline: (1) find-nightly selects oldest nightly ≥7 days; (2) gate-check verifies CI passed on nightly commit; (3) promote creates tracking tag for release flow. Safe rollback window before general release.
+**Pre-release promotion:** `promote-nightly-to-prerelease.yml` (Wednesdays 8 AM UTC) runs 3-stage pipeline: (1) find-nightly selects most recent nightly (min-tag-age: 0 days); (2) gate-check verifies nightly's build/release success (not unit-tests/build-all, which only exist on PR commits); (3) promote creates tracking tag for release flow. Safe rollback window before general release.
 
 **Release build:** See [Build Release from Prerelease](#build-release-from-prerelease) above.
 

--- a/docs/release-workflow-architecture.md
+++ b/docs/release-workflow-architecture.md
@@ -20,14 +20,16 @@ Daily (4 AM UTC)
 └────────┬─────────┘     Users opt-in to test cutting-edge features
          │
          │
-Wednesday (Week N - 7 AM UTC) ───────────────────────────────┐
+Wednesday (Week N - 8 AM UTC) ───────────────────────────────┐
          │                                                   │
          ▼                                                   │
 ┌─────────────────────────────────────────────────────────────────┐
 │  promote-nightly-to-prerelease.yml (AUTOMATED CRON)             │
 │  ┌──────────────────────────────────────────────────────────────┤
 │  │ WHAT IT DOES:                                                │
-│  │ ✓ Finds most recent CI-passing nightly (min-tag-age: 0 days) │
+│  │ ✓ Finds most recent nightly (min-tag-age: 0 days)            │
+│  │ ✓ Gate-checks: nightly build/release success                 │
+│  │   (not unit-tests; those ran on PR before merge to develop)  │
 │  │ ✓ Creates marketplace-prerelease-* tracking tag              │
 │  │   (marks which nightly to promote to stable next week)       │
 │  │ ✓ Publishes that specific nightly to marketplace             │
@@ -228,8 +230,9 @@ Emergency Path: ❌ None (wait 7+ days)
 ```
 WEEK N    Mon       Tue       Wed       Thu       Fri       Sat       Sun
                               │
-                              ├─ promote-nightly-to-prerelease.yml (AUTOMATED 7 AM UTC)
-                              │    • Finds most recent CI-passing nightly (min-tag-age: 0 days)
+                              ├─ promote-nightly-to-prerelease.yml (AUTOMATED 8 AM UTC)
+                              │    • Finds most recent nightly (min-tag-age: 0 days)
+                              │    • Gate-checks: verifies nightly build/release success
                               │    • Publishes to marketplace as PRE-RELEASE
                               │    • Creates marketplace-prerelease-* tracking tag
                               │    ✓ Real users test in production
@@ -238,7 +241,7 @@ WEEK N    Mon       Tue       Wed       Thu       Fri       Sat       Sun
                               │
 WEEK N+1  Mon       Tue       Wed       Thu       Fri       Sat       Sun
                               │
-                              ├─ build-release.yml (AUTOMATED 8 AM UTC)
+                              ├─ build-release.yml (AUTOMATED 7 AM UTC)
                               │    • Finds previous Wed's marketplace-prerelease-* tag
                               │    • Creates ephemeral staging branch
                               │    • Builds stable VSIXs


### PR DESCRIPTION
## What

Fixes the `gate-check` job in `promote-nightly-to-prerelease.yml` which was failing because it required `unit-tests` and `build-all` check-runs on the nightly's develop commit — checks that never exist there.

## Why it was failing

- Unit + e2e tests run on **PRs** (via `validatePR.yml`) before merge to develop
- After **squash-merge**, the PR head commit (where those checks live) no longer exists
- So the gate could never find `unit-tests`/`build-all` on the develop nightly commit → always failed

Since code only reaches the nightly through a tested, merged PR, re-checking unit tests is both redundant and impossible.

## Change

Gate now verifies the nightly's own terminal success signals instead:

```yaml
required-checks: '["nightly-release / package / Package", "nightly-release / Create GitHub Releases"]'
```

This confirms the nightly compiled/packaged the VSIXs and published the GitHub release cleanly.

## Also

- Updated docs (`release-workflow-architecture.md`, `publishing.md`, `CI-TESTING-PLAN.md`) to reflect the new gate criteria
- Fixed stale schedule refs (promote 8 AM, build-release 7 AM) and `find-nightly` age description (min-tag-age 0, not ≥7 days) in those docs

@W-24093729@


🤖 Generated with [Claude Code](https://claude.com/claude-code)