### PR TITLE
chore: Adopt considerUndefinedAsCancellation across remaining VSCode prompts - W-23559992

### DIFF
--- a/.claude/plans/W-23559992.md
+++ b/.claude/plans/W-23559992.md
@@ -1,0 +1,38 @@
+# W-23559992: Adopt `considerUndefinedAsCancellation` across remaining VSCode prompts
+
+## Context
+
+GUS subject: Adopt considerUndefinedAsCancellation across remaining VSCode prompts [ai-auto] [repo:forcedotcom/salesforcedx-vscode]
+
+Remaining direct VS Code prompts use local `undefined` checks instead of the shared `PromptService` cancellation path. Adopt `considerUndefinedAsCancellation` so dismissing these prompts produces the same typed user-cancellation behavior as already-migrated prompts, while preserving behavior after a selection.
+
+Observed source files:
+
+- `packages/salesforcedx-vscode-apex-debugger/src/index.ts`
+- `packages/salesforcedx-vscode-apex/src/languageUtils/languageClientManager.ts`
+- `packages/salesforcedx-vscode-metadata/src/commands/refreshSObjects.ts`
+- `packages/salesforcedx-vscode-apex-oas/src/oas/externalServiceRegistrationManager.ts`
+
+## Phases
+
+### 1. Use shared cancellation handling for remaining prompts
+
+- Pass each identified `showQuickPick` or `showInputBox` result through `PromptService.considerUndefinedAsCancellation`.
+- Remove the replaced local `undefined` branches; keep existing selected-value transformations, telemetry, and command work unchanged.
+- Update affected existing tests to assert dismissal follows the `UserCancellationError` path and selections retain current behavior.
+- Commit: `fix: adopt shared cancellation handling for remaining prompts`
+
+## Skills to apply
+
+- `typescript`: repository TypeScript conventions.
+- `effect-best-practices`: typed cancellation composition at Effect boundaries.
+- `services-extension-consumption`: obtain and use `PromptService` through the services extension API.
+- `verification`: package-scoped validation and relevant Playwright coverage.
+
+## Verification
+
+- Run package-scoped tests covering the changed prompt flows in `salesforcedx-vscode-apex-debugger`, `salesforcedx-vscode-apex`, `salesforcedx-vscode-metadata`, and `salesforcedx-vscode-apex-oas`.
+- Run `npm run test:desktop -w salesforcedx-vscode-apex-debugger -- --retries 0`.
+- Run `npm run test:desktop -w salesforcedx-vscode-apex -- --retries 0`.
+- Run `npm run test:desktop -w salesforcedx-vscode-metadata -- --retries 0`.
+- Let the repository stop hook run compile, lint, Effect language service checks, tests, bundle checks, and knip.

--- a/packages/salesforcedx-vscode-apex-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-debugger/src/index.ts
@@ -41,7 +41,7 @@ const cachedExceptionBreakpoints: Map<string, ExceptionBreakpointItem> = new Map
 export const getDebuggerType = async (session: vscode.DebugSession): Promise<string> =>
   session.type === LIVESHARE_DEBUGGER_TYPE ? session.customRequest(LIVESHARE_DEBUG_TYPE_REQUEST) : session.type;
 
-const registerCommands = (): vscode.Disposable => {
+const registerDebuggerHandlers = (): vscode.Disposable => {
   const customEventHandler = vscode.debug.onDidReceiveDebugSessionCustomEvent(async event => {
     if (event?.session) {
       const type = await getDebuggerType(event.session);
@@ -66,10 +66,6 @@ const registerCommands = (): vscode.Disposable => {
       }
     }
   });
-  const exceptionBreakpointCmd = vscode.commands.registerCommand(
-    'sf.debug.exception.breakpoint',
-    configureExceptionBreakpoint
-  );
   const startSessionHandler = vscode.debug.onDidStartDebugSession(session => {
     cachedExceptionBreakpoints.forEach(breakpoint => {
       const args: SetExceptionBreakpointsArguments = {
@@ -79,7 +75,7 @@ const registerCommands = (): vscode.Disposable => {
     });
   });
 
-  return vscode.Disposable.from(customEventHandler, exceptionBreakpointCmd, startSessionHandler);
+  return vscode.Disposable.from(customEventHandler, startSessionHandler);
 };
 
 export type ExceptionBreakpointItem = vscode.QuickPickItem & {
@@ -105,14 +101,20 @@ const EXCEPTION_BREAK_MODES: BreakModeItem[] = [
   }
 ];
 
-const configureExceptionBreakpoint = async (): Promise<void> => {
-  const salesforceApexExtension = await getActiveApexExtension();
-  const exceptionBreakpointInfos =
-    (await salesforceApexExtension.exports.getExceptionBreakpointInfo()) as ExceptionBreakpointItem[];
-  console.log('Retrieved exception breakpoint info from language server');
+const configureExceptionBreakpoint = Effect.fn('configureExceptionBreakpoint')(function* () {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const promptService = yield* api.services.PromptService;
+  const salesforceApexExtension = yield* Effect.promise(() => getActiveApexExtension());
+  const exceptionBreakpointInfos = (yield* Effect.promise(() =>
+    salesforceApexExtension.exports.getExceptionBreakpointInfo()
+  )) as ExceptionBreakpointItem[];
+  yield* Effect.log('Retrieved exception breakpoint info from language server');
   let enabledExceptionBreakpointTyperefs: string[] = [];
-  if (vscode.debug.activeDebugSession) {
-    const responseBody = await vscode.debug.activeDebugSession.customRequest(LIST_EXCEPTION_BREAKPOINTS_REQUEST);
+  const activeDebugSession = vscode.debug.activeDebugSession;
+  if (activeDebugSession) {
+    const responseBody = (yield* Effect.promise(() =>
+      activeDebugSession.customRequest(LIST_EXCEPTION_BREAKPOINTS_REQUEST)
+    )) as { typerefs?: string[] };
     if (responseBody?.typerefs) {
       enabledExceptionBreakpointTyperefs = responseBody.typerefs;
     }
@@ -127,25 +129,26 @@ const configureExceptionBreakpoint = async (): Promise<void> => {
     placeHolder: nls.localize('select_exception_text'),
     matchOnDescription: true
   };
-  const selectedException = await vscode.window.showQuickPick(processedBreakpointInfos, selectExceptionOptions);
-  if (selectedException) {
-    const selectBreakModeOptions: vscode.QuickPickOptions = {
-      placeHolder: nls.localize('select_break_option_text'),
-      matchOnDescription: true
-    };
-    const selectedBreakMode = await vscode.window.showQuickPick(EXCEPTION_BREAK_MODES, selectBreakModeOptions);
-    if (selectedBreakMode) {
-      selectedException.breakMode = selectedBreakMode.breakMode;
-      const args: SetExceptionBreakpointsArguments = {
-        exceptionInfo: selectedException
-      };
-      if (vscode.debug.activeDebugSession) {
-        await vscode.debug.activeDebugSession.customRequest(EXCEPTION_BREAKPOINT_REQUEST, args);
-      }
-      updateExceptionBreakpointCache(selectedException);
-    }
+  const selectedException = yield* Effect.promise(() =>
+    vscode.window.showQuickPick(processedBreakpointInfos, selectExceptionOptions)
+  ).pipe(Effect.flatMap(promptService.considerUndefinedAsCancellation));
+  const selectBreakModeOptions: vscode.QuickPickOptions = {
+    placeHolder: nls.localize('select_break_option_text'),
+    matchOnDescription: true
+  };
+  const selectedBreakMode = yield* Effect.promise(() =>
+    vscode.window.showQuickPick(EXCEPTION_BREAK_MODES, selectBreakModeOptions)
+  ).pipe(Effect.flatMap(promptService.considerUndefinedAsCancellation));
+  selectedException.breakMode = selectedBreakMode.breakMode;
+  const args: SetExceptionBreakpointsArguments = {
+    exceptionInfo: selectedException
+  };
+  const currentDebugSession = vscode.debug.activeDebugSession;
+  if (currentDebugSession) {
+    yield* Effect.promise(() => currentDebugSession.customRequest(EXCEPTION_BREAKPOINT_REQUEST, args));
   }
-};
+  yield* Effect.sync(() => updateExceptionBreakpointCache(selectedException));
+});
 
 export const mergeExceptionBreakpointInfos = (
   breakpointInfos: ExceptionBreakpointItem[],
@@ -246,11 +249,11 @@ export const activateEffect = Effect.fn('activation:salesforcedx-vscode-apex-deb
 ) {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   yield* Effect.sync(() => {
-    const commands = registerCommands();
+    const debuggerHandlers = registerDebuggerHandlers();
     const debugHandlers = registerDebugHandlers();
     const fileWatchers = registerFileWatchers();
     extensionContext.subscriptions.push(
-      commands,
+      debuggerHandlers,
       fileWatchers,
       debugHandlers,
       vscode.debug.registerDebugConfigurationProvider('apex', new DebugConfigurationProvider())
@@ -258,6 +261,7 @@ export const activateEffect = Effect.fn('activation:salesforcedx-vscode-apex-deb
   });
 
   const registerCommand = api.services.registerCommandWithRuntime(getRuntime());
+  yield* registerCommand('sf.debug.exception.breakpoint', configureExceptionBreakpoint);
   yield* registerCommand('sf.debugger.stop', debuggerStop);
   yield* registerCommand('sf.debug.isv.bootstrap', isvDebugBootstrap);
 });

--- a/packages/salesforcedx-vscode-apex-debugger/test/jest/activation.test.ts
+++ b/packages/salesforcedx-vscode-apex-debugger/test/jest/activation.test.ts
@@ -6,13 +6,20 @@
  */
 
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
+import { EXCEPTION_BREAKPOINT_BREAK_MODE_ALWAYS } from '@salesforce/salesforcedx-apex-debugger';
 import * as Effect from 'effect/Effect';
+import * as Exit from 'effect/Exit';
 import * as Layer from 'effect/Layer';
 import { NotificationModeService } from 'salesforcedx-vscode-services/src/vscode/notificationModeService';
+import { UserCancellationError } from 'salesforcedx-vscode-services/src/vscode/prompts/promptService';
 import * as vscode from 'vscode';
-import { activateEffect } from '../../src/index';
+import { activateEffect, getExceptionBreakpointCache, type ExceptionBreakpointItem } from '../../src/index';
 
 const registerCommandWithRuntime = jest.fn();
+const promptService = {
+  considerUndefinedAsCancellation: <T>(value: T | undefined) =>
+    value === undefined ? Effect.fail(new UserCancellationError()) : Effect.succeed(value)
+};
 const notificationMode = {
   getProgressLocation: () => Effect.succeed(vscode.ProgressLocation.Notification),
   showSuccessNotification: () => Effect.void
@@ -23,6 +30,7 @@ const extensionProviderLayer = () =>
     Layer.succeed(ExtensionProviderService, {
       getServicesApi: Effect.succeed({
         services: {
+          PromptService: Effect.succeed(promptService),
           registerCommandWithRuntime: () => registerCommandWithRuntime,
           NotificationModeService
         }
@@ -41,8 +49,20 @@ const runActivate = () =>
     >
   );
 
+const runExceptionBreakpointCommand = async () => {
+  await runActivate();
+  const command = registerCommandWithRuntime.mock.calls.find(
+    ([commandId]) => commandId === 'sf.debug.exception.breakpoint'
+  )?.[1] as () => Effect.Effect<void, unknown, ExtensionProviderService>;
+  return Effect.runPromiseExit(
+    command().pipe(Effect.provide(extensionProviderLayer())) as Effect.Effect<void, unknown, never>
+  );
+};
+
 describe('activateEffect', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
+    getExceptionBreakpointCache().clear();
     registerCommandWithRuntime.mockReturnValue(Effect.void);
     // registerCommands/registerDebugHandlers touch vscode.debug (absent from the shared mock) and
     // Disposable.from; stub just enough for the Effect.sync registration block to run.
@@ -52,6 +72,18 @@ describe('activateEffect', () => {
       registerDebugConfigurationProvider: jest.fn()
     };
     (vscode.Disposable as unknown as { from: jest.Mock }).from = jest.fn();
+    (vscode.extensions.getExtension as jest.Mock).mockReturnValue({
+      isActive: true,
+      exports: {
+        getExceptionBreakpointInfo: jest.fn().mockResolvedValue([
+          {
+            label: 'System.Exception',
+            typeref: 'System.Exception',
+            breakMode: 'never'
+          }
+        ])
+      }
+    });
     (vscode.workspace.createFileSystemWatcher as jest.Mock).mockReturnValue({
       onDidChange: jest.fn(),
       onDidCreate: jest.fn(),
@@ -62,7 +94,44 @@ describe('activateEffect', () => {
   it('registers the Effect-based commands', async () => {
     await runActivate();
 
+    expect(registerCommandWithRuntime).toHaveBeenCalledWith('sf.debug.exception.breakpoint', expect.anything());
     expect(registerCommandWithRuntime).toHaveBeenCalledWith('sf.debugger.stop', expect.anything());
     expect(registerCommandWithRuntime).toHaveBeenCalledWith('sf.debug.isv.bootstrap', expect.anything());
+  });
+
+  it('fails with UserCancellationError when exception selection is dismissed', async () => {
+    (vscode.window.showQuickPick as jest.Mock).mockResolvedValue(undefined);
+
+    const exit = await runExceptionBreakpointCommand();
+
+    expect(Exit.isFailure(exit) && exit.cause).toMatchObject({ error: { _tag: 'UserCancellationError' } });
+  });
+
+  it('fails with UserCancellationError when break mode selection is dismissed', async () => {
+    (vscode.window.showQuickPick as jest.Mock)
+      .mockResolvedValueOnce({ label: 'System.Exception', typeref: 'System.Exception', breakMode: 'never' })
+      .mockResolvedValueOnce(undefined);
+
+    const exit = await runExceptionBreakpointCommand();
+
+    expect(Exit.isFailure(exit) && exit.cause).toMatchObject({ error: { _tag: 'UserCancellationError' } });
+  });
+
+  it('updates the breakpoint for successful selections', async () => {
+    const selectedException: ExceptionBreakpointItem = {
+      label: 'System.Exception',
+      typeref: 'System.Exception',
+      breakMode: 'never'
+    };
+    (vscode.window.showQuickPick as jest.Mock)
+      .mockResolvedValueOnce(selectedException)
+      .mockResolvedValueOnce({ label: 'Always', breakMode: EXCEPTION_BREAKPOINT_BREAK_MODE_ALWAYS });
+
+    const exit = await runExceptionBreakpointCommand();
+
+    expect(Exit.isSuccess(exit)).toBe(true);
+    expect(getExceptionBreakpointCache().get('System.Exception')).toMatchObject({
+      breakMode: EXCEPTION_BREAKPOINT_BREAK_MODE_ALWAYS
+    });
   });
 });

--- a/packages/salesforcedx-vscode-apex-oas/src/oas/externalServiceRegistrationManager.ts
+++ b/packages/salesforcedx-vscode-apex-oas/src/oas/externalServiceRegistrationManager.ts
@@ -139,6 +139,7 @@ export const handleExistingESR = async (): Promise<string> =>
 
 export const getFolderForArtifact = Effect.fn('ApexOas.Esr.getFolderForArtifact')(function* () {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const promptService = yield* api.services.PromptService;
   const registryAccess = yield* api.services.MetadataRegistryService.getRegistryAccess().pipe(
     Effect.mapError(
       cause => new EsrPathResolutionFailed({ message: `${nls.localize('registry_access_failed')}: ${String(cause)}` })
@@ -156,13 +157,13 @@ export const getFolderForArtifact = Effect.fn('ApexOas.Esr.getFolderForArtifact'
     )
   );
   const defaultESRFolder = path.join(workspaceInfo.fsPath, 'force-app', 'main', 'default', esrDefaultDirectoryName);
-  const folderUri = yield* Effect.promise(async () =>
+  const folderUri = yield* Effect.promise(() =>
     vscode.window.showInputBox({
       prompt: nls.localize('select_folder_for_oas'),
       value: defaultESRFolder
     })
-  );
-  return folderUri ? path.resolve(folderUri) : undefined;
+  ).pipe(Effect.flatMap(promptService.considerUndefinedAsCancellation));
+  return path.resolve(folderUri);
 });
 
 /**

--- a/packages/salesforcedx-vscode-apex-oas/test/jest/oas/externalServiceRegistrationManager.test.ts
+++ b/packages/salesforcedx-vscode-apex-oas/test/jest/oas/externalServiceRegistrationManager.test.ts
@@ -6,10 +6,12 @@
  */
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import * as Effect from 'effect/Effect';
+import * as Exit from 'effect/Exit';
 import * as Layer from 'effect/Layer';
 import { XMLParser } from 'fast-xml-parser';
 import * as path from 'node:path';
 import type { OpenAPIV3 } from 'openapi-types';
+import { UserCancellationError } from 'salesforcedx-vscode-services/src/vscode/prompts/promptService';
 import * as vscode from 'vscode';
 import { nls } from '../../../src/messages/nls';
 import {
@@ -36,7 +38,11 @@ const buildExtensionProviderLayer = (registryAccess: any) =>
         },
         WorkspaceService: {
           getWorkspaceInfoOrThrow: () => Effect.succeed({ fsPath: fakeWorkspace })
-        }
+        },
+        PromptService: Effect.succeed({
+          considerUndefinedAsCancellation: <T>(value: T | undefined) =>
+            value === undefined ? Effect.fail(new UserCancellationError()) : Effect.succeed(value)
+        })
       }
     } as any)
   });
@@ -102,12 +108,18 @@ describe('externalServiceRegistrationManager', () => {
       });
     });
 
-    it('returns undefined if no folder is selected', async () => {
+    it('fails with UserCancellationError if no folder is selected', async () => {
       (vscode.window.showInputBox as jest.Mock).mockResolvedValue(undefined);
-      const result = await runEffect(getFolderForArtifact(), {
-        getTypeByName: () => ({ directoryName: 'externalServiceRegistrations' })
-      });
-      expect(result).toBeUndefined();
+      const exit = await Effect.runPromiseExit(
+        getFolderForArtifact().pipe(
+          Effect.provide(
+            buildExtensionProviderLayer({
+              getTypeByName: () => ({ directoryName: 'externalServiceRegistrations' })
+            })
+          )
+        ) as Effect.Effect<unknown, unknown, never>
+      );
+      expect(Exit.isFailure(exit) && exit.cause).toMatchObject({ error: { _tag: 'UserCancellationError' } });
     });
 
     it('throws if registry access fails', async () => {

--- a/packages/salesforcedx-vscode-apex/src/languageUtils/languageClientManager.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageUtils/languageClientManager.ts
@@ -57,6 +57,18 @@ interface RestartQuickPickItem extends vscode.QuickPickItem {
   type: 'restart' | 'reset';
 }
 
+const promptForRestartOption = Effect.fn('LanguageClientManager.promptForRestartOption')(function* (
+  items: RestartQuickPickItem[]
+) {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const promptService = yield* api.services.PromptService;
+  return yield* Effect.promise(() =>
+    vscode.window.showQuickPick(items, {
+      placeHolder: nls.localize('apex_language_server_restart_dialog_prompt')
+    })
+  ).pipe(Effect.flatMap(promptService.considerUndefinedAsCancellation));
+});
+
 export type ToolsEntry = { readonly uri: URI; readonly type: vscode.FileType };
 
 /** Given `.sfdx/tools` entries, the NNN-named subdirectory URIs to delete. Pure; unit-tested directly. */
@@ -154,9 +166,12 @@ export class LanguageClientManager {
     source: 'commandPalette' | 'statusBar',
     restartBehavior: string
   ): Promise<string | undefined> {
-    const selectedOption = await vscode.window.showQuickPick(items, {
-      placeHolder: nls.localize('apex_language_server_restart_dialog_prompt')
-    });
+    const selectedOption = await getRuntime().runPromise(
+      promptForRestartOption(items).pipe(
+        Effect.catchTag('UserCancellationError', () => Effect.void),
+        Effect.provideService(ExtensionProviderService, { getServicesApi })
+      )
+    );
 
     if (selectedOption) {
       await this.sendRestartTelemetry(selectedOption, source, restartBehavior);

--- a/packages/salesforcedx-vscode-apex/test/jest/languageUtils/languageClientManager.test.ts
+++ b/packages/salesforcedx-vscode-apex/test/jest/languageUtils/languageClientManager.test.ts
@@ -6,6 +6,7 @@
  */
 
 import * as Effect from 'effect/Effect';
+import { UserCancellationError } from 'salesforcedx-vscode-services/src/vscode/prompts/promptService';
 import * as vscode from 'vscode';
 import { URI, Utils } from 'vscode-uri';
 import { ApexLanguageClient } from '../../../src/apexLanguageClient';
@@ -21,6 +22,10 @@ const restartFlag = languageClientManager as unknown as { isRestarting: boolean 
 // Spans emitted via getRuntime().runFork are recorded so restart telemetry (name + attributes) can be asserted.
 // Prefixed `mock*` so jest.mock's factory may reference it (jest hoists the factory above imports).
 const mockRecordedSpans: RecordedSpan[] = [];
+const promptService = {
+  considerUndefinedAsCancellation: <T>(value: T | undefined) =>
+    value === undefined ? Effect.fail(new UserCancellationError()) : Effect.succeed(value)
+};
 
 const spanAttributes = (name: string): Record<string, unknown> | undefined => {
   const hit = mockRecordedSpans.find(s => s.name === name);
@@ -175,6 +180,17 @@ describe('Language Client Manager', () => {
         get: jest.fn().mockReturnValue('prompt')
       });
       (vscode.workspace.getConfiguration as jest.Mock) = mockGetConfiguration;
+      (vscode.extensions.getExtension as jest.Mock).mockReturnValue({
+        isActive: true,
+        exports: {
+          services: {
+            PromptService: Effect.succeed(promptService),
+            WorkspaceService: {
+              getWorkspaceInfo: () => Effect.succeed({ isEmpty: true })
+            }
+          }
+        }
+      });
 
       // Reset the isRestarting flag
       restartFlag.isRestarting = false;
@@ -262,6 +278,7 @@ describe('Language Client Manager', () => {
         isActive: true,
         exports: {
           services: {
+            PromptService: Effect.succeed(promptService),
             WorkspaceService: {
               getWorkspaceInfo: () =>
                 Effect.succeed({
@@ -320,7 +337,12 @@ describe('Language Client Manager', () => {
       });
 
       // No services extension → getServicesApi fails ServicesExtensionNotFoundError.
-      (vscode.extensions.getExtension as jest.Mock).mockReturnValue(undefined);
+      (vscode.extensions.getExtension as jest.Mock)
+        .mockReturnValueOnce({
+          isActive: true,
+          exports: { services: { PromptService: Effect.succeed(promptService) } }
+        })
+        .mockReturnValue(undefined);
 
       // Mock createLanguageClient to resolve immediately
       jest.spyOn(languageClientManager, 'createLanguageClient').mockResolvedValueOnce();

--- a/packages/salesforcedx-vscode-metadata/src/commands/refreshSObjects.ts
+++ b/packages/salesforcedx-vscode-metadata/src/commands/refreshSObjects.ts
@@ -21,19 +21,21 @@ export const SOBJECT_REFRESH_COMPLETE_CMD = 'sf.internal.sobjectrefresh.complete
 
 const refreshSemaphore = Effect.runSync(Effect.makeSemaphore(1));
 
-const gatherCategory = () =>
-  Effect.promise(async () => {
-    const options = [
-      nls.localize('sobject_refresh_all'),
-      nls.localize('sobject_refresh_custom'),
-      nls.localize('sobject_refresh_standard')
-    ];
-    const choice = await vscode.window.showQuickPick(options);
-    if (!choice) return undefined;
-    if (choice === options[1]) return 'CUSTOM' as const;
-    if (choice === options[2]) return 'STANDARD' as const;
-    return 'ALL' as const;
-  });
+const gatherCategory = Effect.fn('gatherSObjectCategory')(function* () {
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const promptService = yield* api.services.PromptService;
+  const options = [
+    nls.localize('sobject_refresh_all'),
+    nls.localize('sobject_refresh_custom'),
+    nls.localize('sobject_refresh_standard')
+  ];
+  const choice = yield* Effect.promise(() => vscode.window.showQuickPick(options)).pipe(
+    Effect.flatMap(promptService.considerUndefinedAsCancellation)
+  );
+  if (choice === options[1]) return 'CUSTOM' as const;
+  if (choice === options[2]) return 'STANDARD' as const;
+  return 'ALL' as const;
+});
 
 /** Emit the cross-extension completion notification for the given exit code, if core is present. */
 const emitCompletion = (exitCode: number) =>
@@ -98,7 +100,6 @@ const executeRefresh = Effect.fn('executeRefresh')(function* (
 const runRefresh = Effect.fn('runRefresh')(function* (source?: SObjectRefreshSource) {
   if (!source || source === 'manual') {
     const picked = yield* gatherCategory();
-    if (!picked) return;
     yield* executeRefresh(picked, source);
   } else {
     yield* executeRefresh('ALL', source);

--- a/packages/salesforcedx-vscode-metadata/test/jest/commands/refreshSObjects.test.ts
+++ b/packages/salesforcedx-vscode-metadata/test/jest/commands/refreshSObjects.test.ts
@@ -21,6 +21,7 @@ jest.mock('../../../src/commands/sobjectArtifactWriter', () => ({
 }));
 
 import { refreshSObjectsCommand, SOBJECT_REFRESH_COMPLETE_CMD } from '../../../src/commands/refreshSObjects';
+import { nls } from '../../../src/messages';
 
 const SUCCESS_CODE = 0;
 const FAILURE_CODE = 1;
@@ -30,6 +31,8 @@ const appendToChannel = jest.fn(() => Effect.void);
 // Stand-in PromptService.withCancellableProgressReporting: runs the build effect with a mock
 // progress + uncancelled token in the same fiber, so a typed failure propagates unchanged.
 const mockPromptService = {
+  considerUndefinedAsCancellation: <T>(value: T | undefined) =>
+    value === undefined ? Effect.fail(new UserCancellationError()) : Effect.succeed(value),
   withCancellableProgressReporting:
     (_title: string, _location?: vscode.ProgressLocation) =>
     <A, E, R>(build: (progress: unknown, token: unknown) => Effect.Effect<A, E, R>) =>
@@ -91,6 +94,29 @@ describe('refreshSObjectsCommand completion + error surfacing', () => {
 
     expect(exit._tag).toBe('Success');
     expect(executeCommand).toHaveBeenCalledWith(SOBJECT_REFRESH_COMPLETE_CMD, { exitCode: SUCCESS_CODE });
+  });
+
+  it('refreshes the selected category', async () => {
+    (vscode.window.showQuickPick as jest.Mock).mockResolvedValue(nls.localize('sobject_refresh_custom'));
+    streamAndWriteSobjectArtifacts.mockReturnValue(
+      Effect.succeed({ data: { cancelled: false, standardObjects: 0, customObjects: 2 } })
+    );
+
+    const exit = await runCommand('manual');
+
+    expect(exit._tag).toBe('Success');
+    expect(streamAndWriteSobjectArtifacts).toHaveBeenCalledWith(
+      expect.objectContaining({ category: 'CUSTOM', source: 'manual' })
+    );
+  });
+
+  it('cancels when no category is selected', async () => {
+    (vscode.window.showQuickPick as jest.Mock).mockResolvedValue(undefined);
+
+    const exit = await runCommand('manual');
+
+    expect(exit._tag).toBe('Success');
+    expect(streamAndWriteSobjectArtifacts).not.toHaveBeenCalled();
   });
 
   it('surfaces the real underlying error (not "An error has occurred") and emits FAILURE_CODE', async () => {

--- a/packages/salesforcedx-vscode-services-types/package.json
+++ b/packages/salesforcedx-vscode-services-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/vscode-services",
-  "version": "67.17.3",
+  "version": "67.17.4",
   "description": "TypeScript type definitions for Salesforce VS Code Services extension API",
   "author": "Salesforce",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-23559992@

### What changed and why?

- Updated the remaining direct `showQuickPick` and `showInputBox` calls in the Apex debugger, Apex language client, metadata refresh, and Apex OAS extensions to use `PromptService.considerUndefinedAsCancellation`.
- Replaced local `undefined` handling with the shared typed `UserCancellationError` path.
- Preserved existing selected-value transformations, telemetry, and command behavior.
- Updated focused tests to cover prompt dismissal and successful selections.
- Package-scoped tests and repository validation cover the affected prompt flows, including compilation, lint, Effect checks, bundle checks, and knip.
