### PR TITLE
chore: Adopt effect/Predicate emptiness guards at strict null comparisons - W-23587060

### DIFF
--- a/.claude/plans/W-23587060.md
+++ b/.claude/plans/W-23587060.md
@@ -1,0 +1,27 @@
+# W-23587060
+
+## Context
+
+Adopt `effect/Predicate` null and undefined guards in the SOQL extension where strict comparisons currently express emptiness checks. Preserve existing branches and return values; this is a predicate-only refactor.
+
+Files:
+
+- `packages/salesforcedx-vscode-soql/src/editor/htmlUtils.ts`
+- `packages/salesforcedx-vscode-soql/src/commands/dataQuery.ts`
+- `packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/services/globals.ts`
+
+## Phases
+
+1. Replace strict `null` and `undefined` emptiness comparisons with the matching `Predicate` functions and update `effect` imports in the 3 files above.
+   Commit: `refactor(soql): use Predicate for emptiness guards`
+
+## Skills to apply
+
+- `typescript`: preserve narrowing, existing control flow, and repository TypeScript conventions.
+- `effect-best-practices`: use the specific `Predicate` null or undefined function matching each current comparison.
+- `verification`: validate the refactor through repository checks.
+
+## Verification
+
+- Review the diff to confirm only guard syntax and imports changed.
+- Run the repository stop-hook checks: compile, lint, Effect language service, tests, bundle, and knip.

--- a/packages/salesforcedx-vscode-soql/src/commands/dataQuery.ts
+++ b/packages/salesforcedx-vscode-soql/src/commands/dataQuery.ts
@@ -9,7 +9,7 @@ import { Column, createTable, ExtensionProviderService, Row } from '@salesforce/
 import type { JsonMap } from '@salesforce/ts-types';
 import * as Cause from 'effect/Cause';
 import * as Effect from 'effect/Effect';
-import { isNullable, isRecord, isUndefined } from 'effect/Predicate';
+import { isNull, isNullable, isRecord, isUndefined } from 'effect/Predicate';
 import * as vscode from 'vscode';
 import { Utils } from 'vscode-uri';
 import { stripAllRows } from '../editor/allRows';
@@ -540,7 +540,7 @@ const DISPLAY_OBJECT_MAX_DEPTH = 10;
  * Formats a value inside an object/array for display (shows `null` / `undefined` as words).
  */
 const formatNestedDisplayValue = (value: unknown, depthRemaining: number): string => {
-  if (value === null) {
+  if (isNull(value)) {
     return 'null';
   }
   if (isUndefined(value)) {

--- a/packages/salesforcedx-vscode-soql/src/editor/htmlUtils.ts
+++ b/packages/salesforcedx-vscode-soql/src/editor/htmlUtils.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { isNotNull } from 'effect/Predicate';
 import * as vscode from 'vscode';
 import { URI, Utils } from 'vscode-uri';
 
@@ -37,7 +38,7 @@ export const transformHtml = (html: string, lwcDistUri: URI, webview: vscode.Web
 const transformScriptTags = (html: string, lwcDistUri: URI, webview: vscode.Webview): string => {
   let matches: string[] | null;
   let newScriptSrc: URI;
-  while ((matches = scriptRegex.exec(html)) !== null) {
+  while (isNotNull((matches = scriptRegex.exec(html)))) {
     newScriptSrc = webview.asWebviewUri(Utils.joinPath(lwcDistUri, matches[1]));
     // eslint-disable-next-line no-param-reassign
     html = html.replace(`./${matches[1]}`, newScriptSrc.toString());

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/services/globals.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/services/globals.ts
@@ -5,6 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { isUndefined } from 'effect/Predicate';
+
 export type VSCodeWebviewApi = {
   readonly getState: () => unknown;
   readonly postMessage: (message: unknown) => void;
@@ -22,7 +24,7 @@ export const getBodyClass = (): string | null => window.document.body.getAttribu
 let vsCode: VSCodeWebviewApi | undefined;
 
 export const getVscode = (): VSCodeWebviewApi => {
-  if (vsCode === undefined) {
+  if (isUndefined(vsCode)) {
     vsCode = globalThis.acquireVsCodeApi();
   }
   return vsCode;


### PR DESCRIPTION
### What issues does this PR fix or reference?

@W-23587060@

### What changed and why?

Replaced strict `null` and `undefined` comparisons with the corresponding `effect/Predicate` guards in the SOQL extension:

- `isNotNull` for script regex matching in `htmlUtils.ts`
- `isNull` for nested display values in `dataQuery.ts`
- `isUndefined` for VS Code API initialization in `globals.ts`

This standardizes emptiness checks with the Effect predicate conventions while preserving existing control flow, type narrowing, return values, and runtime behavior.
