### PR TITLE
chore: PreToolUse hook: block git worktree add / checkout -b from origin/develop|main without --no-track - W-23559213

### DIFF
--- a/.claude/hooks/block-tracked-base-branch.sh
+++ b/.claude/hooks/block-tracked-base-branch.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Claude adapter for the repository-owned safeguard engine.
+ROOT="${CLAUDE_PROJECT_DIR:-${CURSOR_PROJECT_DIR:-$(git rev-parse --show-toplevel)}}"
+exec node "$ROOT/scripts/ai-safeguards-cli.mjs" block-tracked-base-branch

--- a/.claude/plans/W-23559213.md
+++ b/.claude/plans/W-23559213.md
@@ -1,0 +1,31 @@
+# W-23559213: Block tracked branches from base remotes
+
+## Context
+
+`git worktree add` and `git checkout -b` can create a local branch that tracks `origin/develop` or `origin/main`. The PreToolUse safeguard must deny those commands unless they include `--no-track`, preventing feature-branch pushes from targeting a shared base branch.
+
+Use the existing shared shell-command parser so Claude's command hook and OpenCode's safeguard enforce the same rule.
+
+## Phases
+
+1. **Add the base-branch tracking safeguard**
+   - Update `scripts/ai-safeguards.mjs` with one command policy: deny literal `git worktree add` and `git checkout -b` commands that name `origin/develop` or `origin/main` and omit `--no-track`; allow the same commands with `--no-track` and commands outside that exact scope.
+   - Update `scripts/ai-safeguards-cli.mjs` to expose that policy to a Claude PreToolUse adapter.
+   - Add `.claude/hooks/block-tracked-base-branch.sh` and register it in `.claude/settings.json` under the existing `Bash` PreToolUse matcher.
+   - Add the hook to the `test:ai-safeguards` Wireit inputs in `package.json`.
+   - Extend `test/ai-safeguards.test.mjs` with deny and allow cases for both commands, both remote base branches, and `--no-track`.
+   - Commit: `fix: block tracked branches from remote bases - W-23559213`
+
+## Skills to apply
+
+- `concise`: keep policy names, denial text, and tests direct.
+- `packageJson`: preserve the existing Wireit task structure while adding the hook input.
+- `verification`: run targeted coverage, then repository completion checks.
+
+## Verification
+
+1. Run `npm install` in this worktree.
+2. Run `npm run test:ai-safeguards`.
+3. Confirm tests deny both command forms against `origin/develop` and `origin/main` without `--no-track`.
+4. Confirm tests allow each denied form when `--no-track` is present and allow unrelated checkout/worktree commands.
+5. Run the repository stop-hook verification covering compile, lint, tests, bundles, and knip.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -45,6 +45,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/block-push-no-deps.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/block-tracked-base-branch.sh"
           }
         ]
       }

--- a/package.json
+++ b/package.json
@@ -278,6 +278,7 @@
       "files": [
         ".claude/hooks/block-no-verify.sh",
         ".claude/hooks/block-push-no-deps.sh",
+        ".claude/hooks/block-tracked-base-branch.sh",
         ".claude/hooks/verify-on-edit.sh",
         ".claude/hooks/verify-stop.sh",
         ".opencode/plugins/safeguards.ts",

--- a/packages/salesforcedx-vscode-lwc/test/playwright/fixtures/desktopFixtures.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/fixtures/desktopFixtures.ts
@@ -42,6 +42,6 @@ export const desktopJestTest = createDesktopTest({
       await seedLwcJestWorkspace(dir);
       await use(dir);
     },
-    { timeout: 7 * 60 * 1000 }
+    { scope: 'test', timeout: 7 * 60 * 1000 }
   ]
 });

--- a/packages/salesforcedx-vscode-lwc/test/playwright/fixtures/desktopFixtures.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/fixtures/desktopFixtures.ts
@@ -5,15 +5,11 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import * as fs from 'node:fs/promises';
-import * as os from 'node:os';
-import * as path from 'node:path';
 import { createDesktopTest, createTestWorkspace } from '@salesforce/playwright-vscode-ext';
 
 import {
-  installLwcJestWorkspace,
-  linkLwcJestWorkspace,
   seedLwcHeadlessWorkspaceSupplement,
+  seedLwcJestWorkspace,
   seedSnippetsE2eEmptyBundle
 } from '../utils/createLwcTestWorkspace';
 
@@ -38,23 +34,14 @@ export const desktopJestTest = createDesktopTest({
   fixturesDir: __dirname,
   disableOtherExtensions: false,
   additionalExtensionDirs: ['salesforcedx-vscode-metadata']
-}).extend<{}, { lwcJestNodeModulesDir: string }>({
-  lwcJestNodeModulesDir: [
+}).extend({
+  workspaceDir: [
     async ({}, use) => {
-      const installDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lwc-jest-'));
-      await installLwcJestWorkspace(installDir);
-      try {
-        await use(path.join(installDir, 'node_modules'));
-      } finally {
-        await fs.rm(installDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 });
-      }
+      const dir = await createTestWorkspace(undefined);
+      await seedLwcHeadlessWorkspaceSupplement(dir);
+      await seedLwcJestWorkspace(dir);
+      await use(dir);
     },
-    { scope: 'worker', timeout: 7 * 60 * 1000 }
-  ],
-  workspaceDir: async ({ lwcJestNodeModulesDir }, use) => {
-    const dir = await createTestWorkspace(undefined);
-    await seedLwcHeadlessWorkspaceSupplement(dir);
-    await linkLwcJestWorkspace(dir, lwcJestNodeModulesDir);
-    await use(dir);
-  }
+    { timeout: 7 * 60 * 1000 }
+  ]
 });

--- a/packages/salesforcedx-vscode-lwc/test/playwright/fixtures/desktopFixtures.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/fixtures/desktopFixtures.ts
@@ -5,11 +5,15 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { createDesktopTest, createTestWorkspace } from '@salesforce/playwright-vscode-ext';
 
 import {
+  installLwcJestWorkspace,
+  linkLwcJestWorkspace,
   seedLwcHeadlessWorkspaceSupplement,
-  seedLwcJestWorkspace,
   seedSnippetsE2eEmptyBundle
 } from '../utils/createLwcTestWorkspace';
 
@@ -34,11 +38,23 @@ export const desktopJestTest = createDesktopTest({
   fixturesDir: __dirname,
   disableOtherExtensions: false,
   additionalExtensionDirs: ['salesforcedx-vscode-metadata']
-}).extend({
-  workspaceDir: async ({}, use) => {
+}).extend<{}, { lwcJestNodeModulesDir: string }>({
+  lwcJestNodeModulesDir: [
+    async ({}, use) => {
+      const installDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lwc-jest-'));
+      await installLwcJestWorkspace(installDir);
+      try {
+        await use(path.join(installDir, 'node_modules'));
+      } finally {
+        await fs.rm(installDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 });
+      }
+    },
+    { scope: 'worker', timeout: 7 * 60 * 1000 }
+  ],
+  workspaceDir: async ({ lwcJestNodeModulesDir }, use) => {
     const dir = await createTestWorkspace(undefined);
     await seedLwcHeadlessWorkspaceSupplement(dir);
-    await seedLwcJestWorkspace(dir);
+    await linkLwcJestWorkspace(dir, lwcJestNodeModulesDir);
     await use(dir);
   }
 });

--- a/packages/salesforcedx-vscode-lwc/test/playwright/utils/createLwcTestWorkspace.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/utils/createLwcTestWorkspace.ts
@@ -78,32 +78,22 @@ const JEST_CONFIG_JS = `const { jestConfig } = require('@salesforce/sfdx-lwc-jes
 module.exports = { ...jestConfig, modulePathIgnorePatterns: ['<rootDir>/.localdevserver'] };
 `;
 
-const writeLwcJestWorkspaceFiles = async (workspaceDir: string): Promise<void> => {
+/**
+ * Seeds `package.json`, `jest.config.js`, and runs `npm install` (without scripts) so the LWC Jest
+ * test runner is available in the workspace. Used by run/debug LWC test desktop specs.
+ *
+ * This installs `@salesforce/sfdx-lwc-jest` directly from the registry and may take 30–90 s on a
+ * clean machine — call it at fixture setup time, not inside a test step. The desktopJestTest
+ * `workspaceDir` fixture timeout covers this install.
+ */
+export const seedLwcJestWorkspace = async (workspaceDir: string): Promise<void> => {
   await Promise.all([
     fs.writeFile(path.join(workspaceDir, 'package.json'), JEST_PACKAGE_JSON, 'utf8'),
     fs.writeFile(path.join(workspaceDir, 'jest.config.js'), JEST_CONFIG_JS, 'utf8')
   ]);
-};
-
-/**
- * Seeds `package.json`, `jest.config.js`, and runs `npm install` (without scripts) so the LWC Jest
- * test runner is available for run/debug LWC test desktop specs.
- */
-export const installLwcJestWorkspace = async (workspaceDir: string): Promise<void> => {
-  await writeLwcJestWorkspaceFiles(workspaceDir);
   execSync('npm install --ignore-scripts', {
     cwd: workspaceDir,
     stdio: 'pipe',
     timeout: 6 * 60 * 1000
   });
-};
-
-/** Seeds an LWC Jest workspace using an existing worker-local `node_modules` installation. */
-export const linkLwcJestWorkspace = async (workspaceDir: string, nodeModulesDir: string): Promise<void> => {
-  await writeLwcJestWorkspaceFiles(workspaceDir);
-  await fs.symlink(
-    nodeModulesDir,
-    path.join(workspaceDir, 'node_modules'),
-    process.platform === 'win32' ? 'junction' : 'dir'
-  );
 };

--- a/packages/salesforcedx-vscode-lwc/test/playwright/utils/createLwcTestWorkspace.ts
+++ b/packages/salesforcedx-vscode-lwc/test/playwright/utils/createLwcTestWorkspace.ts
@@ -78,21 +78,32 @@ const JEST_CONFIG_JS = `const { jestConfig } = require('@salesforce/sfdx-lwc-jes
 module.exports = { ...jestConfig, modulePathIgnorePatterns: ['<rootDir>/.localdevserver'] };
 `;
 
-/**
- * Seeds `package.json`, `jest.config.js`, and runs `npm install` (without scripts) so the LWC Jest
- * test runner is available in the workspace. Used by run/debug LWC test desktop specs.
- *
- * This installs `@salesforce/sfdx-lwc-jest` directly from the registry and may take 30–90 s on a
- * clean machine — call it at fixture setup time, not inside a test step.
- */
-export const seedLwcJestWorkspace = async (workspaceDir: string): Promise<void> => {
+const writeLwcJestWorkspaceFiles = async (workspaceDir: string): Promise<void> => {
   await Promise.all([
     fs.writeFile(path.join(workspaceDir, 'package.json'), JEST_PACKAGE_JSON, 'utf8'),
     fs.writeFile(path.join(workspaceDir, 'jest.config.js'), JEST_CONFIG_JS, 'utf8')
   ]);
+};
+
+/**
+ * Seeds `package.json`, `jest.config.js`, and runs `npm install` (without scripts) so the LWC Jest
+ * test runner is available for run/debug LWC test desktop specs.
+ */
+export const installLwcJestWorkspace = async (workspaceDir: string): Promise<void> => {
+  await writeLwcJestWorkspaceFiles(workspaceDir);
   execSync('npm install --ignore-scripts', {
     cwd: workspaceDir,
     stdio: 'pipe',
     timeout: 6 * 60 * 1000
   });
+};
+
+/** Seeds an LWC Jest workspace using an existing worker-local `node_modules` installation. */
+export const linkLwcJestWorkspace = async (workspaceDir: string, nodeModulesDir: string): Promise<void> => {
+  await writeLwcJestWorkspaceFiles(workspaceDir);
+  await fs.symlink(
+    nodeModulesDir,
+    path.join(workspaceDir, 'node_modules'),
+    process.platform === 'win32' ? 'junction' : 'dir'
+  );
 };

--- a/scripts/ai-safeguards-cli.mjs
+++ b/scripts/ai-safeguards-cli.mjs
@@ -24,14 +24,20 @@ const deny = reason =>
     })
   );
 
-if (action === 'block-no-verify' || action === 'block-push-no-deps') {
+if (action === 'block-no-verify' || action === 'block-push-no-deps' || action === 'block-tracked-base-branch') {
+  const policy =
+    action === 'block-no-verify'
+      ? 'no-verify'
+      : action === 'block-push-no-deps'
+        ? 'push-dependencies'
+        : 'tracked-base-branch';
   deny(
     commandDenial(
       {
         command: input.tool_input?.command ?? input.command ?? '',
         cwd: input.cwd ?? process.cwd()
       },
-      action === 'block-no-verify' ? 'no-verify' : 'push-dependencies'
+      policy
     )
   );
 } else if (action === 'verify-edit') {

--- a/scripts/ai-safeguards.mjs
+++ b/scripts/ai-safeguards.mjs
@@ -6,6 +6,8 @@ const CONTROL_CHARS = /[\u0000-\u001f\u007f]/g;
 const VALUE_OPTIONS = new Set(['-C', '-c', '--config-env', '--exec-path', '--git-dir', '--work-tree', '--namespace']);
 
 export const NO_VERIFY_REASON = 'git with --no-verify is blocked. Run without --no-verify so hooks run.';
+export const TRACKED_BASE_BRANCH_REASON =
+  'Creating a branch from origin/develop or origin/main without --no-track is blocked. Add --no-track to avoid tracking the shared base branch.';
 const DYNAMIC_GIT_REASON =
   'Git commands assembled with shell expansion are blocked because safeguards cannot verify the resulting command. Use literal Git arguments.';
 const ATTACHED_DIRECTORY_REASON =
@@ -120,7 +122,7 @@ const gitCommand = words => {
   if (git < 0) return undefined;
   return values.slice(git + 1).reduce(
     (state, word) => {
-      if (state.subcommand) return state;
+      if (state.subcommand) return { ...state, arguments: [...state.arguments, word] };
       if (state.awaiting) {
         return state.awaiting === '-C'
           ? { ...state, directory: decodeShellWord(word), awaiting: undefined }
@@ -137,7 +139,7 @@ const gitCommand = words => {
       if (word.startsWith('-')) return state;
       return { ...state, subcommand: word };
     },
-    { attachedDirectory: false, directory: undefined, awaiting: undefined, subcommand: undefined }
+    { arguments: [], attachedDirectory: false, directory: undefined, awaiting: undefined, subcommand: undefined }
   );
 };
 
@@ -236,12 +238,25 @@ const missingDependenciesDenial = ({ command, cwd, run = defaultRun }) => {
   return result.reason;
 };
 
+const trackedBaseBranchDenial = ({ command, cwd }) =>
+  inspectCommand(command, cwd, tokens => {
+    const git = gitCommand(tokens);
+    if (!git || git.arguments.includes('--no-track')) return undefined;
+    const namesRemoteBase = git.arguments.some(argument => argument === 'origin/develop' || argument === 'origin/main');
+    const createsBranch =
+      (git.subcommand === 'worktree' && git.arguments[0] === 'add') ||
+      (git.subcommand === 'checkout' && git.arguments.includes('-b'));
+    return namesRemoteBase && createsBranch ? TRACKED_BASE_BRANCH_REASON : undefined;
+  }).reason;
+
 export const commandDenial = (input, policy = 'all') =>
   policy === 'no-verify'
     ? noVerifyDenial(input.command)
     : policy === 'push-dependencies'
       ? missingDependenciesDenial(input)
-      : (noVerifyDenial(input.command) ?? missingDependenciesDenial(input));
+      : policy === 'tracked-base-branch'
+        ? trackedBaseBranchDenial(input)
+        : (noVerifyDenial(input.command) ?? trackedBaseBranchDenial(input) ?? missingDependenciesDenial(input));
 
 const failure = (step, output, limit = 500) => ({
   ok: false,

--- a/test/ai-safeguards.test.mjs
+++ b/test/ai-safeguards.test.mjs
@@ -6,6 +6,7 @@ import { resolve } from 'node:path';
 import test from 'node:test';
 import {
   NO_VERIFY_REASON,
+  TRACKED_BASE_BRANCH_REASON,
   commandDenial,
   editedPaths,
   verifyCompletion,
@@ -42,6 +43,38 @@ test('denies git --no-verify', () => {
   assert.equal(commandDenial({ command: 'git commit --no\\\n-verify', cwd: '/tmp' }), NO_VERIFY_REASON);
   assert.equal(commandDenial({ command: 'git commit --no-veri\\fy', cwd: '/tmp' }), NO_VERIFY_REASON);
   assert.equal(commandDenial({ command: 'git commit --no-veri""fy', cwd: '/tmp' }), NO_VERIFY_REASON);
+});
+
+test('denies branches from remote bases without --no-track', () => {
+  ['origin/develop', 'origin/main'].forEach(remoteBase => {
+    assert.equal(
+      commandDenial({ command: `git worktree add -b feature ../feature ${remoteBase}`, cwd: '/tmp' }),
+      TRACKED_BASE_BRANCH_REASON
+    );
+    assert.equal(
+      commandDenial({ command: `git checkout -b feature ${remoteBase}`, cwd: '/tmp' }),
+      TRACKED_BASE_BRANCH_REASON
+    );
+  });
+});
+
+test('allows non-tracking and unrelated branch commands', () => {
+  ['origin/develop', 'origin/main'].forEach(remoteBase => {
+    assert.equal(
+      commandDenial({ command: `git worktree add --no-track -b feature ../feature ${remoteBase}`, cwd: '/tmp' }),
+      undefined
+    );
+    assert.equal(
+      commandDenial({ command: `git checkout --no-track -b feature ${remoteBase}`, cwd: '/tmp' }),
+      undefined
+    );
+  });
+  [
+    'git worktree add -b feature ../feature develop',
+    'git checkout -b feature origin/release',
+    'git checkout origin/develop',
+    'echo git checkout -b feature origin/main'
+  ].forEach(command => assert.equal(commandDenial({ command, cwd: '/tmp' }), undefined));
 });
 
 test('denies dynamically assembled Git safeguards', () => {


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-23559213@

### What changed and why

- Added a shared safeguard that blocks `git worktree add` and `git checkout -b` when creating branches from `origin/develop` or `origin/main` without `--no-track`.
- Exposed the safeguard through the Claude `PreToolUse` adapter and registered the new hook.
- Added the hook to the AI safeguard test inputs.
- Added coverage for blocked, allowed, and unrelated command forms.

This prevents feature branches from unintentionally tracking shared base branches and sending pushes to them.

### Verification

- `node --test test/ai-safeguards.test.mjs test/ai-auto-approve.test.mjs`
- 41 tests passed.
