### PR TITLE
chore: 3.2 Fan out parallel setup to metadataE2E + orgBrowserE2E (Playwright + dreamhouse clone) - W-23195717

### DIFF
--- a/.claude/plans/W-23195717.md
+++ b/.claude/plans/W-23195717.md
@@ -1,0 +1,30 @@
+# W-23195717
+
+## Context
+
+`metadataE2E.yml` and `orgBrowserE2E.yml` install Playwright Chromium and clone Dreamhouse sequentially during cache-miss setup. These independent operations can run concurrently, reducing setup time before Dreamhouse scratch-org creation and Playwright execution.
+
+## Phases
+
+### 1. Fan out Playwright and Dreamhouse setup
+
+Commit: `ci: parallelize Playwright and Dreamhouse setup`
+
+- Update `.github/workflows/metadataE2E.yml` web and desktop jobs.
+- Update `.github/workflows/orgBrowserE2E.yml` web and desktop jobs.
+- Replace the separate Chromium installation and Dreamhouse clone steps with one cache-miss setup step that starts both concurrently.
+- Explicitly wait for both operations and fail the step if either fails.
+- Preserve each operation's current retry behavior.
+- Keep scratch-org creation, Dreamhouse deployment, test execution, artifact upload, and cleanup after the joined setup step.
+
+## Skills to apply
+
+- `concise`: keep workflow changes and comments minimal.
+- `playwright-e2e`: preserve Playwright CI setup and Dreamhouse alias expectations.
+- `verification`: validate GitHub Actions changes with the repository workflow checker.
+
+## Verification
+
+- Run `npm run check:actions` from the repository root.
+- Run both changed workflows in GitHub Actions and confirm each web and desktop job completes setup, Dreamhouse scratch-org creation, and its Playwright test command.
+- Confirm a failure in either parallel operation prevents scratch-org creation and test execution.

--- a/.github/workflows/metadataE2E.yml
+++ b/.github/workflows/metadataE2E.yml
@@ -95,15 +95,6 @@ jobs:
           command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
-      - name: Clone dreamhouse
-        if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: git clone --depth=1 https://github.com/trailheadapps/dreamhouse-lwc
-            dreamhouse-lwc
-          retry_wait_seconds: 60
-
       - name: Auth to dev hub (global)
         if: steps.try-run.outcome == 'failure'
         uses: salesforcecli/github-workflows/.github/actions/retry@main
@@ -113,13 +104,38 @@ jobs:
             --set-default-dev-hub --alias hub --sfdx-url-stdin'
           retry_wait_seconds: 30
 
-      - name: Install Playwright browsers and OS deps
+      - name: Install Playwright and clone dreamhouse
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        shell: bash
+        run: |
+          retry() {
+            local attempt command_pid timeout_pid
+            for attempt in 1 2 3; do
+              "$@" &
+              command_pid=$!
+              (sleep 3600; kill -KILL "$command_pid" 2>/dev/null) &
+              timeout_pid=$!
+              if wait "$command_pid"; then
+                kill "$timeout_pid" 2>/dev/null || true
+                wait "$timeout_pid" 2>/dev/null || true
+                return 0
+              fi
+              kill "$timeout_pid" 2>/dev/null || true
+              wait "$timeout_pid" 2>/dev/null || true
+              if [ "$attempt" -lt 3 ]; then sleep 60; fi
+            done
+            return 1
+          }
+
+          retry npx playwright install chromium --with-deps &
+          playwright_pid=$!
+          retry git clone --depth=1 https://github.com/trailheadapps/dreamhouse-lwc dreamhouse-lwc &
+          dreamhouse_pid=$!
+
+          failed=0
+          wait "$playwright_pid" || failed=1
+          wait "$dreamhouse_pid" || failed=1
+          exit "$failed"
 
       - name: create scratch org and set up dreamhouse
         if: steps.try-run.outcome == 'failure'
@@ -278,22 +294,38 @@ jobs:
             --set-default-dev-hub --alias hub --sfdx-url-stdin'
           retry_wait_seconds: 30
 
-      - name: Install Playwright browsers and OS deps
+      - name: Install Playwright and clone dreamhouse
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        shell: bash
+        run: |
+          retry() {
+            local attempt command_pid timeout_pid
+            for attempt in 1 2 3; do
+              "$@" &
+              command_pid=$!
+              (sleep 3600; kill -KILL "$command_pid" 2>/dev/null) &
+              timeout_pid=$!
+              if wait "$command_pid"; then
+                kill "$timeout_pid" 2>/dev/null || true
+                wait "$timeout_pid" 2>/dev/null || true
+                return 0
+              fi
+              kill "$timeout_pid" 2>/dev/null || true
+              wait "$timeout_pid" 2>/dev/null || true
+              if [ "$attempt" -lt 3 ]; then sleep 60; fi
+            done
+            return 1
+          }
 
-      - name: Clone dreamhouse
-        if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: git clone --depth=1 https://github.com/trailheadapps/dreamhouse-lwc
-            dreamhouse-lwc
-          retry_wait_seconds: 60
+          retry npx playwright install chromium --with-deps &
+          playwright_pid=$!
+          retry git clone --depth=1 https://github.com/trailheadapps/dreamhouse-lwc dreamhouse-lwc &
+          dreamhouse_pid=$!
+
+          failed=0
+          wait "$playwright_pid" || failed=1
+          wait "$dreamhouse_pid" || failed=1
+          exit "$failed"
 
       - name: create scratch org and set up dreamhouse
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/orgBrowserE2E.yml
+++ b/.github/workflows/orgBrowserE2E.yml
@@ -96,15 +96,6 @@ jobs:
           command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
-      - name: Clone dreamhouse
-        if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: git clone --depth=1 https://github.com/trailheadapps/dreamhouse-lwc
-            dreamhouse-lwc
-          retry_wait_seconds: 60
-
       - name: Auth to dev hub (global)
         if: steps.try-run.outcome == 'failure'
         uses: salesforcecli/github-workflows/.github/actions/retry@main
@@ -114,13 +105,38 @@ jobs:
             --set-default-dev-hub --alias hub --sfdx-url-stdin'
           retry_wait_seconds: 30
 
-      - name: Install Playwright browsers and OS deps
+      - name: Install Playwright and clone dreamhouse
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        shell: bash
+        run: |
+          retry() {
+            local attempt command_pid timeout_pid
+            for attempt in 1 2 3; do
+              "$@" &
+              command_pid=$!
+              (sleep 3600; kill -KILL "$command_pid" 2>/dev/null) &
+              timeout_pid=$!
+              if wait "$command_pid"; then
+                kill "$timeout_pid" 2>/dev/null || true
+                wait "$timeout_pid" 2>/dev/null || true
+                return 0
+              fi
+              kill "$timeout_pid" 2>/dev/null || true
+              wait "$timeout_pid" 2>/dev/null || true
+              if [ "$attempt" -lt 3 ]; then sleep 60; fi
+            done
+            return 1
+          }
+
+          retry npx playwright install chromium --with-deps &
+          playwright_pid=$!
+          retry git clone --depth=1 https://github.com/trailheadapps/dreamhouse-lwc dreamhouse-lwc &
+          dreamhouse_pid=$!
+
+          failed=0
+          wait "$playwright_pid" || failed=1
+          wait "$dreamhouse_pid" || failed=1
+          exit "$failed"
 
       - name: create scratch org and set up dreamhouse
         if: steps.try-run.outcome == 'failure'
@@ -244,22 +260,38 @@ jobs:
           command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
-      - name: Install Playwright browsers and OS deps
+      - name: Install Playwright and clone dreamhouse
         if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+        shell: bash
+        run: |
+          retry() {
+            local attempt command_pid timeout_pid
+            for attempt in 1 2 3; do
+              "$@" &
+              command_pid=$!
+              (sleep 3600; kill -KILL "$command_pid" 2>/dev/null) &
+              timeout_pid=$!
+              if wait "$command_pid"; then
+                kill "$timeout_pid" 2>/dev/null || true
+                wait "$timeout_pid" 2>/dev/null || true
+                return 0
+              fi
+              kill "$timeout_pid" 2>/dev/null || true
+              wait "$timeout_pid" 2>/dev/null || true
+              if [ "$attempt" -lt 3 ]; then sleep 60; fi
+            done
+            return 1
+          }
 
-      - name: Clone dreamhouse
-        if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: git clone --depth=1 https://github.com/trailheadapps/dreamhouse-lwc
-            dreamhouse-lwc
-          retry_wait_seconds: 60
+          retry npx playwright install chromium --with-deps &
+          playwright_pid=$!
+          retry git clone --depth=1 https://github.com/trailheadapps/dreamhouse-lwc dreamhouse-lwc &
+          dreamhouse_pid=$!
+
+          failed=0
+          wait "$playwright_pid" || failed=1
+          wait "$dreamhouse_pid" || failed=1
+          exit "$failed"
 
       - name: Auth to dev hub (global)
         if: steps.try-run.outcome == 'failure'


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-23195717@

Updated `metadataE2E.yml` and `orgBrowserE2E.yml` so web and desktop jobs install Playwright Chromium and clone Dreamhouse concurrently during cache-miss setup.

The combined setup step preserves the existing three-attempt retry behavior and waits for both operations, failing before scratch-org creation if either operation fails. This reduces setup time while keeping the remaining setup, test, artifact, and cleanup steps unchanged.

Tests not run; workflow-only change.
