### PR TITLE
fix(ci): need to include GH_REPO so the repo can be inferred from bare issue numbers – tagPendingRelease.yml - W-24109222

### DIFF
--- a/.github/workflows/tagPendingRelease.yml
+++ b/.github/workflows/tagPendingRelease.yml
@@ -81,6 +81,7 @@ jobs:
         if: steps.parse.outputs.issues != '' || steps.parse.outputs.unresolved != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           ISSUE_NUMBERS: ${{ steps.parse.outputs.issues }}
           UNRESOLVED: ${{ steps.parse.outputs.unresolved }}
         run: |


### PR DESCRIPTION
Second attempt

### What does this PR do?

PR https://github.com/forcedotcom/salesforcedx-vscode/pull/8105 produces a fix for Issue https://github.com/forcedotcom/salesforcedx-vscode/issues/8094, but the GHA run that was automatically triggered after that PR was merged (https://github.com/forcedotcom/salesforcedx-vscode/actions/runs/33912723119) said "Parsed issue numbers: none".

The problem was that the workflow checks for the full issue URL, while we've been typing just "#8094" in the issue body – Github automatically links to issues when we do that, and it's less typing. What should be done is, the workflow should check for "#____" and only under the "What issues does this PR fix or reference?" section. (There might be another issue reference somewhere else in the description, which we don't want to accidentally tag with "pending release".

### What issues does this PR fix or reference?
#8094, @W-24109222@
