### PR TITLE
chore: 2 Redact Salesforce secrets from the Effect console logger - W-23597360

### DIFF
--- a/.claude/plans/W-23597360.md
+++ b/.claude/plans/W-23597360.md
@@ -1,0 +1,31 @@
+# W-23597360: Redact Salesforce secrets from the Effect console logger
+
+## Context
+
+`packages/salesforcedx-vscode-services/src/observability/redactSensitiveData.ts` already redacts recognizable Salesforce credentials and target-org values from strings. Effect's console logger can still print unredacted log messages, causes, and annotations. Apply the existing redactor at the shared logger boundary so Effect console output does not expose those values.
+
+## Phases
+
+### 1. Redact Effect console output
+
+Commit: `fix: redact Salesforce secrets from Effect console logs`
+
+- Add `packages/salesforcedx-vscode-services/src/observability/redactingConsoleLogger.ts` with an Effect logger that preserves the default console logger's output behavior while redacting string content through `redactSensitiveData` before writing it.
+- Update `packages/salesforcedx-vscode-services/src/servicesLayers.ts` to install the redacting logger in the shared Effect layer used by services runtimes.
+- Add `packages/salesforcedx-vscode-services/test/jest/observability/redactingConsoleLogger.test.ts` covering redaction in Effect console output and preservation of non-sensitive content.
+- Export a shared services layer that includes the redacting logger and use it in every in-repo consumer runtime.
+- Add `packages/salesforcedx-vscode-services/test/playwright/specs/redactingConsoleLogger.headless.spec.ts` to verify logs emitted through the activated services runtime are redacted.
+
+## Skills to apply
+
+- `effect-best-practices`: implement logger and layer composition with repository Effect conventions.
+- `typescript`: follow TypeScript imports, types, naming, and functional style.
+- `verification`: run focused checks and required package verification after the source change.
+
+## Verification
+
+- Run the focused logger test: `npm test -w salesforcedx-vscode-services -- --runInBand test/jest/observability/redactingConsoleLogger.test.ts`.
+- Run services unit tests: `npm test -w salesforcedx-vscode-services -- --runInBand`.
+- Run the services runtime logger Playwright test: `WIREIT_CACHE=none npm run test:web -w salesforcedx-vscode-services -- --retries 0 test/playwright/specs/redactingConsoleLogger.headless.spec.ts`.
+- Run services Playwright web tests: `npm run test:web -w salesforcedx-vscode-services -- --retries 0`.
+- Confirm the repository stop-hook checks pass: compile, lint, Effect LS, tests, bundle, and knip.

--- a/.claude/skills/services-extension-consumption/SKILL.md
+++ b/.claude/skills/services-extension-consumption/SKILL.md
@@ -28,7 +28,9 @@ const api = yield * (yield * ExtensionProviderService).getServicesApi;
 
 ## Prebuilt vs Per-Extension Services
 
-`api.services.prebuiltServicesDependencies` — pre-built `Context.Context` from services extension activation. Wrap with `Layer.succeedContext(...)`.
+`api.services.prebuiltServicesLayer` — shared service instances plus runtime configuration, including the redacting logger. Provide or merge this layer directly.
+
+`api.services.prebuiltServicesDependencies` — deprecated context-only compatibility field. It omits FiberRef runtime configuration; new consumers must use `prebuiltServicesLayer`.
 
 Shares singleton instances (caches, watchers) across extensions; avoids re-building stateful services.
 
@@ -385,7 +387,7 @@ For direct service mocking (no accessor), use `Layer.succeed(Service, mockImpl)`
 
 ## Common Patterns
 
-- Start with `Layer.succeedContext(api.services.prebuiltServicesDependencies)` — don't add individual `*.Default` for services already there
+- Start with `api.services.prebuiltServicesLayer` — don't add individual `*.Default` for services already there
 - Only add per-extension layers on top
 - `import { ICONS }` outside Effect; `MediaService` inside Effect
 - `ChannelServiceLayer` before `ErrorHandlerService`
@@ -395,7 +397,7 @@ For direct service mocking (no accessor), use `Layer.succeed(Service, mockImpl)`
 - `registerCommandWithRuntime` for all commands (tracing + error handling)
 - Use `getRuntime().runPromise` / `runFork` instead of `Effect.provide(AllServicesLayer)` for execution
 
-## Don't: rebuild services already in prebuiltServicesDependencies
+## Don't: rebuild services already in prebuiltServicesLayer
 
 ```typescript
 // WRONG — creates new singleton instances, duplicating caches/watchers/state
@@ -411,7 +413,7 @@ return Layer.mergeAll(
 
 // CORRECT — share the already-built singletons
 return Layer.mergeAll(
-  Layer.succeedContext(api.services.prebuiltServicesDependencies),
+  api.services.prebuiltServicesLayer,
   ExtensionProviderServiceLive,
   api.services.ExtensionContextServiceLayer(context),
   api.services.SdkLayerFor(context),
@@ -424,4 +426,4 @@ return Layer.mergeAll(
 
 Invoke the `effect-advocate` subagent on plans and diffs — its top-priority finding category is "you re-implemented something that already exists in `salesforcedx-vscode-services`."
 
-`prebuiltServicesDependencies` contains ~27 services built once during services extension activation. Calling `.Default` on any of them creates a **second instance** with its own caches, watchers, and state — silently breaking cross-extension sharing.
+`prebuiltServicesLayer` contains ~27 services built once during services extension activation. Calling `.Default` on any of them creates a **second instance** with its own caches, watchers, and state — silently breaking cross-extension sharing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -46877,7 +46877,7 @@
     },
     "packages/salesforcedx-vscode-services-types": {
       "name": "@salesforce/vscode-services",
-      "version": "67.17.6",
+      "version": "67.17.7",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.43",

--- a/packages/effect-ext-utils/src/allServicesLayer.ts
+++ b/packages/effect-ext-utils/src/allServicesLayer.ts
@@ -36,7 +36,7 @@ export const buildAllServicesLayer = (context: ExtensionContext, fallbackDisplay
       const channelLayer = api.services.ChannelServiceLayer(pjson.displayName ?? fallbackDisplayName);
       const errorHandlerWithChannel = Layer.provide(api.services.ErrorHandlerService.Default, channelLayer);
       return Layer.mergeAll(
-        Layer.succeedContext(api.services.prebuiltServicesDependencies),
+        api.services.prebuiltServicesLayer,
         ExtensionProviderServiceLive,
         api.services.ExtensionContextServiceLayer(context),
         api.services.SdkLayerFor(context),

--- a/packages/effect-ext-utils/src/preconditionCheckers.ts
+++ b/packages/effect-ext-utils/src/preconditionCheckers.ts
@@ -6,7 +6,6 @@
  */
 
 import * as Effect from 'effect/Effect';
-import * as Layer from 'effect/Layer';
 import * as vscode from 'vscode';
 import { getServicesApi } from './extensionProvider';
 import { nls } from './messages';
@@ -22,7 +21,7 @@ export const sfProjectPreconditionChecker = {
       Effect.gen(function* () {
         const api = yield* getServicesApi;
         const isProject = yield* api.services.ProjectService.isSalesforceProject().pipe(
-          Effect.provide(Layer.succeedContext(api.services.prebuiltServicesDependencies))
+          Effect.provide(api.services.prebuiltServicesLayer)
         );
         if (!isProject) {
           return yield* Effect.sync(() => {

--- a/packages/salesforcedx-utils-vscode/src/context/workspaceContextUtil.ts
+++ b/packages/salesforcedx-utils-vscode/src/context/workspaceContextUtil.ts
@@ -9,7 +9,6 @@ import { Connection, StateAggregator } from '@salesforce/core';
 import { Global } from '@salesforce/core/global';
 import { getServicesApi } from '@salesforce/effect-ext-utils';
 import * as Effect from 'effect/Effect';
-import * as Layer from 'effect/Layer';
 import { isError } from 'effect/Predicate';
 import * as vscode from 'vscode';
 import { URI, Utils } from 'vscode-uri';
@@ -34,8 +33,7 @@ export const WORKSPACE_CONTEXT_ORG_ID_ERROR = 'workspace_context_org_id_error';
  */
 const getValidatedConnection = Effect.fn('WorkspaceContextUtil.getConnection')(function* () {
   const api = yield* getServicesApi;
-  const prebuilt = Layer.succeedContext(api.services.prebuiltServicesDependencies);
-  return yield* api.services.ConnectionService.getConnection().pipe(Effect.provide(prebuilt));
+  return yield* api.services.ConnectionService.getConnection().pipe(Effect.provide(api.services.prebuiltServicesLayer));
 });
 
 /**

--- a/packages/salesforcedx-utils-vscode/src/telemetry/reporters/o11yReporter.ts
+++ b/packages/salesforcedx-utils-vscode/src/telemetry/reporters/o11yReporter.ts
@@ -11,7 +11,6 @@ import { getServicesApi } from '@salesforce/effect-ext-utils';
 import { O11yService } from '@salesforce/o11y-reporter';
 import type { TelemetryReporter } from '@salesforce/vscode-service-provider';
 import * as Effect from 'effect/Effect';
-import * as Layer from 'effect/Layer';
 import { Disposable, env, workspace } from 'vscode';
 import { isInternalHost } from '../utils/isInternal';
 import { getCommonProperties, getInternalProperties } from './telemetryUtils';
@@ -35,8 +34,7 @@ const getPdpEventSchema = async (): Promise<Record<string, unknown>> => {
 };
 const getConnectionEffect = Effect.fn('O11yReporter.getConnection')(function* () {
   const api = yield* getServicesApi;
-  const prebuilt = Layer.succeedContext(api.services.prebuiltServicesDependencies);
-  return yield* api.services.ConnectionService.getConnection().pipe(Effect.provide(prebuilt));
+  return yield* api.services.ConnectionService.getConnection().pipe(Effect.provide(api.services.prebuiltServicesLayer));
 });
 
 const getConnection = (): Promise<Connection> => Effect.runPromise(getConnectionEffect());

--- a/packages/salesforcedx-utils-vscode/test/jest/context/workspaceContextUtil.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/context/workspaceContextUtil.test.ts
@@ -43,11 +43,11 @@ jest.mock('@salesforce/core', () => ({
 }));
 jest.mock('@salesforce/effect-ext-utils', () => {
   const E = require('effect/Effect');
-  const Ctx = require('effect/Context');
+  const Layer = require('effect/Layer');
   return {
     getServicesApi: E.succeed({
       services: {
-        prebuiltServicesDependencies: Ctx.empty(),
+        prebuiltServicesLayer: Layer.empty,
         ConnectionService: {
           getConnection: (...args: unknown[]) => mockGetConnectionSvc(...args),
           validateAccessTokenOrPromptReauth: (...args: unknown[]) => mockValidateReauthSvc(...args)

--- a/packages/salesforcedx-utils-vscode/test/jest/telemetry/reporters/o11yReporter.test.ts
+++ b/packages/salesforcedx-utils-vscode/test/jest/telemetry/reporters/o11yReporter.test.ts
@@ -15,11 +15,11 @@ const mockGetConnectionSvc = jest.fn();
 
 jest.mock('@salesforce/effect-ext-utils', () => {
   const E = require('effect/Effect');
-  const Ctx = require('effect/Context');
+  const Layer = require('effect/Layer');
   return {
     getServicesApi: E.succeed({
       services: {
-        prebuiltServicesDependencies: Ctx.empty(),
+        prebuiltServicesLayer: Layer.empty,
         ConnectionService: {
           getConnection: (...args: unknown[]) => mockGetConnectionSvc(...args)
         }

--- a/packages/salesforcedx-vscode-apex/src/languageServerScanConfig.ts
+++ b/packages/salesforcedx-vscode-apex/src/languageServerScanConfig.ts
@@ -5,8 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import type * as Context from 'effect/Context';
 import * as Effect from 'effect/Effect';
+import type * as Layer from 'effect/Layer';
 import { isString } from 'effect/Predicate';
 import * as vscode from 'vscode';
 
@@ -30,7 +30,7 @@ type MetadataRegistryServiceLike = {
 type SalesforceVSCodeServicesApiLike = {
   services: {
     MetadataRegistryService: MetadataRegistryServiceLike;
-    prebuiltServicesDependencies: Context.Context<unknown>;
+    prebuiltServicesLayer: Layer.Layer<unknown>;
   };
 };
 
@@ -88,7 +88,7 @@ export const buildMetadataRegistryScanConfig = async (): Promise<ApexLspScanConf
           const apexFolderNames = getApexFolderNames(registryAccess);
           return deriveExcludedMetadataFolders(registryAccess.getRegistry(), apexFolderNames);
         }),
-        Effect.provide(servicesApi.services.prebuiltServicesDependencies)
+        Effect.provide(servicesApi.services.prebuiltServicesLayer)
       )
     );
   } catch {

--- a/packages/salesforcedx-vscode-services-types/package.json
+++ b/packages/salesforcedx-vscode-services-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/vscode-services",
-  "version": "67.17.6",
+  "version": "67.17.7",
   "description": "TypeScript type definitions for Salesforce VS Code Services extension API",
   "author": "Salesforce",
   "license": "BSD-3-Clause",

--- a/packages/salesforcedx-vscode-services/src/index.ts
+++ b/packages/salesforcedx-vscode-services/src/index.ts
@@ -44,6 +44,7 @@ import { TraceFlagService } from './core/traceFlagService';
 import { TransmogrifierService } from './core/transmogrifierService';
 import { nls } from './messages';
 import { annotateExtensionPackType } from './observability/extensionPackStatus';
+import { redactingConsoleLoggerLayer } from './observability/redactingConsoleLogger';
 import { getSdkLayerConfigFromContext } from './observability/sdkLayerConfig';
 import { seedTelemetryIdentities } from './observability/seedTelemetryIdentities';
 import { SdkLayerFor, ServicesSdkLayer } from './observability/spans';
@@ -83,43 +84,46 @@ import { SettingsService } from './vscode/settingsService';
 import { SettingsWatcherLayer } from './vscode/settingsWatcherService';
 import { WorkspaceService } from './vscode/workspaceService';
 
+type PrebuiltServicesDependencies =
+  | AliasService
+  | ApexLogService
+  | ChannelService
+  | ComponentSetService
+  | LightningComponentService
+  | ConfigService
+  | ConnectionService
+  | EditorService
+  | ErrorHandlerService
+  | ExecuteAnonymousService
+  | FileChangePubSub
+  | FsService
+  | MediaService
+  | MetadataChangeNotificationService
+  | MetadataDeleteService
+  | MetadataDeployService
+  | MetadataDescribeService
+  | OrgMetadataCatalog
+  | OrgMetadataCatalogChangePubSub
+  | PromptService
+  | MetadataRegistryService
+  | MetadataRetrieveService
+  | ProjectService
+  | Resource.Resource
+  | SettingsChangePubSub
+  | SettingsService
+  | SourceTrackingService
+  | TemplateService
+  | TerminalService
+  | TraceFlagService
+  | TransmogrifierService
+  | WorkspaceService;
+
 export type SalesforceVSCodeServicesApi = {
   services: {
-    /** contains most of the dependencies prebuilt in the services extension */
-    prebuiltServicesDependencies: Context.Context<
-      | AliasService
-      | ApexLogService
-      | ChannelService
-      | ComponentSetService
-      | LightningComponentService
-      | ConfigService
-      | ConnectionService
-      | EditorService
-      | ErrorHandlerService
-      | ExecuteAnonymousService
-      | FileChangePubSub
-      | FsService
-      | MediaService
-      | MetadataChangeNotificationService
-      | MetadataDeleteService
-      | MetadataDeployService
-      | MetadataDescribeService
-      | OrgMetadataCatalog
-      | OrgMetadataCatalogChangePubSub
-      | PromptService
-      | MetadataRegistryService
-      | MetadataRetrieveService
-      | ProjectService
-      | Resource.Resource
-      | SettingsChangePubSub
-      | SettingsService
-      | SourceTrackingService
-      | TemplateService
-      | TerminalService
-      | TraceFlagService
-      | TransmogrifierService
-      | WorkspaceService
-    >;
+    /** @deprecated Use prebuiltServicesLayer so Effect runtime configuration is preserved. */
+    prebuiltServicesDependencies: Context.Context<PrebuiltServicesDependencies>;
+    /** Shared service instances and Effect runtime configuration. */
+    prebuiltServicesLayer: Layer.Layer<PrebuiltServicesDependencies>;
     ApexLogService: typeof ApexLogService;
     AliasService: typeof AliasService;
     TemplateService: typeof TemplateService;
@@ -305,7 +309,9 @@ export {
 } from './vscode/notificationModeService';
 
 /** Effect that runs when the extension is activated after FS setup */
-const activationEffect = Effect.fn('activation:salesforcedx-vscode-services')(function* () {
+const activationEffect = Effect.fn('activation:salesforcedx-vscode-services')(function* (
+  context: vscode.ExtensionContext
+) {
   yield* (yield* ChannelService).appendToChannel(`${SERVICES_CHANNEL_NAME} extension is activating!`);
   // seed populates defaultOrgRef.cliId + webUserId before connectionService and core can read it
   yield* seedTelemetryIdentities();
@@ -339,6 +345,15 @@ const activationEffect = Effect.fn('activation:salesforcedx-vscode-services')(fu
       )
     )
   );
+
+  if (
+    context.extensionMode === vscode.ExtensionMode.Development ||
+    context.extensionMode === vscode.ExtensionMode.Test
+  ) {
+    yield* registerCommandWithRuntime(yield* getServicesRuntime())('sf.internal.testRedactingConsoleLogger', () =>
+      Effect.logInfo('runtime logger test 00D000000000000!playwright-secret')
+    );
+  }
 
   if (process.env.ESBUILD_PLATFORM === 'web') {
     // auth settings go before other things so retrieveOnLoad can use them
@@ -480,10 +495,12 @@ export const activate = async (context: vscode.ExtensionContext): Promise<Salesf
     // reauth cache) instead of Effect.provide(ConnectionService.Default), which builds a private
     // ConnectionService with its own reauth cache (a duplicate reauth modal on desktop). The exporter
     // fails fast until this is set, so it never blocks activation waiting on it.
-    builtContext.pipe(Layer.succeedContext, ManagedRuntime.make, setServicesRuntime);
+    // Layer.buildWithScope returns only Context, so restore the logger FiberRef on the managed runtime.
+    const prebuiltServicesLayer = Layer.merge(Layer.succeedContext(builtContext), redactingConsoleLoggerLayer);
+    prebuiltServicesLayer.pipe(ManagedRuntime.make, setServicesRuntime);
 
-    await activationEffect().pipe(
-      Effect.provide(builtContext),
+    await activationEffect(context).pipe(
+      Effect.provide(prebuiltServicesLayer),
       Effect.tapError(error => Effect.sync(() => console.error('❌ [Services] Activation failed:', error))),
       Effect.runPromise
     );
@@ -494,6 +511,7 @@ export const activate = async (context: vscode.ExtensionContext): Promise<Salesf
     return {
       services: {
         prebuiltServicesDependencies: builtContext,
+        prebuiltServicesLayer,
         ApexLogService,
         AliasService,
         TemplateService,

--- a/packages/salesforcedx-vscode-services/src/observability/redactingConsoleLogger.ts
+++ b/packages/salesforcedx-vscode-services/src/observability/redactingConsoleLogger.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as Logger from 'effect/Logger';
+import { redactSensitiveData } from './redactSensitiveData';
+
+const redactingConsoleLogger = Logger.stringLogger.pipe(Logger.map(redactSensitiveData), Logger.withConsoleLog);
+
+export const redactingConsoleLoggerLayer = Logger.replace(Logger.defaultLogger, redactingConsoleLogger);

--- a/packages/salesforcedx-vscode-services/src/servicesLayers.ts
+++ b/packages/salesforcedx-vscode-services/src/servicesLayers.ts
@@ -24,6 +24,7 @@ import { SourceTrackingService } from './core/sourceTrackingService';
 import { TemplateService } from './core/templateService';
 import { TraceFlagService } from './core/traceFlagService';
 import { TransmogrifierService } from './core/transmogrifierService';
+import { redactingConsoleLoggerLayer } from './observability/redactingConsoleLogger';
 import { OrgCatalogDocuments } from './orgCatalog/orgCatalogDocuments';
 import { OrgCatalogState } from './orgCatalog/orgCatalogState';
 import { OrgMetadataCatalog } from './orgCatalog/orgMetadataCatalog';
@@ -81,5 +82,6 @@ export const globalLayers = Layer.mergeAll(
   TerminalService.Default,
   TransmogrifierService.Default,
   TraceFlagService.Default,
-  WorkspaceService.Default
+  WorkspaceService.Default,
+  redactingConsoleLoggerLayer
 );

--- a/packages/salesforcedx-vscode-services/test/jest/index.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/index.test.ts
@@ -255,6 +255,15 @@ describe('Extension', () => {
     const services = api.services.prebuiltServicesDependencies;
     Context.get(services, ConfigService);
     Context.get(services, ConnectionService);
+    const consoleLog = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    Effect.runSync(
+      Effect.logInfo('api layer 00D000000000000!api-layer-secret').pipe(
+        Effect.provide(api.services.prebuiltServicesLayer)
+      )
+    );
+    expect(String(consoleLog.mock.calls[0][0])).toContain('<REDACTED ACCESS TOKEN>');
+    expect(String(consoleLog.mock.calls[0][0])).not.toContain('api-layer-secret');
+    consoleLog.mockRestore();
     const externalSdkContext = await Effect.runPromise(
       Layer.buildWithScope(api.services.SdkLayerFor(context), Effect.runSync(getExtensionScope()))
     );

--- a/packages/salesforcedx-vscode-services/test/jest/observability/redactingConsoleLogger.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/observability/redactingConsoleLogger.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import * as Cause from 'effect/Cause';
+import * as Effect from 'effect/Effect';
+import type { SpiedFunction } from 'jest-mock';
+import { redactingConsoleLoggerLayer } from '../../../src/observability/redactingConsoleLogger';
+
+describe('redactingConsoleLogger', () => {
+  const runLog = (log: Effect.Effect<void>): void =>
+    Effect.runSync(log.pipe(Effect.provide(redactingConsoleLoggerLayer)));
+
+  let consoleLog: SpiedFunction<typeof console.log>;
+
+  beforeEach(() => {
+    consoleLog = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleLog.mockRestore();
+  });
+
+  it('redacts secrets from messages, causes, and annotations before writing to the console', () => {
+    runLog(
+      Effect.logError(
+        'request used 00D000000000000!message-secret',
+        Cause.fail('response contained eyJheader.eyJpayload.cause-secret')
+      ).pipe(Effect.annotateLogs({ cookie: 'sid=annotation-secret' }))
+    );
+
+    expect(consoleLog).toHaveBeenCalledTimes(1);
+    const output = String(consoleLog.mock.calls[0][0]);
+    expect(output).not.toContain('message-secret');
+    expect(output).not.toContain('cause-secret');
+    expect(output).not.toContain('annotation-secret');
+    expect(output).toContain('<REDACTED ACCESS TOKEN>');
+    expect(output).toContain('<REDACTED JWT TOKEN>');
+    expect(output).toContain('<REDACTED SID>');
+  });
+
+  it('preserves the default logger metadata and non-sensitive content', () => {
+    runLog(Effect.logInfo('deployment completed').pipe(Effect.annotateLogs({ componentCount: 3 })));
+
+    expect(consoleLog).toHaveBeenCalledTimes(1);
+    const output = String(consoleLog.mock.calls[0][0]);
+    expect(output).toContain('timestamp=');
+    expect(output).toContain('level=INFO');
+    expect(output).toContain('fiber=');
+    expect(output).toContain('message="deployment completed"');
+    expect(output).toContain('componentCount=3');
+  });
+});

--- a/packages/salesforcedx-vscode-services/test/playwright/specs/redactingConsoleLogger.headless.spec.ts
+++ b/packages/salesforcedx-vscode-services/test/playwright/specs/redactingConsoleLogger.headless.spec.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect } from '@playwright/test';
+import { executeCommandById, waitForVSCodeWorkbench } from '@salesforce/playwright-vscode-ext';
+import { test } from '../fixtures';
+
+test('redacts Effect logs emitted through the services runtime', async ({ page }) => {
+  const consoleLogs: string[] = [];
+  page.on('console', message => consoleLogs.push(message.text()));
+  await waitForVSCodeWorkbench(page);
+
+  await executeCommandById(page, 'sf.internal.testRedactingConsoleLogger', {
+    verifyExecution: async () => {
+      expect(consoleLogs.join('\n')).toContain('<REDACTED ACCESS TOKEN>');
+    }
+  });
+
+  expect(consoleLogs.join('\n')).not.toContain('playwright-secret');
+});


### PR DESCRIPTION
### What issues does this PR fix or reference?

@W-23597360@

### What changed and why?

- Added a shared Effect console logger that applies `redactSensitiveData` to log messages, causes, and annotations before writing output.
- Installed the redacting logger in the shared services layer and activated runtime.
- Exposed `prebuiltServicesLayer` and migrated in-repo consumers so logger configuration is preserved across runtimes.
- Added unit, activation, and headless Playwright coverage for redaction and default log metadata.
- Kept `prebuiltServicesDependencies` as a deprecated compatibility field.

This prevents Salesforce access tokens, JWTs, SID cookies, and target-org values from appearing in Effect console logs.

### Testing

- `npm test -w salesforcedx-vscode-services -- --runInBand test/jest/observability/redactingConsoleLogger.test.ts`
- Passed: 1 suite, 2 tests.
