### PR TITLE
chore: Adopt Effect HashSet for set algebra and build loops - W-23574407

### DIFF
--- a/.claude/plans/W-23574407.md
+++ b/.claude/plans/W-23574407.md
@@ -1,0 +1,31 @@
+# W-23574407: Adopt Effect HashSet for set algebra and build loops
+
+## Context
+
+`packages/salesforcedx-vscode-apex-oas/src/oas/documentProcessorPipeline/methodValidationStep.ts` builds native sets for eligible Apex methods and OAS operation IDs, then uses native `Set.difference` for mismatch detection. Use Effect `HashSet` for both set construction and set algebra so this Effect-based pipeline uses one collection API.
+
+## Phases
+
+### 1. Replace native set operations
+
+Commit: `refactor(apex-oas): use Effect HashSet for method validation`
+
+- Update `packages/salesforcedx-vscode-apex-oas/src/oas/documentProcessorPipeline/methodValidationStep.ts`.
+- Build method-name and operation-ID sets with `HashSet.fromIterable`.
+- Compute both mismatch sets with `HashSet.difference`.
+- Convert mismatch values for the existing diagnostic mapping and return order.
+
+## Skills to apply
+
+- `effect-best-practices`: use Effect collection APIs idiomatically.
+- `typescript`: preserve inferred types, avoid mutation, and keep the change minimal.
+- `verification`: verify compile, lint, tests, bundle, and Effect idioms.
+- `concise`: keep implementation comments and commit scope minimal.
+
+## Verification
+
+- Run `npm run compile -w salesforcedx-vscode-apex-oas`.
+- Run `npm run lint -w salesforcedx-vscode-apex-oas`.
+- Run `npm test -w salesforcedx-vscode-apex-oas`.
+- Run `npm run vscode:bundle -w salesforcedx-vscode-apex-oas`.
+- Run the `effect-advocate` review for missed Effect idioms.

--- a/packages/salesforcedx-vscode-apex-oas/src/oas/documentProcessorPipeline/methodValidationStep.ts
+++ b/packages/salesforcedx-vscode-apex-oas/src/oas/documentProcessorPipeline/methodValidationStep.ts
@@ -6,7 +6,9 @@
  */
 
 import type { ProcessorInputOutput } from './processorStep';
+import * as Arr from 'effect/Array';
 import * as Effect from 'effect/Effect';
+import * as HashSet from 'effect/HashSet';
 import { JSONPath } from 'jsonpath-plus';
 import type { OpenAPIV3 } from 'openapi-types';
 import type { ApexClassOASEligibleResponse } from 'salesforcedx-vscode-apex';
@@ -22,28 +24,36 @@ const collectMethodMismatches = (
   eligibilityResult: ApexClassOASEligibleResponse
 ): vscode.Diagnostic[] => {
   const symbols = eligibilityResult.symbols ?? [];
-  const methodNames = new Set<string>(
+  const methodNameValues = Arr.dedupe(
     symbols.filter(symbol => symbol.isApexOasEligible).map(symbol => symbol.docSymbol.name)
   );
+  const methodNames = HashSet.fromIterable(methodNameValues);
   // Use JSONPath to find all operationIds in the OAS document
-  const operationIds = new Set<string>(JSONPath({ path: '$..operationId', json: oasYaml }));
+  const operationIdValues = Arr.dedupe(JSONPath<string[]>({ path: '$..operationId', json: oasYaml }));
+  const operationIds = HashSet.fromIterable(operationIdValues);
 
-  const missingFromDoc = Array.from(methodNames.difference(operationIds)).map(
-    methodName =>
-      new vscode.Diagnostic(
-        new vscode.Range(0, 0, 0, 0),
-        nls.localize('eligible_method_not_in_doc', methodName),
-        vscode.DiagnosticSeverity.Error
-      )
-  );
-  const ineligibleInDoc = Array.from(operationIds.difference(methodNames)).map(
-    methodName =>
-      new vscode.Diagnostic(
-        new vscode.Range(0, 0, 0, 0),
-        nls.localize('ineligible_method_in_doc', methodName),
-        vscode.DiagnosticSeverity.Error
-      )
-  );
+  const methodNamesMissingFromDoc = HashSet.difference(methodNames, operationIds);
+  const missingFromDoc = methodNameValues
+    .filter(methodName => HashSet.has(methodNamesMissingFromDoc, methodName))
+    .map(
+      methodName =>
+        new vscode.Diagnostic(
+          new vscode.Range(0, 0, 0, 0),
+          nls.localize('eligible_method_not_in_doc', methodName),
+          vscode.DiagnosticSeverity.Error
+        )
+    );
+  const ineligibleOperationIds = HashSet.difference(operationIds, methodNames);
+  const ineligibleInDoc = operationIdValues
+    .filter(operationId => HashSet.has(ineligibleOperationIds, operationId))
+    .map(
+      operationId =>
+        new vscode.Diagnostic(
+          new vscode.Range(0, 0, 0, 0),
+          nls.localize('ineligible_method_in_doc', operationId),
+          vscode.DiagnosticSeverity.Error
+        )
+    );
   return [...missingFromDoc, ...ineligibleInDoc];
 };
 

--- a/packages/salesforcedx-vscode-apex-oas/test/jest/oas/documentProcessingPipeline/methodValidationStep.test.ts
+++ b/packages/salesforcedx-vscode-apex-oas/test/jest/oas/documentProcessingPipeline/methodValidationStep.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import * as Effect from 'effect/Effect';
+import type { ApexClassOASEligibleResponse } from 'salesforcedx-vscode-apex';
+import * as vscode from 'vscode';
+import { SymbolKind } from 'vscode-languageserver-protocol';
+import { URI } from 'vscode-uri';
+import { nls } from '../../../../src/messages/nls';
+import type { ProcessorInputOutput } from '../../../../src/oas/documentProcessorPipeline/processorStep';
+
+Object.assign(vscode, { DiagnosticSeverity: { Error: 0 } });
+jest.mocked(vscode.languages.createDiagnosticCollection).mockReturnValue({
+  clear: jest.fn()
+} as unknown as vscode.DiagnosticCollection);
+
+const { methodValidationStep } = jest.requireActual<
+  typeof import('../../../../src/oas/documentProcessorPipeline/methodValidationStep')
+>('../../../../src/oas/documentProcessorPipeline/methodValidationStep');
+
+describe('methodValidationStep', () => {
+  it('preserves source order for multiple method mismatches', async () => {
+    const methodNames = ['firstMethod', 'secondMethod', 'thirdMethod', 'fourthMethod'];
+    const operationIds = ['firstOperation', 'secondOperation', 'thirdOperation', 'fourthOperation'];
+    const position = { line: 0, character: 0 };
+    const eligibilityResult: ApexClassOASEligibleResponse = {
+      resourceUri: URI.file('/test.cls'),
+      isApexOasEligible: true,
+      isEligible: true,
+      symbols: methodNames.map(name => ({
+        isApexOasEligible: true,
+        isEligible: true,
+        docSymbol: {
+          name,
+          kind: SymbolKind.Method,
+          range: { start: position, end: position },
+          selectionRange: { start: position, end: position }
+        }
+      }))
+    };
+    const input: ProcessorInputOutput = {
+      errors: [],
+      eligibilityResult,
+      openAPIDoc: {
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: Object.fromEntries(
+          operationIds.map((operationId, index) => [`/operation-${index}`, { get: { operationId, responses: {} } }])
+        )
+      }
+    };
+    const localize = jest.spyOn(nls, 'localize');
+
+    await Effect.runPromise(methodValidationStep(input));
+
+    expect(localize.mock.calls).toEqual([
+      ...methodNames.map(methodName => ['eligible_method_not_in_doc', methodName]),
+      ...operationIds.map(operationId => ['ineligible_method_in_doc', operationId])
+    ]);
+  });
+});


### PR DESCRIPTION
### What issues does this PR fix or reference?

@W-23574407@

### What changed

- Replaced native `Set` construction and `Set.difference` with Effect `HashSet.fromIterable` and `HashSet.difference`.
- Preserved deduplicated source arrays for stable diagnostic ordering.
- Added a regression test covering multiple method mismatches and source-order preservation.

### Why

This keeps set construction and set algebra consistent with the Effect-based pipeline while preserving existing diagnostic behavior and ordering.
