### PR TITLE
chore: Remove unused @salesforce/templates dependency from salesforcedx-vscode-core - W-23543091

### DIFF
--- a/.claude/plans/W-23543091.md
+++ b/.claude/plans/W-23543091.md
@@ -1,0 +1,29 @@
+# W-23543091
+
+## Context
+
+Remove the unused `@salesforce/templates` dependency from `salesforcedx-vscode-core`. This avoids declaring and installing the package for core while preserving the existing dependency owned by `salesforcedx-vscode-services`.
+
+Files:
+
+- `packages/salesforcedx-vscode-core/package.json`
+- `package-lock.json`
+
+## Phases
+
+### 1. Remove the core dependency
+
+- Delete `@salesforce/templates` from `salesforcedx-vscode-core` dependencies.
+- Regenerate root lockfile metadata so the core workspace no longer declares it; retain entries required by `salesforcedx-vscode-services`.
+- Commit message: `chore: remove templates dependency from core`
+
+## Skills to apply
+
+- `packageJson`: preserve repository dependency conventions.
+- `verification`: verify the dependency and lockfile change.
+
+## Verification
+
+- Run `npm install` from the repository root to update and validate `package-lock.json`.
+- Confirm `packages/salesforcedx-vscode-core/package.json` and its lockfile workspace entry no longer reference `@salesforce/templates`.
+- Run the repository stop-hook checks: compile, lint, tests, bundle, and knip.

--- a/package-lock.json
+++ b/package-lock.json
@@ -46684,7 +46684,6 @@
         "@salesforce/o11y-reporter": "^1.8.5",
         "@salesforce/salesforcedx-utils-vscode": "*",
         "@salesforce/source-deploy-retrieve": "^13.2.0",
-        "@salesforce/templates": "^66.13.9",
         "@salesforce/ts-types": "^3.0.0",
         "@salesforce/vscode-i18n": "*",
         "@salesforce/vscode-service-provider": "^1.5.0",

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -33,7 +33,6 @@
     "@salesforce/o11y-reporter": "^1.8.5",
     "@salesforce/salesforcedx-utils-vscode": "*",
     "@salesforce/source-deploy-retrieve": "^13.2.0",
-    "@salesforce/templates": "^66.13.9",
     "@salesforce/ts-types": "^3.0.0",
     "@salesforce/vscode-i18n": "*",
     "@salesforce/vscode-service-provider": "^1.5.0",


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-23543091@

### What changed and why?
Removed the unused `@salesforce/templates` dependency from `salesforcedx-vscode-core` and its workspace entry in `package-lock.json`.

The dependency remains available through `salesforcedx-vscode-services`, which owns its usage. This prevents `salesforcedx-vscode-core` from declaring and installing an unnecessary package.
