### PR TITLE
chore: 4 Collapse ARD log-file command hops; prompt in debug config - W-23711394

### DIFF
--- a/.claude/plans/W-23711394.md
+++ b/.claude/plans/W-23711394.md
@@ -1,0 +1,42 @@
+# W-23711394: Collapse ARD log-file command hops
+
+## Context
+
+ARD log-file launches currently pass through internal VS Code commands before calling `launchFromLogFile`, and `DebugConfigurationProvider` executes another command to prompt for a log file. Collapse those internal hops so TypeScript callers invoke `launchFromLogFile` directly and the debug configuration owns log-file prompting. Keep the user-facing launch commands as entry points; remove only internal command registrations and activation metadata made unnecessary by the direct calls.
+
+Files:
+
+- `packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts`
+- `packages/salesforcedx-vscode-apex-replay-debugger/src/commands/anonApexDebug.ts`
+- `packages/salesforcedx-vscode-apex-replay-debugger/src/commands/launchApexReplayDebuggerWithCurrentFile.ts`
+- `packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts`
+- `packages/salesforcedx-vscode-apex-replay-debugger/package.json`
+
+## Phases
+
+### 1. Replace internal command dispatch with direct calls
+
+- Import and call `launchFromLogFile` from ARD TypeScript callers instead of dispatching `sf.launch.replay.debugger.logfile` or `sf.launch.replay.debugger.logfile.path` internally.
+- Keep user-facing command handlers in `src/index.ts`, but have each handler call the implementation directly.
+- Move the log-file prompt used by `${command:AskForLogFileName}` resolution into `DebugConfigurationProvider`; read the selected file through the existing debug-configuration path.
+- Remove the superseded `extension.replay-debugger.getLogFileName` and `sf.launch.replay.debugger.logfile.path` registrations and activation events.
+- Update existing focused tests only where assertions encode the removed command hops.
+
+Commit: `refactor(apex-replay-debugger): collapse log-file command hops`
+
+## Skills to apply
+
+- `concise`: keep changes and plan language minimal.
+- `typescript`: preserve repository TypeScript conventions and typed command boundaries.
+- `effect-best-practices`: retain the existing Effect runtime and typed file-service flow.
+- `packageJson`: update activation events consistently with command registration changes.
+- `verification`: run focused checks and rely on repository readiness hooks for broad checks.
+
+## Verification
+
+1. Run ARD focused Jest tests: `npm test -w salesforcedx-vscode-apex-replay-debugger -- --runInBand`.
+2. Run duplicate detection: `npm run check:dupes`; inspect any report entries touching changed code.
+3. Verify command IDs removed from `package.json` have no remaining references and user-facing launch command IDs remain registered.
+4. Exercise existing ARD Playwright coverage for selected-log, current-log, last-log, and anonymous-Apex launch paths in CI.
+5. Confirm compile, lint, Effect diagnostics, bundle, knip, and tests pass through the repository stop hook.
+6. Inspect the final diff to confirm it contains one implementation approach, no fallback command dispatch, and no unrelated changes.

--- a/packages/salesforcedx-vscode-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/package.json
@@ -230,9 +230,8 @@
   },
   "activationEvents": [
     "onDebugResolve:apex",
-    "onCommand:extension.replay-debugger.getLogFileName",
+    "onDebugResolve:apex-replay",
     "onCommand:sf.launch.replay.debugger.logfile",
-    "onCommand:sf.launch.replay.debugger.logfile.path",
     "onCommand:sf.anon.apex.debug.delegate",
     "onCommand:sf.launch.apex.replay.debugger.with.current.file"
   ],
@@ -370,9 +369,6 @@
         "languages": [
           "apex"
         ],
-        "variables": {
-          "AskForLogFileName": "extension.replay-debugger.getLogFileName"
-        },
         "configurationSnippets": [
           {
             "label": "%launch_snippet_label_text%",

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/activation/getDialogStartingPath.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/activation/getDialogStartingPath.ts
@@ -8,8 +8,13 @@
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import * as Effect from 'effect/Effect';
 import * as vscode from 'vscode';
-import { URI } from 'vscode-uri';
-import { LAST_OPENED_LOG_FOLDER_KEY } from '../debuggerConstants';
+import { URI, Utils } from 'vscode-uri';
+import { LAST_OPENED_LOG_FOLDER_KEY, LAST_OPENED_LOG_KEY } from '../debuggerConstants';
+
+export const updateLastOpened = (extensionContext: vscode.ExtensionContext, logUri: URI) => {
+  extensionContext.workspaceState.update(LAST_OPENED_LOG_KEY, logUri.fsPath);
+  extensionContext.workspaceState.update(LAST_OPENED_LOG_FOLDER_KEY, Utils.dirname(logUri).fsPath);
+};
 
 export const getDialogStartingPath = Effect.fn('ApexReplayDebugger.getDialogStartingPath')(function* (
   extContext: vscode.ExtensionContext
@@ -17,8 +22,7 @@ export const getDialogStartingPath = Effect.fn('ApexReplayDebugger.getDialogStar
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const { isEmpty } = yield* api.services.WorkspaceService.getWorkspaceInfo();
   if (isEmpty) return undefined;
-  // If the user has already selected a document through getLogFileName then
-  // use that path if it still exists.
+  // If the user has already selected a log file, use that folder if it still exists.
   const pathToLastOpenedLogFolder = getLastOpenedLogFolder(extContext);
   if (pathToLastOpenedLogFolder && (yield* api.services.FsService.fileOrFolderExists(pathToLastOpenedLogFolder))) {
     return URI.file(pathToLastOpenedLogFolder);
@@ -27,7 +31,7 @@ export const getDialogStartingPath = Effect.fn('ApexReplayDebugger.getDialogStar
   // same directory that the SFDX download logs command would download to
   // if it exists.
   // The workspace folders are re-read on every ProjectService call, so they can go away between the isEmpty
-  // check above and these calls (this runs during activation). A closed workspace means "no starting path",
+  // check above and these calls. A closed workspace means "no starting path",
   // not a failed activation.
   const logsFolder = yield* api.services.ProjectService.getDebugLogsFolder().pipe(
     Effect.orElseSucceed(() => undefined)

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
@@ -9,15 +9,70 @@ import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import { extractAnonApexSource, type HeapDumpResult } from '@salesforce/salesforcedx-apex-replay-debugger';
 import { errorToString } from '@salesforce/salesforcedx-utils-vscode';
 import * as Effect from 'effect/Effect';
-import { isString, isUndefined } from 'effect/Predicate';
+import * as Option from 'effect/Option';
+import { isUndefined } from 'effect/Predicate';
+import * as Schema from 'effect/Schema';
 import type { ApexVSCodeApi } from 'salesforcedx-vscode-apex';
 import * as vscode from 'vscode';
+import { getDialogStartingPath, updateLastOpened } from '../activation/getDialogStartingPath';
 import { DEBUGGER_LAUNCH_TYPE, DEBUGGER_TYPE } from '../debuggerConstants';
 import { nls } from '../messages';
 import { fetchHeapDumpOverlayResults } from '../services/heapDumpOverlayFetch';
 import { getRuntime } from '../services/runtime';
 
+const LOG_FILE_PROMPT = '${command:AskForLogFileName}';
+
+class SelectedLogFileReadError extends Schema.TaggedError<SelectedLogFileReadError>()('SelectedLogFileReadError', {
+  message: Schema.String,
+  filePath: Schema.String,
+  cause: Schema.String
+}) {}
+
+type SelectedLogFile = {
+  readonly contents: string;
+  readonly path: string;
+  readonly name: string;
+};
+
+const selectLogFile = Effect.fn('ApexReplayDebugger.selectLogFile')(function* (
+  config: vscode.DebugConfiguration,
+  extensionContext: vscode.ExtensionContext
+) {
+  if ((config.logFile ?? LOG_FILE_PROMPT) !== LOG_FILE_PROMPT) return undefined;
+
+  const api = yield* (yield* ExtensionProviderService).getServicesApi;
+  const defaultUri = yield* getDialogStartingPath(extensionContext);
+  const fileUris = yield* Effect.promise(() =>
+    vscode.window.showOpenDialog({
+      canSelectFiles: true,
+      canSelectFolders: false,
+      canSelectMany: false,
+      defaultUri
+    })
+  );
+  if (fileUris?.length !== 1) return yield* new api.services.UserCancellationError();
+
+  const filePath = fileUris[0].fsPath;
+  yield* Effect.sync(() => updateLastOpened(extensionContext, fileUris[0]));
+  const contents = yield* api.services.FsService.readFile(filePath).pipe(
+    Effect.mapError(
+      cause =>
+        new SelectedLogFileReadError({
+          message: `Failed to read selected log file: ${errorToString(cause)}`,
+          filePath,
+          cause: errorToString(cause)
+        })
+    ),
+    Effect.tapError(error =>
+      Effect.logError('Failed to read selected log file', { filePath: error.filePath, cause: error.cause })
+    )
+  );
+  return { contents, path: filePath, name: getBasename(filePath) } satisfies SelectedLogFile;
+});
+
 export class DebugConfigurationProvider implements vscode.DebugConfigurationProvider {
+  constructor(private readonly extensionContext: vscode.ExtensionContext) {}
+
   private salesforceApexExtension = vscode.extensions.getExtension<ApexVSCodeApi>(
     'salesforce.salesforcedx-vscode-apex'
   );
@@ -31,7 +86,7 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
       name: nls.localize('config_name_text'),
       type: DEBUGGER_TYPE,
       request: DEBUGGER_LAUNCH_TYPE,
-      logFile: logFile ?? '${command:AskForLogFileName}',
+      logFile: logFile ?? LOG_FILE_PROMPT,
       stopOnEntry,
       trace: true,
       ...(anonApexFilePath ? { anonApexFilePath } : {}),
@@ -51,16 +106,26 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
     config: vscode.DebugConfiguration,
     _token?: vscode.CancellationToken
   ): vscode.ProviderResult<vscode.DebugConfiguration> {
-    return this.asyncDebugConfig(config).catch(async err =>
-      vscode.window.showErrorMessage(errorToString(err), { modal: true }).then(() => undefined)
-    );
+    return getRuntime()
+      .runPromise(
+        selectLogFile(config, this.extensionContext).pipe(
+          Effect.flatMap(selectedLogFile => Effect.promise(() => this.asyncDebugConfig(config, selectedLogFile))),
+          Effect.map(Option.fromNullable),
+          Effect.catchTag('UserCancellationError', () => Effect.succeed(Option.none<vscode.DebugConfiguration>())),
+          Effect.map(Option.getOrUndefined)
+        )
+      )
+      .catch(async err => vscode.window.showErrorMessage(errorToString(err), { modal: true }).then(() => undefined));
   }
 
-  private async asyncDebugConfig(config: vscode.DebugConfiguration): Promise<vscode.DebugConfiguration | undefined> {
+  private async asyncDebugConfig(
+    config: vscode.DebugConfiguration,
+    selectedLogFile: SelectedLogFile | undefined
+  ): Promise<vscode.DebugConfiguration | undefined> {
     config.name = config.name || nls.localize('config_name_text');
     config.type = config.type || DEBUGGER_TYPE;
     config.request = config.request || DEBUGGER_LAUNCH_TYPE;
-    config.logFile = config.logFile ?? '${command:AskForLogFileName}';
+    config.logFile = config.logFile ?? LOG_FILE_PROMPT;
     if (isUndefined(config.stopOnEntry)) {
       config.stopOnEntry = true;
     }
@@ -77,7 +142,7 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
     }
 
     // Handle log file reading for web compatibility
-    if (config.logFile && config.logFile !== '${command:AskForLogFileName}') {
+    if (config.logFile && config.logFile !== LOG_FILE_PROMPT) {
       // Direct file path provided
       try {
         config.logFileContents = await getRuntime().runPromise(readLogFile(config.logFile));
@@ -91,23 +156,12 @@ export class DebugConfigurationProvider implements vscode.DebugConfigurationProv
         // paste Effect's multi-line pretty-printed cause (with stack) into the modal dialog.
         throw new Error(`Failed to read log file: ${errorToString(error)}`);
       }
-    } else if (config.logFile === '${command:AskForLogFileName}') {
-      // User needs to select a file
-      try {
-        const logFilePath = await vscode.commands.executeCommand('extension.replay-debugger.getLogFileName');
-        if (logFilePath && isString(logFilePath)) {
-          config.logFileContents = await getRuntime().runPromise(readLogFile(logFilePath));
-          config.logFilePath = logFilePath;
-          config.logFileName = getBasename(logFilePath);
-          // Remove logFile since we're now using logFileContents
-          delete config.logFile;
-        } else {
-          throw new Error('No log file selected');
-        }
-      } catch (error) {
-        console.error('Failed to read selected log file:', error);
-        throw new Error(`Failed to read selected log file: ${errorToString(error)}`);
-      }
+    } else if (selectedLogFile) {
+      config.logFileContents = selectedLogFile.contents;
+      config.logFilePath = selectedLogFile.path;
+      config.logFileName = selectedLogFile.name;
+      // Remove logFile since we're now using logFileContents
+      delete config.logFile;
     }
 
     if (typeof config.logFileContents !== 'string') {

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
@@ -11,7 +11,6 @@ import { errorToString } from '@salesforce/salesforcedx-utils-vscode';
 import * as Effect from 'effect/Effect';
 import * as Option from 'effect/Option';
 import { isUndefined } from 'effect/Predicate';
-import * as Schema from 'effect/Schema';
 import type { ApexVSCodeApi } from 'salesforcedx-vscode-apex';
 import * as vscode from 'vscode';
 import { getDialogStartingPath, updateLastOpened } from '../activation/getDialogStartingPath';
@@ -21,12 +20,6 @@ import { fetchHeapDumpOverlayResults } from '../services/heapDumpOverlayFetch';
 import { getRuntime } from '../services/runtime';
 
 const LOG_FILE_PROMPT = '${command:AskForLogFileName}';
-
-class SelectedLogFileReadError extends Schema.TaggedError<SelectedLogFileReadError>()('SelectedLogFileReadError', {
-  message: Schema.String,
-  filePath: Schema.String,
-  cause: Schema.String
-}) {}
 
 type SelectedLogFile = {
   readonly contents: string;
@@ -55,17 +48,7 @@ const selectLogFile = Effect.fn('ApexReplayDebugger.selectLogFile')(function* (
   const filePath = fileUris[0].fsPath;
   yield* Effect.sync(() => updateLastOpened(extensionContext, fileUris[0]));
   const contents = yield* api.services.FsService.readFile(filePath).pipe(
-    Effect.mapError(
-      cause =>
-        new SelectedLogFileReadError({
-          message: `Failed to read selected log file: ${errorToString(cause)}`,
-          filePath,
-          cause: errorToString(cause)
-        })
-    ),
-    Effect.tapError(error =>
-      Effect.logError('Failed to read selected log file', { filePath: error.filePath, cause: error.cause })
-    )
+    Effect.tapError(error => Effect.logError('Failed to read selected log file', error))
   );
   return { contents, path: filePath, name: getBasename(filePath) } satisfies SelectedLogFile;
 });

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/adapter/debugConfigurationProvider.ts
@@ -48,7 +48,9 @@ const selectLogFile = Effect.fn('ApexReplayDebugger.selectLogFile')(function* (
   const filePath = fileUris[0].fsPath;
   yield* Effect.sync(() => updateLastOpened(extensionContext, fileUris[0]));
   const contents = yield* api.services.FsService.readFile(filePath).pipe(
-    Effect.tapError(error => Effect.logError('Failed to read selected log file', error))
+    Effect.tapError(error =>
+      Effect.logError('Failed to read selected log file', { filePath: error.filePath, cause: error.message })
+    )
   );
   return { contents, path: filePath, name: getBasename(filePath) } satisfies SelectedLogFile;
 });

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/anonApexDebug.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/anonApexDebug.ts
@@ -12,6 +12,7 @@ import { URI, Utils } from 'vscode-uri';
 import { nls } from '../messages';
 import { getRuntime } from '../services/runtime';
 import { type ProgressAndSuccessCommandKey } from '../utils/notificationMode';
+import { launchFromLogFile } from './launchFromLogFile';
 
 export const makeDoubleDigit = (currentDigit: number): string => format('%d', currentDigit).padStart(2, '0');
 
@@ -35,14 +36,7 @@ const launchReplayDebugger = Effect.fn('ApexReplayDebugger.launchReplayDebugger'
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   if (!logs) return false;
   yield* api.services.FsService.safeWriteFile(logFilePath, logs);
-  yield* Effect.promise(() =>
-    vscode.commands.executeCommand(
-      'sf.launch.replay.debugger.logfile.path',
-      logFilePath.fsPath,
-      anonApexFilePath,
-      anonApexLineOffset
-    )
-  );
+  yield* Effect.promise(() => launchFromLogFile(logFilePath.fsPath, true, anonApexFilePath, anonApexLineOffset));
   return true;
 });
 

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/launchApexReplayDebuggerWithCurrentFile.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/commands/launchApexReplayDebuggerWithCurrentFile.ts
@@ -8,9 +8,11 @@ import { sfProjectPreconditionChecker } from '@salesforce/effect-ext-utils';
 import { basename } from 'node:path';
 import * as vscode from 'vscode';
 import { URI, Utils } from 'vscode-uri';
+import { updateLastOpened } from '../activation/getDialogStartingPath';
 import { nls } from '../messages';
+import { launchFromLogFile } from './launchFromLogFile';
 
-export const launchApexReplayDebuggerWithCurrentFile = async () => {
+export const launchApexReplayDebuggerWithCurrentFile = async (extensionContext: vscode.ExtensionContext) => {
   const editor = vscode.window.activeTextEditor;
   if (!editor) {
     void vscode.window.showErrorMessage(nls.localize('unable_to_locate_editor'));
@@ -24,7 +26,8 @@ export const launchApexReplayDebuggerWithCurrentFile = async () => {
   }
 
   if (isLogFile(sourceUri)) {
-    await launchReplayDebuggerLogFile(sourceUri);
+    updateLastOpened(extensionContext, sourceUri);
+    await launchFromLogFile(sourceUri.fsPath);
     return;
   }
 
@@ -45,12 +48,6 @@ export const launchApexReplayDebuggerWithCurrentFile = async () => {
 const isLogFile = (sourceUri: URI): boolean => Utils.extname(sourceUri).toLowerCase() === '.log';
 
 const isAnonymousApexFile = (sourceUri: URI): boolean => Utils.extname(sourceUri).toLowerCase() === '.apex';
-
-const launchReplayDebuggerLogFile = async (sourceUri: URI) => {
-  await vscode.commands.executeCommand('sf.launch.replay.debugger.logfile', {
-    fsPath: sourceUri.fsPath
-  });
-};
 
 const IS_TEST_REG_EXP = /@isTest/i;
 

--- a/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/src/index.ts
@@ -16,10 +16,9 @@ import {
 } from '@salesforce/salesforcedx-apex-replay-debugger';
 import { TelemetryService } from '@salesforce/salesforcedx-utils-vscode';
 import * as Effect from 'effect/Effect';
-import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { URI } from 'vscode-uri';
-import { getDialogStartingPath } from './activation/getDialogStartingPath';
+import { updateLastOpened } from './activation/getDialogStartingPath';
 import { DebugConfigurationProvider } from './adapter/debugConfigurationProvider';
 import { salesforceApexExtension } from './apexExtension';
 import {
@@ -35,7 +34,6 @@ import { launchFromLogFile } from './commands/launchFromLogFile';
 import { setupAndDebugTests } from './commands/quickLaunch';
 import {
   DEBUGGER_TYPE,
-  LAST_OPENED_LOG_FOLDER_KEY,
   LAST_OPENED_LOG_KEY,
   LIVESHARE_DEBUG_TYPE_REQUEST,
   LIVESHARE_DEBUGGER_TYPE
@@ -47,38 +45,16 @@ import { disposeRuntime, getRuntime } from './services/runtime';
 export { retrieveLineBreakpointInfo } from './apexExtension';
 export { writeToDebuggerOutputWindow } from './channels';
 
-const registerCommands = async (extensionContext: vscode.ExtensionContext): Promise<vscode.Disposable> => {
-  const dialogStartingPathUri = await getRuntime().runPromise(getDialogStartingPath(extensionContext));
-  const promptForLogCmd = vscode.commands.registerCommand('extension.replay-debugger.getLogFileName', async () => {
-    const fileUris: URI[] | undefined = await vscode.window.showOpenDialog({
-      canSelectFiles: true,
-      canSelectFolders: false,
-      canSelectMany: false,
-      defaultUri: dialogStartingPathUri
-    });
-    if (fileUris?.length === 1) {
-      updateLastOpened(extensionContext, fileUris[0].fsPath);
-      return fileUris[0].fsPath;
-    }
-  });
+const registerCommands = (extensionContext: vscode.ExtensionContext): vscode.Disposable => {
   const launchFromLogFileCmd = vscode.commands.registerCommand(
     'sf.launch.replay.debugger.logfile',
     async (editorUri: URI) => {
       const resolved = editorUri ?? vscode.window.activeTextEditor?.document.uri;
 
       if (resolved) {
-        updateLastOpened(extensionContext, resolved.fsPath);
+        updateLastOpened(extensionContext, resolved);
       }
       await launchFromLogFile(resolved?.fsPath);
-    }
-  );
-
-  const launchFromLogFilePathCmd = vscode.commands.registerCommand(
-    'sf.launch.replay.debugger.logfile.path',
-    async (logFilePath, anonApexFilePath?: string, anonApexLineOffset?: number) => {
-      if (logFilePath) {
-        await launchFromLogFile(logFilePath, true, anonApexFilePath, anonApexLineOffset);
-      }
     }
   );
 
@@ -97,24 +73,17 @@ const registerCommands = async (extensionContext: vscode.ExtensionContext): Prom
 
   const launchApexReplayDebuggerWithCurrentFileCmd = vscode.commands.registerCommand(
     'sf.launch.apex.replay.debugger.with.current.file',
-    launchApexReplayDebuggerWithCurrentFile
+    () => launchApexReplayDebuggerWithCurrentFile(extensionContext)
   );
 
   return vscode.Disposable.from(
-    promptForLogCmd,
     launchFromLogFileCmd,
-    launchFromLogFilePathCmd,
     launchFromLastLogFileCmd,
     sfCreateCheckpointsCmd,
     sfToggleCheckpointCmd,
     anonApexDebugDelegateCmd,
     launchApexReplayDebuggerWithCurrentFileCmd
   );
-};
-
-export const updateLastOpened = (extensionContext: vscode.ExtensionContext, logPath: string) => {
-  extensionContext.workspaceState.update(LAST_OPENED_LOG_KEY, logPath);
-  extensionContext.workspaceState.update(LAST_OPENED_LOG_FOLDER_KEY, path.dirname(logPath));
 };
 
 export const getDebuggerType = async (session: vscode.DebugSession): Promise<string> => {
@@ -167,11 +136,11 @@ export const activate = async (extensionContext: vscode.ExtensionContext) => {
 export const activateEffect = Effect.fn('activation:salesforcedx-vscode-apex-replay-debugger')(function* (
   extensionContext: vscode.ExtensionContext
 ) {
-  const commands = yield* Effect.promise(() => registerCommands(extensionContext));
+  const commands = registerCommands(extensionContext);
   const debugHandlers = registerDebugHandlers();
   const debugConfigProvider = vscode.debug.registerDebugConfigurationProvider(
     'apex-replay',
-    new DebugConfigurationProvider()
+    new DebugConfigurationProvider(extensionContext)
   );
   // Resolve the services channel eagerly: it is created on first resolution, so without this
   // 'Apex Replay Debugger' is missing from the Output dropdown until the first debugger write.

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/jest/adapter/debugConfigurationProvider.test.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/jest/adapter/debugConfigurationProvider.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+import { UserCancellationError } from 'salesforcedx-vscode-services/src/vscode/prompts/promptService';
+import * as vscode from 'vscode';
+import { URI } from 'vscode-uri';
+import { DebugConfigurationProvider } from '../../../src/adapter/debugConfigurationProvider';
+import { LAST_OPENED_LOG_FOLDER_KEY, LAST_OPENED_LOG_KEY } from '../../../src/debuggerConstants';
+import { buildAllServicesLayer, setAllServicesLayer } from '../../../src/services/extensionProvider';
+import { disposeRuntime } from '../../../src/services/runtime';
+
+describe('DebugConfigurationProvider log-file prompt', () => {
+  const readFile = jest.fn();
+  const workspaceStateUpdate = jest.fn();
+  const extensionContext = {
+    workspaceState: { update: workspaceStateUpdate }
+  } as unknown as vscode.ExtensionContext;
+
+  beforeEach(() => {
+    readFile.mockReturnValue(Effect.succeed('64.0 APEX_CODE,FINEST\n12:00:00.0|USER_INFO|[EXTERNAL]|005'));
+    workspaceStateUpdate.mockResolvedValue(undefined);
+    (vscode.window as unknown as { showOpenDialog: jest.Mock }).showOpenDialog = jest.fn();
+    (vscode.window.showErrorMessage as jest.Mock).mockResolvedValue(undefined);
+    (vscode.extensions.getExtension as jest.Mock).mockReturnValue(undefined);
+    setAllServicesLayer(
+      Layer.succeed(ExtensionProviderService, {
+        getServicesApi: Effect.succeed({
+          services: {
+            FsService: { readFile },
+            UserCancellationError,
+            WorkspaceService: { getWorkspaceInfo: () => Effect.succeed({ isEmpty: true }) }
+          }
+        })
+      } as unknown as ExtensionProviderService) as ReturnType<typeof buildAllServicesLayer>
+    );
+  });
+
+  afterEach(disposeRuntime);
+
+  it('reads and remembers the selected log file', async () => {
+    const selectedLog = URI.file('/logs/selected.log');
+    (vscode.window.showOpenDialog as jest.Mock).mockResolvedValue([selectedLog]);
+
+    const resolved = await new DebugConfigurationProvider(extensionContext).resolveDebugConfiguration(undefined, {
+      name: 'Prompt for log',
+      type: 'apex-replay',
+      request: 'launch',
+      logFile: '${command:AskForLogFileName}'
+    });
+
+    expect(resolved).toMatchObject({
+      logFileContents: '64.0 APEX_CODE,FINEST\n12:00:00.0|USER_INFO|[EXTERNAL]|005',
+      logFilePath: selectedLog.fsPath,
+      logFileName: 'selected.log'
+    });
+    expect(resolved).not.toHaveProperty('logFile');
+    expect(workspaceStateUpdate).toHaveBeenCalledWith(LAST_OPENED_LOG_KEY, selectedLog.fsPath);
+    expect(workspaceStateUpdate).toHaveBeenCalledWith(LAST_OPENED_LOG_FOLDER_KEY, '/logs');
+  });
+
+  it('silently cancels when no log file is selected', async () => {
+    (vscode.window.showOpenDialog as jest.Mock).mockResolvedValue(undefined);
+
+    const resolved = await new DebugConfigurationProvider(extensionContext).resolveDebugConfiguration(undefined, {
+      name: 'Prompt for log',
+      type: 'apex-replay',
+      request: 'launch',
+      logFile: '${command:AskForLogFileName}'
+    });
+
+    expect(resolved).toBeUndefined();
+    expect(readFile).not.toHaveBeenCalled();
+    expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+  });
+});

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/jest/adapter/debugConfigurationProvider.test.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/jest/adapter/debugConfigurationProvider.test.ts
@@ -62,7 +62,7 @@ describe('DebugConfigurationProvider log-file prompt', () => {
     });
     expect(resolved).not.toHaveProperty('logFile');
     expect(workspaceStateUpdate).toHaveBeenCalledWith(LAST_OPENED_LOG_KEY, selectedLog.fsPath);
-    expect(workspaceStateUpdate).toHaveBeenCalledWith(LAST_OPENED_LOG_FOLDER_KEY, '/logs');
+    expect(workspaceStateUpdate).toHaveBeenCalledWith(LAST_OPENED_LOG_FOLDER_KEY, URI.file('/logs').fsPath);
   });
 
   it('silently cancels when no log file is selected', async () => {

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/promptForLogFile.desktop.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/promptForLogFile.desktop.spec.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from '@playwright/test';
+import { QUICK_INPUT_WIDGET, setupMinimalOrgAndAuth } from '@salesforce/playwright-vscode-ext';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { test } from '../fixtures';
+
+test('an apex-replay launch activates the extension and prompts for a log file', async ({ page, workspaceDir }) => {
+  test.setTimeout(300_000);
+  await setupMinimalOrgAndAuth(page);
+
+  const vscodeDirectory = path.join(workspaceDir, '.vscode');
+  await fs.mkdir(vscodeDirectory, { recursive: true });
+  await fs.writeFile(
+    path.join(vscodeDirectory, 'launch.json'),
+    JSON.stringify({
+      version: '0.2.0',
+      configurations: [
+        {
+          name: 'Prompt for Apex Replay Debug Log',
+          type: 'apex-replay',
+          request: 'launch',
+          logFile: '${command:AskForLogFileName}',
+          stopOnEntry: true,
+          trace: true
+        }
+      ]
+    })
+  );
+
+  await page.keyboard.press('F5');
+
+  const filePicker = page.locator(QUICK_INPUT_WIDGET);
+  await expect(filePicker).toBeVisible({ timeout: 30_000 });
+  await expect(filePicker.getByRole('textbox', { name: 'Folder path' })).toBeVisible();
+  await expect(filePicker.getByRole('button', { name: 'OK' })).toBeVisible();
+  await page.keyboard.press('Escape');
+});


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-23711394@

### What changed and why

- Replaced internal VS Code command dispatch with direct `launchFromLogFile` calls for anonymous Apex and current-file launches.
- Kept the user-facing log-file launch and last-log-file commands.
- Removed the obsolete `getLogFileName` and `logfile.path` registrations and activation events.
- Moved `${command:AskForLogFileName}` handling into `DebugConfigurationProvider`, including prompting, reading the selected file through `FsService`, remembering the selection, and handling cancellation.
- Added focused unit tests and Playwright coverage for log-file prompting.

This reduces command indirection and keeps debug configuration resolution responsible for obtaining and preparing the log file while preserving existing launch behavior.

Verification:
- Apex Replay Debugger Jest suite: 24 tests passed
- TypeScript compilation passed
- ESLint: 0 errors, warnings only
- Confirmed removed command IDs have no remaining references and user-facing command IDs remain registered
