### PR TITLE
chore: Bump all direct minimatch dependencies to 10.2.6 - W-23631763

### DIFF
--- a/.claude/plans/W-23631763.md
+++ b/.claude/plans/W-23631763.md
@@ -1,0 +1,32 @@
+# W-23631763: Bump direct minimatch dependencies to 10.2.6
+
+## Context
+
+Update every direct `minimatch` dependency in the repository to `10.2.6` as requested by W-23631763. This removes older direct versions and records the resulting dependency graph in the npm lockfile.
+
+Files:
+
+- `packages/eslint-local-rules/package.json`
+- `packages/salesforcedx-lightning-lsp-common/package.json`
+- `packages/salesforcedx-lwc-language-server/package.json`
+- `packages/salesforcedx-aura-language-server/src/tern/package.json`
+- `package-lock.json`
+
+## Phases
+
+### Phase 1: Update direct dependencies and lockfile
+
+- Set all 4 direct `minimatch` declarations to `^10.2.6`, preserving the repository's existing caret range style.
+- Run `npm install` from the repository root to regenerate `package-lock.json`.
+- Commit message: `fix: bump direct minimatch dependencies to 10.2.6`
+
+## Skills to apply
+
+- `packageJson`: preserve repository dependency conventions.
+- `verification`: verify the dependency-only change with repository checks.
+
+## Verification
+
+- Confirm all direct `minimatch` declarations are `^10.2.6`.
+- Confirm `package-lock.json` resolves those direct dependencies to `minimatch@10.2.6`.
+- Run the repository compile, lint, and test checks from the repository root.

--- a/package-lock.json
+++ b/package-lock.json
@@ -45784,7 +45784,7 @@
         "@humanwhocodes/momoa": "^3.3.10",
         "@typescript-eslint/parser": "^8.68.0",
         "@typescript-eslint/utils": "^8.68.0",
-        "minimatch": "^10.2.4"
+        "minimatch": "^10.2.6"
       },
       "devDependencies": {
         "@types/eslint": "^9.0.0",
@@ -46052,6 +46052,7 @@
         "acorn-loose": "^6.0.0",
         "acorn-walk": "^6.0.0",
         "line-column": "^1.0.2",
+        "minimatch": "^10.2.6",
         "vscode-html-languageservice": "^5.0.0",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.12",
@@ -46087,7 +46088,7 @@
         "@salesforce/vscode-i18n": "*",
         "effect": "^3.21.2",
         "ejs": "^3.1.10",
-        "minimatch": "^9.0.5",
+        "minimatch": "^10.2.6",
         "tiny-jsonc": "^1.0.2",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-protocol": "^3.17.5",
@@ -46104,36 +46105,6 @@
       },
       "engines": {
         "vscode": "^1.90.0"
-      }
-    },
-    "packages/salesforcedx-lightning-lsp-common/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "packages/salesforcedx-lightning-lsp-common/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "packages/salesforcedx-lightning-lsp-common/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/salesforcedx-lwc-language-server": {
@@ -46155,7 +46126,7 @@
         "comment-parser": "^0.7.6",
         "effect": "^3.21.2",
         "ejs": "^3.1.10",
-        "minimatch": "^10.2.3",
+        "minimatch": "^10.2.6",
         "vscode-html-languageservice": "^5.5.1",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.12",

--- a/packages/eslint-local-rules/package.json
+++ b/packages/eslint-local-rules/package.json
@@ -119,7 +119,7 @@
     "@humanwhocodes/momoa": "^3.3.10",
     "@typescript-eslint/parser": "^8.68.0",
     "@typescript-eslint/utils": "^8.68.0",
-    "minimatch": "^10.2.4"
+    "minimatch": "^10.2.6"
   },
   "devDependencies": {
     "@types/eslint": "^9.0.0",

--- a/packages/salesforcedx-aura-language-server/package.json
+++ b/packages/salesforcedx-aura-language-server/package.json
@@ -81,6 +81,7 @@
     "acorn-loose": "^6.0.0",
     "acorn-walk": "^6.0.0",
     "line-column": "^1.0.2",
+    "minimatch": "^10.2.6",
     "vscode-html-languageservice": "^5.0.0",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.12",

--- a/packages/salesforcedx-aura-language-server/src/tern/package.json
+++ b/packages/salesforcedx-aura-language-server/src/tern/package.json
@@ -18,7 +18,6 @@
     "acorn-walk": "^6.0.0",
     "acorn-loose": "^6.0.0",
     "enhanced-resolve": "^2.2.2",
-    "minimatch": "^3.0.3",
     "resolve-from": "2.0.0"
   },
   "devDependencies": {

--- a/packages/salesforcedx-lightning-lsp-common/package.json
+++ b/packages/salesforcedx-lightning-lsp-common/package.json
@@ -114,7 +114,7 @@
     "@salesforce/vscode-i18n": "*",
     "effect": "^3.21.2",
     "ejs": "^3.1.10",
-    "minimatch": "^9.0.5",
+    "minimatch": "^10.2.6",
     "tiny-jsonc": "^1.0.2",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-protocol": "^3.17.5",

--- a/packages/salesforcedx-lwc-language-server/package.json
+++ b/packages/salesforcedx-lwc-language-server/package.json
@@ -92,7 +92,7 @@
     "comment-parser": "^0.7.6",
     "effect": "^3.21.2",
     "ejs": "^3.1.10",
-    "minimatch": "^10.2.3",
+    "minimatch": "^10.2.6",
     "vscode-html-languageservice": "^5.5.1",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.12",


### PR DESCRIPTION
### What issues does this PR fix or reference?

@W-23631763@

### What changed and why?

- Updated all direct `minimatch` dependencies to `^10.2.6`.
- Moved the Aura language server dependency to its root package and removed the older nested `^3.0.3` declaration.
- Regenerated `package-lock.json`, resolving direct dependencies to `minimatch@10.2.6` and removing obsolete nested entries.

This standardizes the repository’s direct `minimatch` version as requested.
