### PR TITLE
chore: 4 Enforce consistent-type-imports eslint rule for salesforcedx-visualforce-markup-language-server - W-23371047

### DIFF
--- a/.claude/plans/W-23371047.md
+++ b/.claude/plans/W-23371047.md
@@ -1,0 +1,27 @@
+# W-23371047
+
+## Context
+
+Enforce `@typescript-eslint/consistent-type-imports` for `packages/salesforcedx-visualforce-language-server/**/*.ts`. This keeps imports used only as TypeScript types explicit and consistent with packages already migrated in `eslint.config.mjs`.
+
+Files:
+
+- `eslint.config.mjs`
+- `packages/salesforcedx-visualforce-language-server/src/**/*.ts` reported by the rule
+- `packages/salesforcedx-visualforce-language-server/test/**/*.ts` reported by the rule
+
+## Phases
+
+1. Add a package-scoped `@typescript-eslint/consistent-type-imports` configuration using `prefer: 'type-imports'` and `fixStyle: 'inline-type-imports'`; apply ESLint's fixes to every reported Visualforce language server import; manually correct any remaining reports without changing runtime behavior. Commit: `refactor: enforce type imports in visualforce language server`
+
+## Skills to apply
+
+- `typescript`: preserve TypeScript import semantics and repository style.
+- `verification`: verify the package after configuration and import changes.
+
+## Verification
+
+- Run `npm run lint -w @salesforce/salesforcedx-visualforce-language-server` from the repository root.
+- Run `npm run compile -w @salesforce/salesforcedx-visualforce-language-server` from the repository root.
+- Run `npm test -w @salesforce/salesforcedx-visualforce-language-server` from the repository root.
+- Review the diff to confirm changes are limited to the ESLint override and type-only import syntax.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -850,6 +850,16 @@ export default [
     }
   },
   {
+    // consistent-type-imports for salesforcedx-visualforce-language-server (inline to avoid no-duplicate-imports; W-23371047)
+    files: ['packages/salesforcedx-visualforce-language-server/**/*.ts'],
+    rules: {
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        { prefer: 'type-imports', fixStyle: 'inline-type-imports' }
+      ]
+    }
+  },
+  {
     // consistent-type-imports for playwright-vscode-ext (inline to avoid no-duplicate-imports; W-23370906)
     files: ['packages/playwright-vscode-ext/**/*.ts'],
     rules: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46877,7 +46877,7 @@
     },
     "packages/salesforcedx-vscode-services-types": {
       "name": "@salesforce/vscode-services",
-      "version": "67.17.6",
+      "version": "67.17.7",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.43",

--- a/packages/salesforcedx-visualforce-language-server/src/languageModelCache.ts
+++ b/packages/salesforcedx-visualforce-language-server/src/languageModelCache.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import { TextDocument } from 'vscode-languageserver-textdocument';
+import { type TextDocument } from 'vscode-languageserver-textdocument';
 
 export type LanguageModelCache<T> = {
   get(document: TextDocument): T;

--- a/packages/salesforcedx-visualforce-language-server/src/modes/cssMode.ts
+++ b/packages/salesforcedx-visualforce-language-server/src/modes/cssMode.ts
@@ -7,9 +7,9 @@
 import { getCSSLanguageService, type Stylesheet } from 'vscode-css-languageservice';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import type { Position } from 'vscode-languageserver-types';
-import { getLanguageModelCache, LanguageModelCache } from '../languageModelCache';
-import { CSS_STYLE_RULE, HTMLDocumentRegions } from './embeddedSupport';
-import { ColorInformation, LanguageMode, Settings } from './languageModes';
+import { getLanguageModelCache, type LanguageModelCache } from '../languageModelCache';
+import { CSS_STYLE_RULE, type HTMLDocumentRegions } from './embeddedSupport';
+import { type ColorInformation, type LanguageMode, type Settings } from './languageModes';
 
 export const getCSSMode = (documentRegions: LanguageModelCache<HTMLDocumentRegions>): LanguageMode => {
   const cssLanguageService = getCSSLanguageService();

--- a/packages/salesforcedx-visualforce-language-server/src/modes/embeddedSupport.ts
+++ b/packages/salesforcedx-visualforce-language-server/src/modes/embeddedSupport.ts
@@ -7,9 +7,9 @@
 
 'use strict';
 
-import { LanguageService, TokenType } from 'vscode-html-languageservice';
+import { type LanguageService, TokenType } from 'vscode-html-languageservice';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { Position, Range } from 'vscode-languageserver-types';
+import { Position, type Range } from 'vscode-languageserver-types';
 
 type LanguageRange = Range & {
   languageId: string;

--- a/packages/salesforcedx-visualforce-language-server/src/modes/formatting.ts
+++ b/packages/salesforcedx-visualforce-language-server/src/modes/formatting.ts
@@ -5,11 +5,11 @@
 'use strict';
 
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { FormattingOptions, Position, Range, TextEdit } from 'vscode-languageserver-types';
+import { type FormattingOptions, Position, Range, TextEdit } from 'vscode-languageserver-types';
 import { pushAll } from '../utils/arrays';
 import { applyEdits } from '../utils/edits';
 import { isEOL } from '../utils/strings';
-import { LanguageModes, Settings } from './languageModes';
+import { type LanguageModes, type Settings } from './languageModes';
 
 export const format = (
   languageModes: LanguageModes,

--- a/packages/salesforcedx-visualforce-language-server/src/modes/htmlMode.ts
+++ b/packages/salesforcedx-visualforce-language-server/src/modes/htmlMode.ts
@@ -5,15 +5,15 @@
 'use strict';
 
 import {
-  DocumentContext,
-  HTMLDocument,
-  HTMLFormatConfiguration,
-  LanguageService as HTMLLanguageService
+  type DocumentContext,
+  type HTMLDocument,
+  type HTMLFormatConfiguration,
+  type LanguageService as HTMLLanguageService
 } from 'vscode-html-languageservice';
-import { TextDocument } from 'vscode-languageserver-textdocument';
-import { Position, Range, FormattingOptions } from 'vscode-languageserver-types';
+import { type TextDocument } from 'vscode-languageserver-textdocument';
+import { type Position, type Range, type FormattingOptions } from 'vscode-languageserver-types';
 import { getLanguageModelCache } from '../languageModelCache';
-import { LanguageMode, Settings } from './languageModes';
+import { type LanguageMode, type Settings } from './languageModes';
 
 export const getHTMLMode = (htmlLanguageService: HTMLLanguageService): LanguageMode => {
   let globalSettings: Settings = {};

--- a/packages/salesforcedx-visualforce-language-server/src/modes/javascriptMode.ts
+++ b/packages/salesforcedx-visualforce-language-server/src/modes/javascriptMode.ts
@@ -5,16 +5,16 @@
 'use strict';
 
 import {
-  CompilerOptions,
+  type CompilerOptions,
   createLanguageService,
   displayPartsToString,
   flattenDiagnosticMessageText,
-  FormatCodeOptions,
+  type FormatCodeOptions,
   getDefaultLibFilePath,
   IndentStyle,
-  LanguageServiceHost,
+  type LanguageServiceHost,
   ModuleResolutionKind,
-  NavigationBarItem,
+  type NavigationBarItem,
   ScriptKind,
   ScriptTarget,
   sys,
@@ -23,31 +23,31 @@ import {
 } from 'typescript';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 import {
-  CompletionItem,
+  type CompletionItem,
   CompletionItemKind,
-  CompletionList,
-  Definition,
-  Diagnostic,
+  type CompletionList,
+  type Definition,
+  type Diagnostic,
   DiagnosticSeverity,
-  DocumentHighlight,
+  type DocumentHighlight,
   DocumentHighlightKind,
-  FormattingOptions,
-  Hover,
-  Location,
+  type FormattingOptions,
+  type Hover,
+  type Location,
   MarkedString,
-  ParameterInformation,
+  type ParameterInformation,
   Position,
   Range,
-  SignatureHelp,
-  SignatureInformation,
-  SymbolInformation,
+  type SignatureHelp,
+  type SignatureInformation,
+  type SymbolInformation,
   SymbolKind,
   TextEdit
 } from 'vscode-languageserver-types';
-import { getLanguageModelCache, LanguageModelCache } from '../languageModelCache';
+import { getLanguageModelCache, type LanguageModelCache } from '../languageModelCache';
 import { getWordAtText, isWhitespaceOnly, repeat, startsWith } from '../utils/strings';
-import { HTMLDocumentRegions } from './embeddedSupport';
-import { LanguageMode, Settings } from './languageModes';
+import { type HTMLDocumentRegions } from './embeddedSupport';
+import { type LanguageMode, type Settings } from './languageModes';
 
 const FILE_NAME = 'vscode://javascript/1'; // the same 'file' is used for all contents
 const JS_WORD_REGEX = /(-?\d*\.\d\w*)|([^\`\~\!\@\#\%\^\&\*\(\)\-\=\+\[\{\]\}\\\|\;\:\'\"\,\.\<\>\/\?\s]+)/g;

--- a/packages/salesforcedx-visualforce-language-server/src/modes/languageModes.ts
+++ b/packages/salesforcedx-visualforce-language-server/src/modes/languageModes.ts
@@ -5,29 +5,29 @@
 
 'use strict';
 
-import { LanguageSettings } from 'vscode-css-languageservice';
-import { DocumentContext } from 'vscode-html-languageservice';
-import { ColorInformation, ColorPresentation } from 'vscode-languageserver-protocol';
-import { TextDocument } from 'vscode-languageserver-textdocument';
+import { type LanguageSettings } from 'vscode-css-languageservice';
+import { type DocumentContext } from 'vscode-html-languageservice';
+import { type ColorInformation, type ColorPresentation } from 'vscode-languageserver-protocol';
+import { type TextDocument } from 'vscode-languageserver-textdocument';
 import {
-  CompletionItem,
-  CompletionList,
-  Definition,
-  Diagnostic,
-  DocumentHighlight,
-  DocumentLink,
-  FormattingOptions,
-  Hover,
-  Location,
-  Position,
-  Range,
-  SignatureHelp,
-  SymbolInformation,
-  TextEdit
+  type CompletionItem,
+  type CompletionList,
+  type Definition,
+  type Diagnostic,
+  type DocumentHighlight,
+  type DocumentLink,
+  type FormattingOptions,
+  type Hover,
+  type Location,
+  type Position,
+  type Range,
+  type SignatureHelp,
+  type SymbolInformation,
+  type TextEdit
 } from 'vscode-languageserver-types';
-import { getLanguageModelCache, LanguageModelCache } from '../languageModelCache';
+import { getLanguageModelCache, type LanguageModelCache } from '../languageModelCache';
 import { getCSSMode } from './cssMode';
-import { getDocumentRegions, HTMLDocumentRegions } from './embeddedSupport';
+import { getDocumentRegions, type HTMLDocumentRegions } from './embeddedSupport';
 import { getHTMLMode } from './htmlMode';
 import { getVisualforceHtmlLanguageService } from './visualforceHtmlLanguageService';
 

--- a/packages/salesforcedx-visualforce-language-server/src/modes/visualforceHtmlLanguageService.ts
+++ b/packages/salesforcedx-visualforce-language-server/src/modes/visualforceHtmlLanguageService.ts
@@ -5,17 +5,17 @@
 'use strict';
 
 import {
-  DocumentContext,
+  type DocumentContext,
   getDefaultHTMLDataProvider,
   getLanguageService,
-  HTMLDocument,
-  LanguageService,
-  Position,
+  type HTMLDocument,
+  type LanguageService,
+  type Position,
   Range,
-  TextDocument,
+  type TextDocument,
   TokenType
 } from 'vscode-html-languageservice';
-import { DocumentLink, Hover, MarkedString } from 'vscode-languageserver-types';
+import { type DocumentLink, type Hover, MarkedString } from 'vscode-languageserver-types';
 import { URI } from 'vscode-uri';
 import { visualforceDataProvider } from './visualforceTags';
 

--- a/packages/salesforcedx-visualforce-language-server/src/utils/edits.ts
+++ b/packages/salesforcedx-visualforce-language-server/src/utils/edits.ts
@@ -5,7 +5,7 @@
 'use strict';
 
 import type { TextDocument } from 'vscode-languageserver-textdocument';
-import { Position, TextEdit } from 'vscode-languageserver-types';
+import { type Position, type TextEdit } from 'vscode-languageserver-types';
 
 export const applyEdits = (document: TextDocument, edits: TextEdit[]): string => {
   let text = document.getText();

--- a/packages/salesforcedx-visualforce-language-server/src/visualforceServer.ts
+++ b/packages/salesforcedx-visualforce-language-server/src/visualforceServer.ts
@@ -11,38 +11,38 @@ import {
   createConnection as createBrowserConnection
 } from 'vscode-languageserver/browser';
 import {
-  ColorPresentationParams,
-  CompletionItem,
-  CompletionList,
-  CompletionParams,
-  Connection,
+  type ColorPresentationParams,
+  type CompletionItem,
+  type CompletionList,
+  type CompletionParams,
+  type Connection,
   createConnection as createNodeConnection,
-  Disposable,
-  DocumentColorParams,
+  type Disposable,
+  type DocumentColorParams,
   DocumentRangeFormattingRequest,
-  DocumentSelector,
-  InitializeParams,
-  InitializeResult,
+  type DocumentSelector,
+  type InitializeParams,
+  type InitializeResult,
   Position,
   RequestType,
-  ServerCapabilities,
-  SignatureHelp,
-  TextDocumentPositionParams,
+  type ServerCapabilities,
+  type SignatureHelp,
+  type TextDocumentPositionParams,
   TextDocuments,
   TextDocumentSyncKind
 } from 'vscode-languageserver/node';
 import {
-  ColorInformation,
+  type ColorInformation,
   ColorPresentationRequest,
-  ConfigurationParams,
+  type ConfigurationParams,
   ConfigurationRequest,
   DocumentColorRequest
 } from 'vscode-languageserver-protocol';
 import { TextDocument } from 'vscode-languageserver-textdocument';
-import { Diagnostic, DocumentLink, SymbolInformation } from 'vscode-languageserver-types';
+import { type Diagnostic, type DocumentLink, type SymbolInformation } from 'vscode-languageserver-types';
 import { resolveReference } from './documentLinks';
 import { format } from './modes/formatting';
-import { getLanguageModes, LanguageModes, Settings } from './modes/languageModes';
+import { getLanguageModes, type LanguageModes, type Settings } from './modes/languageModes';
 
 import { pushAll } from './utils/arrays';
 

--- a/packages/salesforcedx-visualforce-language-server/test/jest/completion.test.ts
+++ b/packages/salesforcedx-visualforce-language-server/test/jest/completion.test.ts
@@ -5,8 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { CompletionConfiguration } from 'vscode-html-languageservice';
-import { CompletionItemKind, CompletionList, TextDocument } from 'vscode-languageserver-types';
+import { type CompletionConfiguration } from 'vscode-html-languageservice';
+import { type CompletionItemKind, type CompletionList, TextDocument } from 'vscode-languageserver-types';
 import { getVisualforceHtmlLanguageService } from '../../src/modes/visualforceHtmlLanguageService';
 import { applyEdits } from './textEditSupport';
 

--- a/packages/salesforcedx-visualforce-language-server/test/jest/formatting.test.ts
+++ b/packages/salesforcedx-visualforce-language-server/test/jest/formatting.test.ts
@@ -8,7 +8,7 @@ import * as assert from 'node:assert';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { FormattingOptions, Range, TextDocument, TextEdit } from 'vscode-languageserver-types';
+import { FormattingOptions, Range, TextDocument, type TextEdit } from 'vscode-languageserver-types';
 import { format } from '../../src/modes/formatting';
 import { getLanguageModes } from '../../src/modes/languageModes';
 

--- a/packages/salesforcedx-visualforce-language-server/test/jest/hover.test.ts
+++ b/packages/salesforcedx-visualforce-language-server/test/jest/hover.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import { MarkupContent, MarkedString, TextDocument } from 'vscode-languageserver-types';
+import { type MarkupContent, type MarkedString, TextDocument } from 'vscode-languageserver-types';
 import { getVisualforceHtmlLanguageService } from '../../src/modes/visualforceHtmlLanguageService';
 
 describe('HTML Hover', () => {

--- a/packages/salesforcedx-visualforce-language-server/test/jest/links.test.ts
+++ b/packages/salesforcedx-visualforce-language-server/test/jest/links.test.ts
@@ -5,7 +5,7 @@
 'use strict';
 
 import * as url from 'node:url';
-import { DocumentContext } from 'vscode-html-languageservice';
+import { type DocumentContext } from 'vscode-html-languageservice';
 import { TextDocument } from 'vscode-languageserver-types';
 import { getVisualforceHtmlLanguageService } from '../../src/modes/visualforceHtmlLanguageService';
 

--- a/packages/salesforcedx-visualforce-language-server/test/jest/textEditSupport.ts
+++ b/packages/salesforcedx-visualforce-language-server/test/jest/textEditSupport.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import { TextDocument, TextEdit } from 'vscode-languageserver-types';
+import { type TextDocument, type TextEdit } from 'vscode-languageserver-types';
 
 export const applyEdits = (document: TextDocument, edits: TextEdit[]): string => {
   let text = document.getText();

--- a/packages/salesforcedx-vscode-services-types/package.json
+++ b/packages/salesforcedx-vscode-services-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/vscode-services",
-  "version": "67.17.6",
+  "version": "67.17.7",
   "description": "TypeScript type definitions for Salesforce VS Code Services extension API",
   "author": "Salesforce",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-23371047@

### What changed and why?

Adds a package-scoped `@typescript-eslint/consistent-type-imports` rule for the Visualforce language server, configured with inline type imports.

Updates affected source and test imports to mark type-only symbols explicitly. This enforces consistent import style, avoids duplicate-import conflicts, and preserves runtime behavior.
