### PR TITLE
fix(ci): tagPendingRelease.yml checks for bare issue numbers - W-24109222

### DIFF
--- a/.github/workflows/tagPendingRelease.yml
+++ b/.github/workflows/tagPendingRelease.yml
@@ -28,14 +28,22 @@ jobs:
             exit 0
           fi
 
+          # Isolate the "What issues does this PR fix or reference?" section so
+          # issues mentioned elsewhere in the description aren't tagged.
+          SECTION=$(echo "$PR_BODY" | awk '/^### What issues does this PR fix or reference\?/{flag=1; next} /^### /{flag=0} flag')
+
           # Extract full issue URLs for this repo
-          ISSUE_NUMS=$(echo "$PR_BODY" | grep -oP "github\.com/${REPO}/issues/\K[0-9]+" | sort -u | xargs)
+          ISSUE_NUMS=$(echo "$SECTION" | grep -oP "github\.com/${REPO}/issues/\K[0-9]+" | sort -u | xargs)
 
           # Extract full discussion URLs for this repo
-          DISC_NUMS=$(echo "$PR_BODY" | grep -oP "github\.com/${REPO}/discussions/\K[0-9]+" | sort -u | xargs)
+          DISC_NUMS=$(echo "$SECTION" | grep -oP "github\.com/${REPO}/discussions/\K[0-9]+" | sort -u | xargs)
 
           # Extract keyword-prefixed short references (Closes #NNN, Fixes #NNN, etc.)
-          SHORT_REFS=$(echo "$PR_BODY" | grep -oiP '(?:closes|close|fixes|fix|resolves|resolve)\s*#\K[0-9]+' | sort -u | xargs)
+          SHORT_REFS=$(echo "$SECTION" | grep -oiP '(?:closes|close|fixes|fix|resolves|resolve)\s*#\K[0-9]+' | sort -u | xargs)
+
+          # Extract bare short references (e.g. "#8094")
+          BARE_REFS=$(echo "$SECTION" | grep -oP '(?<![\w/])#\K[0-9]+' | sort -u | xargs)
+          SHORT_REFS=$(echo "$SHORT_REFS $BARE_REFS" | xargs -n1 2>/dev/null | sort -u | xargs)
 
           # Determine unresolved numbers (short refs that aren't already classified)
           UNRESOLVED=""

--- a/package-lock.json
+++ b/package-lock.json
@@ -46896,7 +46896,7 @@
     },
     "packages/salesforcedx-vscode-services-types": {
       "name": "@salesforce/vscode-services",
-      "version": "67.17.4",
+      "version": "67.17.6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.43",

--- a/packages/salesforcedx-vscode-services-types/package.json
+++ b/packages/salesforcedx-vscode-services-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/vscode-services",
-  "version": "67.17.4",
+  "version": "67.17.6",
   "description": "TypeScript type definitions for Salesforce VS Code Services extension API",
   "author": "Salesforce",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
### What does this PR do?

PR https://github.com/forcedotcom/salesforcedx-vscode/pull/8105 produces a fix for Issue https://github.com/forcedotcom/salesforcedx-vscode/issues/8094, but the GHA run that was automatically triggered after that PR was merged (https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/33912723119) said "Parsed issue numbers: none".

The problem was that the workflow checks for the full issue URL, while we've been typing just "#8094" in the issue body – Github automatically links to issues when we do that, and it's less typing. What should be done is, the workflow should check for "#____" and only under the "What issues does this PR fix or reference?" section. (There might be another issue reference somewhere else in the description, which we don't want to accidentally tag with "pending release".

### What issues does this PR fix or reference?
#8094, @W-24109222@