### PR TITLE
chore: 3.1 Fan out parallel Playwright-install setup to 6 org-using E2E workflows - W-23195715

### DIFF
--- a/.claude/plans/W-23195715.md
+++ b/.claude/plans/W-23195715.md
@@ -1,0 +1,28 @@
+# W-23195715
+
+## Context
+
+Fan out Playwright browser installation in 6 org-using E2E workflows so it runs concurrently with independent scratch-org setup, reducing setup duration while preserving retry and failure behavior.
+
+Files:
+
+- `.github/workflows/apexLogE2E.yml`
+- `.github/workflows/apexTestingE2E.yml`
+- `.github/workflows/coreE2E.yml`
+- `.github/workflows/orgE2E.yml`
+- `.github/workflows/servicesE2E.yml`
+- `.github/workflows/soqlE2E.yml`
+
+## Phases
+
+1. Replace each separate retry-action Playwright install step with the existing retry-wrapped background installation pattern; run the workflow's independent project, authentication, and scratch-org setup while installation proceeds; wait for installation and propagate failure before starting tests. Commit: `chore: 3.1 Fan out Playwright install across org E2E setup - W-23195715`
+
+## Skills to apply
+
+- `playwright-e2e`: preserve E2E setup, retry, and test-run behavior.
+- `verification`: validate changed GitHub Actions workflows.
+
+## Verification
+
+- Run `npm run check:actions` from the repository root.
+- Review all 6 workflow diffs to confirm Playwright installation completes successfully before tests and any background failure fails setup.

--- a/.github/workflows/apexLogE2E.yml
+++ b/.github/workflows/apexLogE2E.yml
@@ -91,34 +91,46 @@ jobs:
           command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
-      - name: Auth to dev hub (global)
-        if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: bash -c 'echo "$SFDX_AUTH_URL" | sf org login sfdx-url
-            --set-default-dev-hub --alias hub --sfdx-url-stdin'
-          retry_wait_seconds: 30
-
-      - name: Install Playwright browsers and OS deps
-        if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
-
-      - name: Generate minimal project
-        if: steps.try-run.outcome == 'failure'
-        shell: bash
-        run: sf project generate -n minimal-project
-
-      - name: Create scratch org
+      - name: Install Playwright and create scratch org
         if: steps.try-run.outcome == 'failure'
         shell: bash
         run: |
-          sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$MINIMAL_ORG_ALIAS" --json --wait 30
-        working-directory: minimal-project
+          retry() {
+            local retry_wait_seconds=$1
+            local attempt command_pid timeout_pid
+            shift
+            for attempt in 1 2 3; do
+              "$@" &
+              command_pid=$!
+              (sleep 3600; kill -KILL "$command_pid" 2>/dev/null) &
+              timeout_pid=$!
+              if wait "$command_pid"; then
+                kill "$timeout_pid" 2>/dev/null || true
+                wait "$timeout_pid" 2>/dev/null || true
+                return 0
+              fi
+              kill "$timeout_pid" 2>/dev/null || true
+              wait "$timeout_pid" 2>/dev/null || true
+              if [ "$attempt" -lt 3 ]; then sleep "$retry_wait_seconds"; fi
+            done
+            return 1
+          }
+
+          retry 60 npx playwright install chromium --with-deps &
+          playwright_pid=$!
+
+          (
+            sf project generate -n minimal-project
+            retry 30 bash -c 'echo "$SFDX_AUTH_URL" | sf org login sfdx-url --set-default-dev-hub --alias hub --sfdx-url-stdin'
+            cd minimal-project
+            sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$MINIMAL_ORG_ALIAS" --json --wait 30
+          ) &
+          scratch_org_setup_pid=$!
+
+          failed=0
+          wait "$playwright_pid" || failed=1
+          wait "$scratch_org_setup_pid" || failed=1
+          exit "$failed"
 
       # Apex-log tests mutate TraceFlag/DebugLevel org-wide; wireit test:web sets PLAYWRIGHT_WORKERS.
       - name: Run Apex Log E2E tests
@@ -223,34 +235,46 @@ jobs:
           command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
-      - name: Auth to dev hub (global)
-        if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: bash -c 'echo "$SFDX_AUTH_URL" | sf org login sfdx-url
-            --set-default-dev-hub --alias hub --sfdx-url-stdin'
-          retry_wait_seconds: 30
-
-      - name: Install Playwright browsers and OS deps
-        if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
-
-      - name: Generate minimal project
-        if: steps.try-run.outcome == 'failure'
-        shell: bash
-        run: sf project generate -n minimal-project
-
-      - name: Create scratch org
+      - name: Install Playwright and create scratch org
         if: steps.try-run.outcome == 'failure'
         shell: bash
         run: |
-          sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$MINIMAL_ORG_ALIAS" --json --wait 30
-        working-directory: minimal-project
+          retry() {
+            local retry_wait_seconds=$1
+            local attempt command_pid timeout_pid
+            shift
+            for attempt in 1 2 3; do
+              "$@" &
+              command_pid=$!
+              (sleep 3600; kill -KILL "$command_pid" 2>/dev/null) &
+              timeout_pid=$!
+              if wait "$command_pid"; then
+                kill "$timeout_pid" 2>/dev/null || true
+                wait "$timeout_pid" 2>/dev/null || true
+                return 0
+              fi
+              kill "$timeout_pid" 2>/dev/null || true
+              wait "$timeout_pid" 2>/dev/null || true
+              if [ "$attempt" -lt 3 ]; then sleep "$retry_wait_seconds"; fi
+            done
+            return 1
+          }
+
+          retry 60 npx playwright install chromium --with-deps &
+          playwright_pid=$!
+
+          (
+            sf project generate -n minimal-project
+            retry 30 bash -c 'echo "$SFDX_AUTH_URL" | sf org login sfdx-url --set-default-dev-hub --alias hub --sfdx-url-stdin'
+            cd minimal-project
+            sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$MINIMAL_ORG_ALIAS" --json --wait 30
+          ) &
+          scratch_org_setup_pid=$!
+
+          failed=0
+          wait "$playwright_pid" || failed=1
+          wait "$scratch_org_setup_pid" || failed=1
+          exit "$failed"
 
       # Apex-log tests mutate TraceFlag/DebugLevel org-wide; wireit test:desktop sets PLAYWRIGHT_WORKERS.
       - name: Run Apex Log E2E tests

--- a/.github/workflows/apexTestingE2E.yml
+++ b/.github/workflows/apexTestingE2E.yml
@@ -98,41 +98,47 @@ jobs:
           command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
-      - name: Auth to dev hub (global)
-        if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: bash -c 'echo "$SFDX_AUTH_URL" | sf org login sfdx-url
-            --set-default-dev-hub --alias hub --sfdx-url-stdin'
-          retry_wait_seconds: 30
-
-      - name: Install Playwright browsers and OS deps
-        if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
-
-      - name: Generate non-tracking project
-        if: steps.try-run.outcome == 'failure'
-        shell: bash
-        run: sf project generate -n non-tracking-project
-
-      - name: Create scratch org
+      - name: Install Playwright and create scratch orgs
         if: steps.try-run.outcome == 'failure'
         shell: bash
         run: |
-          sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$NON_TRACKING_ORG_ALIAS" --json --wait 30 --no-track-source
-        working-directory: non-tracking-project
+          retry() {
+            local retry_wait_seconds=$1
+            local attempt command_pid timeout_pid
+            shift
+            for attempt in 1 2 3; do
+              "$@" &
+              command_pid=$!
+              (sleep 3600; kill -KILL "$command_pid" 2>/dev/null) &
+              timeout_pid=$!
+              if wait "$command_pid"; then
+                kill "$timeout_pid" 2>/dev/null || true
+                wait "$timeout_pid" 2>/dev/null || true
+                return 0
+              fi
+              kill "$timeout_pid" 2>/dev/null || true
+              wait "$timeout_pid" 2>/dev/null || true
+              if [ "$attempt" -lt 3 ]; then sleep "$retry_wait_seconds"; fi
+            done
+            return 1
+          }
 
-      - name: Create minimal scratch org
-        if: steps.try-run.outcome == 'failure'
-        shell: bash
-        run: |
-          sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$MINIMAL_ORG_ALIAS" --json --wait 30
-        working-directory: non-tracking-project
+          retry 60 npx playwright install chromium --with-deps &
+          playwright_pid=$!
+
+          (
+            sf project generate -n non-tracking-project
+            retry 30 bash -c 'echo "$SFDX_AUTH_URL" | sf org login sfdx-url --set-default-dev-hub --alias hub --sfdx-url-stdin'
+            cd non-tracking-project
+            sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$NON_TRACKING_ORG_ALIAS" --json --wait 30 --no-track-source
+            sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$MINIMAL_ORG_ALIAS" --json --wait 30
+          ) &
+          scratch_org_setup_pid=$!
+
+          failed=0
+          wait "$playwright_pid" || failed=1
+          wait "$scratch_org_setup_pid" || failed=1
+          exit "$failed"
 
       - name: Run Apex Testing E2E tests (parallel)
         if: steps.try-run.outcome == 'failure'
@@ -280,41 +286,47 @@ jobs:
           command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
-      - name: Auth to dev hub (global)
-        if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: bash -c 'echo "$SFDX_AUTH_URL" | sf org login sfdx-url
-            --set-default-dev-hub --alias hub --sfdx-url-stdin'
-          retry_wait_seconds: 30
-
-      - name: Install Playwright browsers and OS deps
-        if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
-
-      - name: Generate non-tracking project
-        if: steps.try-run.outcome == 'failure'
-        shell: bash
-        run: sf project generate -n non-tracking-project
-
-      - name: Create scratch org
+      - name: Install Playwright and create scratch orgs
         if: steps.try-run.outcome == 'failure'
         shell: bash
         run: |
-          sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$NON_TRACKING_ORG_ALIAS" --json --wait 30 --no-track-source
-        working-directory: non-tracking-project
+          retry() {
+            local retry_wait_seconds=$1
+            local attempt command_pid timeout_pid
+            shift
+            for attempt in 1 2 3; do
+              "$@" &
+              command_pid=$!
+              (sleep 3600; kill -KILL "$command_pid" 2>/dev/null) &
+              timeout_pid=$!
+              if wait "$command_pid"; then
+                kill "$timeout_pid" 2>/dev/null || true
+                wait "$timeout_pid" 2>/dev/null || true
+                return 0
+              fi
+              kill "$timeout_pid" 2>/dev/null || true
+              wait "$timeout_pid" 2>/dev/null || true
+              if [ "$attempt" -lt 3 ]; then sleep "$retry_wait_seconds"; fi
+            done
+            return 1
+          }
 
-      - name: Create minimal scratch org
-        if: steps.try-run.outcome == 'failure'
-        shell: bash
-        run: |
-          sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$MINIMAL_ORG_ALIAS" --json --wait 30
-        working-directory: non-tracking-project
+          retry 60 npx playwright install chromium --with-deps &
+          playwright_pid=$!
+
+          (
+            sf project generate -n non-tracking-project
+            retry 30 bash -c 'echo "$SFDX_AUTH_URL" | sf org login sfdx-url --set-default-dev-hub --alias hub --sfdx-url-stdin'
+            cd non-tracking-project
+            sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$NON_TRACKING_ORG_ALIAS" --json --wait 30 --no-track-source
+            sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$MINIMAL_ORG_ALIAS" --json --wait 30
+          ) &
+          scratch_org_setup_pid=$!
+
+          failed=0
+          wait "$playwright_pid" || failed=1
+          wait "$scratch_org_setup_pid" || failed=1
+          exit "$failed"
 
       - name: Run Apex Testing E2E tests (parallel)
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/coreE2E.yml
+++ b/.github/workflows/coreE2E.yml
@@ -105,35 +105,47 @@ jobs:
           command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
-      - name: Auth to dev hub (global)
-        if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: bash -c 'echo "$SFDX_AUTH_URL" | sf org login sfdx-url
-            --set-default-dev-hub --alias hub --sfdx-url-stdin'
-          retry_wait_seconds: 30
-
-      - name: Install Playwright browsers and OS deps
-        if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
-
-      - name: Generate minimal project
-        if: steps.try-run.outcome == 'failure'
-        shell: bash
-        run: sf project generate -n minimal-project
-
-      - name: create scratch org
+      - name: Install Playwright and create scratch org
         if: steps.try-run.outcome == 'failure'
         # the tests expect a scratch org with a certain alias but don't use the directory directly
         shell: bash
         run: |
-          sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$MINIMAL_ORG_ALIAS" --json --wait 30
-        working-directory: minimal-project
+          retry() {
+            local retry_wait_seconds=$1
+            local attempt command_pid timeout_pid
+            shift
+            for attempt in 1 2 3; do
+              "$@" &
+              command_pid=$!
+              (sleep 3600; kill -KILL "$command_pid" 2>/dev/null) &
+              timeout_pid=$!
+              if wait "$command_pid"; then
+                kill "$timeout_pid" 2>/dev/null || true
+                wait "$timeout_pid" 2>/dev/null || true
+                return 0
+              fi
+              kill "$timeout_pid" 2>/dev/null || true
+              wait "$timeout_pid" 2>/dev/null || true
+              if [ "$attempt" -lt 3 ]; then sleep "$retry_wait_seconds"; fi
+            done
+            return 1
+          }
+
+          retry 60 npx playwright install chromium --with-deps &
+          playwright_pid=$!
+
+          (
+            sf project generate -n minimal-project
+            retry 30 bash -c 'echo "$SFDX_AUTH_URL" | sf org login sfdx-url --set-default-dev-hub --alias hub --sfdx-url-stdin'
+            cd minimal-project
+            sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$MINIMAL_ORG_ALIAS" --json --wait 30
+          ) &
+          scratch_org_setup_pid=$!
+
+          failed=0
+          wait "$playwright_pid" || failed=1
+          wait "$scratch_org_setup_pid" || failed=1
+          exit "$failed"
 
       - name: Run Core E2E tests (parallel)
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/orgE2E.yml
+++ b/.github/workflows/orgE2E.yml
@@ -107,53 +107,49 @@ jobs:
           command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
-      - name: Generate minimal project
+      - name: Install Playwright and create scratch orgs
         if: steps.try-run.outcome == 'failure'
-        shell: bash
-        run: sf project generate -n minimal-project
-
-      - name: Auth to dev hub (global)
-        if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: bash -c 'echo "$SFDX_AUTH_URL" | sf org login sfdx-url
-            --set-default-dev-hub --alias hub --sfdx-url-stdin'
-          retry_wait_seconds: 30
-
-      - name: create scratch org
-        if: steps.try-run.outcome == 'failure'
-        # the tests expect a scratch org with a certain alias but don't use the directory directly
         shell: bash
         run: |
-          sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$MINIMAL_ORG_ALIAS" --json
-        working-directory: minimal-project
+          retry() {
+            local retry_wait_seconds=$1
+            local attempt command_pid timeout_pid
+            shift
+            for attempt in 1 2 3; do
+              "$@" &
+              command_pid=$!
+              (sleep 3600; kill -KILL "$command_pid" 2>/dev/null) &
+              timeout_pid=$!
+              if wait "$command_pid"; then
+                kill "$timeout_pid" 2>/dev/null || true
+                wait "$timeout_pid" 2>/dev/null || true
+                return 0
+              fi
+              kill "$timeout_pid" 2>/dev/null || true
+              wait "$timeout_pid" 2>/dev/null || true
+              if [ "$attempt" -lt 3 ]; then sleep "$retry_wait_seconds"; fi
+            done
+            return 1
+          }
 
-      - name: create throwaway logout scratch org
-        if: steps.try-run.outcome == 'failure'
-        # pre-seeds THROWAWAY_ORG_ALIAS so the real-logout step's createThrowawayOrg fast-paths
-        # (tryUseExistingOrg hit) instead of tripping requireOrgInCI. This org is logged out by the test.
-        shell: bash
-        run: |
-          sf org create scratch -y 1 -f config/project-scratch-def.json -a "$THROWAWAY_ORG_ALIAS" --json
-        working-directory: minimal-project
+          retry 60 npx playwright install chromium --with-deps &
+          playwright_pid=$!
 
-      - name: create default-logout throwaway scratch org
-        if: steps.try-run.outcome == 'failure'
-        # pre-seeds DEFAULT_LOGOUT_ORG_ALIAS so the logout.default step's createThrowawayOrg fast-paths.
-        # This org is set as default and logged out by the test.
-        shell: bash
-        run: |
-          sf org create scratch -y 1 -f config/project-scratch-def.json -a "$DEFAULT_LOGOUT_ORG_ALIAS" --json
-        working-directory: minimal-project
+          (
+            sf project generate -n minimal-project
+            retry 30 bash -c 'echo "$SFDX_AUTH_URL" | sf org login sfdx-url --set-default-dev-hub --alias hub --sfdx-url-stdin'
+            cd minimal-project
+            sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$MINIMAL_ORG_ALIAS" --json
+            # Pre-seed both aliases so the logout tests use these orgs instead of creating orgs in CI.
+            sf org create scratch -y 1 -f config/project-scratch-def.json -a "$THROWAWAY_ORG_ALIAS" --json
+            sf org create scratch -y 1 -f config/project-scratch-def.json -a "$DEFAULT_LOGOUT_ORG_ALIAS" --json
+          ) &
+          scratch_org_setup_pid=$!
 
-      - name: Install Playwright browsers and OS deps
-        if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
+          failed=0
+          wait "$playwright_pid" || failed=1
+          wait "$scratch_org_setup_pid" || failed=1
+          exit "$failed"
 
       - name: Run Org E2E tests (parallel)
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/servicesE2E.yml
+++ b/.github/workflows/servicesE2E.yml
@@ -90,35 +90,47 @@ jobs:
           command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
-      - name: Install Playwright browsers and OS deps
-        if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
-
-      - name: Generate minimal project
-        if: steps.try-run.outcome == 'failure'
-        shell: bash
-        run: sf project generate -n minimal-project
-
-      - name: Auth to dev hub (global)
-        if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: bash -c 'echo "$SFDX_AUTH_URL" | sf org login sfdx-url
-            --set-default-dev-hub --alias hub --sfdx-url-stdin'
-          retry_wait_seconds: 30
-
-      - name: create scratch org
+      - name: Install Playwright and create scratch org
         if: steps.try-run.outcome == 'failure'
         # the tests expect a scratch org with a certain alias but don't use the directory directly
         shell: bash
         run: |
-          sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$MINIMAL_ORG_ALIAS" --json
-        working-directory: minimal-project
+          retry() {
+            local retry_wait_seconds=$1
+            local attempt command_pid timeout_pid
+            shift
+            for attempt in 1 2 3; do
+              "$@" &
+              command_pid=$!
+              (sleep 3600; kill -KILL "$command_pid" 2>/dev/null) &
+              timeout_pid=$!
+              if wait "$command_pid"; then
+                kill "$timeout_pid" 2>/dev/null || true
+                wait "$timeout_pid" 2>/dev/null || true
+                return 0
+              fi
+              kill "$timeout_pid" 2>/dev/null || true
+              wait "$timeout_pid" 2>/dev/null || true
+              if [ "$attempt" -lt 3 ]; then sleep "$retry_wait_seconds"; fi
+            done
+            return 1
+          }
+
+          retry 60 npx playwright install chromium --with-deps &
+          playwright_pid=$!
+
+          (
+            sf project generate -n minimal-project
+            retry 30 bash -c 'echo "$SFDX_AUTH_URL" | sf org login sfdx-url --set-default-dev-hub --alias hub --sfdx-url-stdin'
+            cd minimal-project
+            sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$MINIMAL_ORG_ALIAS" --json
+          ) &
+          scratch_org_setup_pid=$!
+
+          failed=0
+          wait "$playwright_pid" || failed=1
+          wait "$scratch_org_setup_pid" || failed=1
+          exit "$failed"
 
       - name: Run Services E2E tests (parallel)
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/soqlE2E.yml
+++ b/.github/workflows/soqlE2E.yml
@@ -91,34 +91,46 @@ jobs:
           command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
-      - name: Auth to dev hub (global)
-        if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: bash -c 'echo "$SFDX_AUTH_URL" | sf org login sfdx-url
-            --set-default-dev-hub --alias hub --sfdx-url-stdin'
-          retry_wait_seconds: 30
-
-      - name: Install Playwright browsers and OS deps
-        if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
-
-      - name: Generate minimal project
-        if: steps.try-run.outcome == 'failure'
-        shell: bash
-        run: sf project generate -n minimal-project
-
-      - name: Create scratch org
+      - name: Install Playwright and create scratch org
         if: steps.try-run.outcome == 'failure'
         shell: bash
         run: |
-          sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$MINIMAL_ORG_ALIAS" --json --wait 30
-        working-directory: minimal-project
+          retry() {
+            local retry_wait_seconds=$1
+            local attempt command_pid timeout_pid
+            shift
+            for attempt in 1 2 3; do
+              "$@" &
+              command_pid=$!
+              (sleep 3600; kill -KILL "$command_pid" 2>/dev/null) &
+              timeout_pid=$!
+              if wait "$command_pid"; then
+                kill "$timeout_pid" 2>/dev/null || true
+                wait "$timeout_pid" 2>/dev/null || true
+                return 0
+              fi
+              kill "$timeout_pid" 2>/dev/null || true
+              wait "$timeout_pid" 2>/dev/null || true
+              if [ "$attempt" -lt 3 ]; then sleep "$retry_wait_seconds"; fi
+            done
+            return 1
+          }
+
+          retry 60 npx playwright install chromium --with-deps &
+          playwright_pid=$!
+
+          (
+            sf project generate -n minimal-project
+            retry 30 bash -c 'echo "$SFDX_AUTH_URL" | sf org login sfdx-url --set-default-dev-hub --alias hub --sfdx-url-stdin'
+            cd minimal-project
+            sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$MINIMAL_ORG_ALIAS" --json --wait 30
+          ) &
+          scratch_org_setup_pid=$!
+
+          failed=0
+          wait "$playwright_pid" || failed=1
+          wait "$scratch_org_setup_pid" || failed=1
+          exit "$failed"
 
       - name: Run SOQL E2E tests (parallel)
         if: steps.try-run.outcome == 'failure'
@@ -235,34 +247,46 @@ jobs:
           command: npm i -g @salesforce/cli@${{ vars.SF_CLI_VERSION || 'latest' }}
           retry_wait_seconds: 30
 
-      - name: Auth to dev hub (global)
-        if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: bash -c 'echo "$SFDX_AUTH_URL" | sf org login sfdx-url
-            --set-default-dev-hub --alias hub --sfdx-url-stdin'
-          retry_wait_seconds: 30
-
-      - name: Install Playwright browsers and OS deps
-        if: steps.try-run.outcome == 'failure'
-        uses: salesforcecli/github-workflows/.github/actions/retry@main
-        with:
-          max_attempts: 3
-          command: npx playwright install chromium --with-deps
-          retry_wait_seconds: 60
-
-      - name: Generate minimal project
-        if: steps.try-run.outcome == 'failure'
-        shell: bash
-        run: sf project generate -n minimal-project
-
-      - name: Create scratch org
+      - name: Install Playwright and create scratch org
         if: steps.try-run.outcome == 'failure'
         shell: bash
         run: |
-          sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$MINIMAL_ORG_ALIAS" --json --wait 30
-        working-directory: minimal-project
+          retry() {
+            local retry_wait_seconds=$1
+            local attempt command_pid timeout_pid
+            shift
+            for attempt in 1 2 3; do
+              "$@" &
+              command_pid=$!
+              (sleep 3600; kill -KILL "$command_pid" 2>/dev/null) &
+              timeout_pid=$!
+              if wait "$command_pid"; then
+                kill "$timeout_pid" 2>/dev/null || true
+                wait "$timeout_pid" 2>/dev/null || true
+                return 0
+              fi
+              kill "$timeout_pid" 2>/dev/null || true
+              wait "$timeout_pid" 2>/dev/null || true
+              if [ "$attempt" -lt 3 ]; then sleep "$retry_wait_seconds"; fi
+            done
+            return 1
+          }
+
+          retry 60 npx playwright install chromium --with-deps &
+          playwright_pid=$!
+
+          (
+            sf project generate -n minimal-project
+            retry 30 bash -c 'echo "$SFDX_AUTH_URL" | sf org login sfdx-url --set-default-dev-hub --alias hub --sfdx-url-stdin'
+            cd minimal-project
+            sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$MINIMAL_ORG_ALIAS" --json --wait 30
+          ) &
+          scratch_org_setup_pid=$!
+
+          failed=0
+          wait "$playwright_pid" || failed=1
+          wait "$scratch_org_setup_pid" || failed=1
+          exit "$failed"
 
       - name: Run SOQL E2E tests (parallel)
         if: steps.try-run.outcome == 'failure'


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-23195715@

### What changed and why?

- Updated six org-using Playwright E2E workflows to install Chromium and OS dependencies concurrently with project generation, dev-hub authentication, and scratch-org creation.
- Preserved retry behavior with three attempts and existing retry delays.
- Waits for both Playwright installation and org setup to complete, failing the setup step if either process fails.
- Tests still start only after all required setup succeeds.
- Reduces E2E workflow setup time by running independent operations in parallel.

Validation: `npm run check:actions` passed.
