### PR TITLE
feat(soql): migrate Limit and All Rows - W-23928682

### DIFF
--- a/.claude/skills/lit-webview-architecture/SKILL.md
+++ b/.claude/skills/lit-webview-architecture/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: lit-webview-architecture
+description: Design or refactor a Lit webview's package boundary, Effect service contract, host adapter, lifecycle, registration, or browser bundle. Use for VS Code webviews that separate browser-safe UI from extension-host APIs and message protocols.
+review: never
+---
+
+# Lit webview architecture
+
+Boundary: UI owns presentation, browser-safe state/actions, and lifecycle coordination; host owns VS Code APIs, transport, metadata/network authorities, and localization.
+
+## Browser-safe contract
+
+- Immutable view state, UI actions, and typed errors from Effect Schemas. Tagged/literal unions instead of loose primitives, enums, or duplicated constants when invalid states matter.
+- Directional host-to-UI and UI-to-host message schemas. Handler variant added with its behavior; exhaustive `Match`; no opposite-direction placeholder arms.
+- Unknown data validated at entry. DOM `CustomEvent`: structural `type`/`detail` guard, then Schema validation of `detail`; inherited DOM accessors do not form a plain schema struct.
+- Required localized labels injected by the host; no defaults hiding missing localization.
+- No VS Code, JSforce, extension service, or extension-message imports in the browser-safe package. Host data normalized and validated before UI state.
+- Only subpaths with known consumers exported; no root/testing barrels. Type-only dependencies in `devDependencies` with `import type`.
+
+## Effect lifecycle
+
+- 1 service contract: initial state, state stream, typed action dispatch. Extension-owned live layer plus deterministic test layers.
+- 1 composition-root-owned scoped fiber per mounted webview: controller, queues, subscriptions, DOM listeners, finalizers.
+- Listeners/subscriptions acquired and released as scoped resources. Disconnect interrupts and awaits the session fiber.
+- Fiber-identity guard on finalizer cleanup; an old disconnect cannot clear a newer rapid reconnection.
+- Components only render state and dispatch intent—no runtimes, scattered `Effect.runFork`/`Effect.runPromise`, or host calls.
+
+## Registration and bundling
+
+- Explicit host-called custom-element registration; every `customElements.define` guarded by `customElements.get`; no registration import side effects.
+- New entries built with shared browser esbuild config. IIFE retained while HTML loads a classic deferred script; ESM requires matching script/resource-rewrite changes.
+- Non-published UI workspaces marked `private` and excluded from publication/versioning. Contract tests scan source and bundles for host imports and Effect execution in presentation code.
+- Compile/bundle/test order expressed in Wireit; browser tests consume the intended emitted application.
+
+Examples: `packages/soql-builder-ui/src/application.ts`, `packages/soql-builder-ui/src/register.ts`, `packages/soql-builder-ui/test/package-contract.test.mjs`, `packages/salesforcedx-vscode-soql/src/soql-builder-ui/lit/`.

--- a/.claude/skills/lit-webview-testing/SKILL.md
+++ b/.claude/skills/lit-webview-testing/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: lit-webview-testing
+description: Write or review browser component tests for Lit webviews and VSCode Elements. Use for Playwright component harnesses, fake Effect services, accessibility locators, shadow DOM boundaries, lifecycle tests, and deciding what belongs in component tests versus VS Code E2E.
+review: never
+---
+
+# Lit webview browser testing
+
+Real browser required for Lit updates, custom elements, popovers, shadow DOM, accessibility trees, and `ElementInternals`.
+
+## Harness boundary
+
+- Real Lit components, controller, and Effect application lifecycle; only extension backend replaced with a fake service layer.
+- No emulated `acquireVsCodeApi()` or local server.
+- Fake types derived from their factory/service source of truth—not handwritten copies.
+- Fakes support deterministic state emission, action recording, typed stream/dispatch failures, controllable latency, and resource counters.
+- Fake latency via Effect `Clock`; `TestClock` in Effect tests, not wall-clock waits.
+
+## What to test here
+
+- Component contracts and state/action flows: initial, loading, disabled, empty/no-match, invalid/recoverable, restored, external update, success, failure.
+- Action count/payload, including rapid or latent actions when cancellation/serialization matters.
+- Connect, disconnect, reconnect, listener/subscription cleanup, scoped finalization.
+- Keyboard, focus, theme, and form behavior where browser semantics matter.
+- Thin extension-host E2E: VS Code wiring, packaging, CSP/resources, desktop/web integration, critical journeys.
+
+## Interaction rules
+
+- Controls located by accessible role/name/label; documented public `value`/`checked` set before dispatching the public event.
+- Observable UI/application assertions—not private state or arbitrary render delays. Mount helper may await `updateComplete` to establish readiness.
+- Unavoidable shadow traversal isolated in 1 named helper, only for otherwise unobservable contracts such as `ElementInternals` form association.
+- Wrapper adapting an inaccessible nested node: user-visible accessibility assertion first; narrowly scoped implementation assertion only if needed.
+
+## Repository integration
+
+- Compile, fixture bundle, and browser execution in the package Wireit graph and relevant CI `test:web` path.
+- Package compile, lint, unit tests, and focused browser suite run from repository root.
+- General syntax/reliability: [playwright-e2e](../playwright-e2e/SKILL.md). This skill owns the component-test boundary.
+
+Examples: `packages/soql-builder-ui/test/browser/`, `packages/soql-builder-ui/src/testing/fakeEffectService.ts`.

--- a/.claude/skills/vscode-elements-webviews/SKILL.md
+++ b/.claude/skills/vscode-elements-webviews/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: vscode-elements-webviews
+description: Integrate @vscode-elements/elements controls into Lit webviews. Use when adding or changing VSCode Elements selects, text fields, checkboxes, buttons, form association, controlled values, accessibility state, or VS Code theme styling.
+review: never
+---
+
+# VSCode Elements in Lit webviews
+
+Wrapper component = adapter between application state and the VSCode Elements public API.
+
+## Imports and controlled state
+
+- Concrete module imports: `@vscode-elements/elements/dist/<element>/index.js`. Class import when narrowing `currentTarget`; side-effect import when only registration is needed.
+- Controlled state through public `.value`, `.checked`, `.invalid`, and `?disabled` properties.
+- `change`, `input`, and `click` events translated to schema-backed application actions; `currentTarget` narrowed with the concrete element class.
+- Slotted option changes clearing a select's pending value: await nested `updateComplete` in `updated()`, then reapply the controlled value.
+- No private control fields.
+
+## Form association
+
+VSCode Elements inputs use `ElementInternals`; a child Lit shadow root can block discovery of a parent-rendered form.
+
+- Outer-form participation required: `createRenderRoot()` returns `this`, with rationale comment.
+- Otherwise: normal shadow DOM. Light DOM is a targeted interop choice, not a component default.
+- Real-browser assertion for the resulting `control.form` relationship.
+
+## Accessibility
+
+- Host-supplied localized labels; semantic `<label for>` plus the control's public `label` where required.
+- Loading, invalid, disabled, empty, and no-match states via accessible attributes or live status text—not color alone.
+- Public host attributes first. When the accessible node is internal and host attributes do not propagate: smallest possible wrapper-local sync adapter, after nested `updateComplete`.
+- Shadow-root knowledge confined to that adapter and targeted low-level test helpers.
+
+## Styling
+
+- Public `--vscode-*` tokens for colors, borders, focus, and typography; spacing consistent with VS Code controls.
+- No assumption that styles cross a VSCode Elements shadow boundary. Third-party content themed separately with the same tokens.
+
+Examples: `packages/soql-builder-ui/src/components/soqlFromElement.ts`, `packages/soql-builder-ui/src/components/soqlFieldsElement.ts`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -46880,7 +46880,7 @@
     },
     "packages/salesforcedx-vscode-services-types": {
       "name": "@salesforce/vscode-services",
-      "version": "67.17.7",
+      "version": "67.17.8",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.43",

--- a/packages/salesforcedx-vscode-services-types/package.json
+++ b/packages/salesforcedx-vscode-services-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/vscode-services",
-  "version": "67.17.7",
+  "version": "67.17.8",
   "description": "TypeScript type definitions for Salesforce VS Code Services extension API",
   "author": "Salesforce",
   "license": "BSD-3-Clause",

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/lit/index.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/lit/index.ts
@@ -20,11 +20,15 @@ const serviceLayer = VscodeSoqlBuilderServiceLive.pipe(Layer.provide(VscodeMessa
 const main = document.querySelector('#main') ?? document.body.appendChild(document.createElement('main'));
 const app = new SoqlBuilderElement();
 app.labels = {
+  allRows: messages.label_all_rows,
   clearAllFields: messages.action_clear_all_fields,
   count: messages.label_count,
   fields: messages.label_fields,
   from: messages.label_from,
   inputs: messages.label_soql_query_inputs,
+  invalidLimit: messages.error_invalid_limit,
+  limit: messages.label_limit,
+  limitPlaceholder: messages.placeholder_limit,
   loading: messages.label_loading,
   noDefaultOrg: messages.label_no_default_org,
   noResults: messages.label_no_results_found,

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/lit/soqlBuilderModelAdapter.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/lit/soqlBuilderModelAdapter.ts
@@ -36,6 +36,7 @@ import {
   type Condition,
   type Query
 } from '@salesforce/soql-model';
+import * as Match from 'effect/Match';
 import * as Predicate from 'effect/Predicate';
 
 const literalFromModel = (literal: unknown): SoqlLiteral | undefined =>
@@ -92,6 +93,22 @@ const conditionOperators: Readonly<Record<SoqlWhereCondition['condition']['opera
   INCLUDES: ConditionOperator.Includes,
   EXCLUDES: ConditionOperator.Excludes
 };
+
+const limitToModel = Match.type<SoqlBuilderQuery['limit']>().pipe(
+  Match.tagsExhaustive({
+    Empty: () => undefined,
+    Invalid: () => undefined,
+    Valid: ({ value }) => new LimitImpl(value)
+  })
+);
+
+const limitToTelemetry = Match.type<SoqlBuilderQuery['limit']>().pipe(
+  Match.tagsExhaustive({
+    Empty: () => undefined,
+    Invalid: () => undefined,
+    Valid: ({ value }) => value
+  })
+);
 
 export const parseSoqlBuilderQuery = (statement: string): SoqlBuilderQuery => {
   const model = deserialize(statement);
@@ -204,7 +221,7 @@ const buildQueryModel = (query: SoqlBuilderQuery): Query => {
     undefined,
     undefined,
     orderByExpressions.length > 0 ? new OrderByImpl(orderByExpressions) : undefined,
-    query.limit._tag === 'Valid' ? new LimitImpl(query.limit.value) : undefined
+    limitToModel(query.limit)
   );
   if (query.headerComments) model.headerComments = new HeaderCommentsImpl(query.headerComments);
   model.allRows = query.allRows;
@@ -219,7 +236,7 @@ export const createSoqlBuilderTelemetry = (query: SoqlBuilderQuery) => ({
     Predicate.isUndefined(error.grammarRule) ? error.type : `${error.type}:${error.grammarRule}`
   ),
   fields: query.fields.length,
-  limit: query.limit._tag === 'Valid' ? query.limit.value : undefined,
+  limit: limitToTelemetry(query.limit),
   orderBy: query.orderBy.length,
   sObject: query.sObject?.includes('__c') ? 'custom' : 'standard',
   unsupported: query.unsupportedSyntax.map(unsupported => unsupported.reason.reasonCode)

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/lit/vscodeSoqlBuilderService.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/lit/vscodeSoqlBuilderService.ts
@@ -8,6 +8,7 @@
 import {
   SoqlBuilderMessageChannelError,
   SoqlBuilderQueryError,
+  SoqlLimitSchema,
   SoqlBuilderStateSchema,
   createInitialSoqlBuilderQuery,
   createInitialSoqlBuilderState,
@@ -74,6 +75,8 @@ const serializeQuery = (query: SoqlBuilderQuery) => tryQueryOperation(() => seri
 const LegacySavedStateSchema = Schema.Struct({
   originalSoqlStatement: Schema.String
 });
+
+const limitsEqual = Schema.equivalence(SoqlLimitSchema);
 
 const decodeSavedState = (input: unknown) =>
   Schema.decodeUnknown(SoqlBuilderStateSchema)(input).pipe(
@@ -152,8 +155,22 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
       return nextState;
     });
 
+  const saveQueryState = (query: SoqlBuilderQuery) =>
+    SubscriptionRef.updateAndGet(state, current => ({ ...current, query })).pipe(
+      Effect.flatMap(nextState => saveViewState(messageService, nextState))
+    );
+
   const modifyQuery = (update: (current: SoqlBuilderState) => SoqlBuilderQuery) =>
-    SubscriptionRef.get(state).pipe(Effect.flatMap(current => publishQuery(current, update(current))));
+    SubscriptionRef.get(state).pipe(
+      Effect.flatMap(current => {
+        const query = update(current);
+        if (query === current.query) return Effect.void;
+        return Match.value(query.limit).pipe(
+          Match.tag('Invalid', () => saveQueryState(query)),
+          Match.orElse(() => publishQuery(current, query).pipe(Effect.asVoid))
+        );
+      })
+    );
 
   const handleMessage = Match.type<HostToUiSoqlEditorEvent>().pipe(
     Match.discriminatorsExhaustive('type')({
@@ -349,16 +366,11 @@ const makeVscodeSoqlBuilderService = Effect.gen(function* () {
           orderBy: query.orderBy.filter(orderBy => orderBy.field !== action.fieldName)
         }))
       ),
-      LimitChanged: Effect.fn('VscodeSoqlBuilderService.dispatchLimitChanged')(function* (action) {
-        if (action.limit._tag === 'Invalid') {
-          const current = yield* SubscriptionRef.get(state);
-          const nextState = { ...current, query: { ...current.query, limit: action.limit } };
-          yield* SubscriptionRef.set(state, nextState);
-          yield* saveViewState(messageService, nextState);
-          return;
-        }
-        yield* modifyQuery(({ query }) => ({ ...query, limit: action.limit }));
-      }),
+      LimitChanged: Effect.fn('VscodeSoqlBuilderService.dispatchLimitChanged')(action =>
+        modifyQuery(({ query }) =>
+          limitsEqual(query.limit, action.limit) ? query : { ...query, limit: action.limit }
+        )
+      ),
       AllRowsChanged: Effect.fn('VscodeSoqlBuilderService.dispatchAllRowsChanged')(action =>
         modifyQuery(({ query }) => ({ ...query, allRows: action.allRows }))
       ),

--- a/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-soql/src/soql-builder-ui/modules/querybuilder/messages/i18n.ts
@@ -67,6 +67,7 @@ export const messages = {
   label_nulls_last: 'Nulls Last',
 
   // limit
+  error_invalid_limit: 'Enter a whole number greater than or equal to 0.',
   label_limit: 'Limit',
   placeholder_limit: 'Limit...',
 

--- a/packages/salesforcedx-vscode-soql/test/jest/soql-builder-ui/lit/vscodeSoqlBuilderService.test.ts
+++ b/packages/salesforcedx-vscode-soql/test/jest/soql-builder-ui/lit/vscodeSoqlBuilderService.test.ts
@@ -20,6 +20,7 @@ import * as Option from 'effect/Option';
 import * as Schema from 'effect/Schema';
 import * as Stream from 'effect/Stream';
 import {
+  createSoqlBuilderTelemetry,
   parseSoqlBuilderQuery,
   serializeSoqlBuilderQuery
 } from '../../../../src/soql-builder-ui/lit/soqlBuilderModelAdapter';
@@ -115,6 +116,62 @@ describe('VscodeSoqlBuilderService', () => {
     expect(restored.orderBy).toEqual([{ field: 'Name', order: 'DESC', nulls: 'NULLS LAST' }]);
     expect(restored.limit).toEqual({ _tag: 'Valid', value: 10 });
     expect(restored.allRows).toBe(true);
+  });
+
+  it('publishes and saves Limit and All Rows changes without altering other clauses', async () => {
+    const harness = makeMessageHarness({
+      originalSoqlStatement: "SELECT Name FROM Account WHERE Name = 'Acme' ORDER BY Name DESC LIMIT 10"
+    });
+
+    const state = await runWithService(harness.layer, service =>
+      Effect.gen(function* () {
+        yield* service.dispatch({ _tag: 'LimitChanged', limit: { _tag: 'Valid', value: 25 } });
+        yield* service.dispatch({ _tag: 'LimitChanged', limit: { _tag: 'Valid', value: 25 } });
+        yield* service.dispatch({ _tag: 'AllRowsChanged', allRows: true });
+
+        const withAllRows = yield* service.initialState;
+        expect(withAllRows.query.originalSoqlStatement?.replace(/\s+/gu, ' ').trim()).toBe(
+          "SELECT Name FROM Account WHERE Name = 'Acme' ORDER BY Name DESC LIMIT 25 ALL ROWS"
+        );
+
+        yield* service.dispatch({ _tag: 'AllRowsChanged', allRows: false });
+        return yield* service.initialState;
+      })
+    );
+
+    expect(state.query.originalSoqlStatement?.replace(/\s+/gu, ' ').trim()).toBe(
+      "SELECT Name FROM Account WHERE Name = 'Acme' ORDER BY Name DESC LIMIT 25"
+    );
+    expect(state.query.limit).toEqual({ _tag: 'Valid', value: 25 });
+    expect(state.query.allRows).toBe(false);
+    expect(createSoqlBuilderTelemetry(state.query).limit).toBe(25);
+    expect(lastSavedState(harness.states)).toEqual(state);
+    expect(harness.messages.filter(message => message.type === MessageType.UI_SOQL_CHANGED)).toHaveLength(3);
+  });
+
+  it('defers publishing other clause changes while Limit input is invalid', async () => {
+    const originalSoqlStatement = 'SELECT Id FROM Account LIMIT 10';
+    const harness = makeMessageHarness({ originalSoqlStatement });
+
+    const invalidState = await runWithService(harness.layer, service =>
+      Effect.gen(function* () {
+        yield* service.dispatch({ _tag: 'LimitChanged', limit: { _tag: 'Invalid', input: '-1' } });
+        yield* service.dispatch({ _tag: 'AllRowsChanged', allRows: true });
+
+        const invalid = yield* service.initialState;
+        expect(harness.messages.filter(message => message.type === MessageType.UI_SOQL_CHANGED)).toHaveLength(0);
+
+        yield* service.dispatch({ _tag: 'LimitChanged', limit: { _tag: 'Valid', value: 25 } });
+        return invalid;
+      })
+    );
+
+    expect(invalidState.query.limit).toEqual({ _tag: 'Invalid', input: '-1' });
+    expect(invalidState.query.allRows).toBe(true);
+    expect(invalidState.query.originalSoqlStatement).toBe(originalSoqlStatement);
+    expect(lastSavedState(harness.states).query.originalSoqlStatement?.replace(/\s+/gu, ' ').trim()).toBe(
+      'SELECT Id FROM Account LIMIT 25 ALL ROWS'
+    );
   });
 
   it('maps every public action to immutable state and the existing host messages', async () => {

--- a/packages/soql-builder-ui/src/components/soqlBuilderElement.styles.ts
+++ b/packages/soql-builder-ui/src/components/soqlBuilderElement.styles.ts
@@ -35,12 +35,14 @@ export const soqlBuilderElementStyles = css`
   }
 
   soql-builder-fields,
-  soql-builder-from {
+  soql-builder-from,
+  soql-builder-limit {
     display: contents;
   }
 
   soql-builder-fields .input,
-  soql-builder-from .input {
+  soql-builder-from .input,
+  soql-builder-limit .input {
     display: grid;
     gap: 4px;
     min-width: 0;
@@ -49,6 +51,28 @@ export const soqlBuilderElementStyles = css`
   soql-builder-from .required {
     color: var(--vscode-inputValidation-errorForeground, var(--vscode-errorForeground, #f48771));
     margin-inline-start: 2px;
+  }
+
+  soql-builder-limit .required {
+    color: var(--vscode-inputValidation-errorForeground, var(--vscode-errorForeground, #f48771));
+    margin-inline-start: 2px;
+  }
+
+  soql-builder-limit .limit-input {
+    justify-items: start;
+  }
+
+  soql-builder-limit vscode-textfield {
+    width: 8rem;
+  }
+
+  soql-builder-limit .all-rows-input {
+    grid-column: 2;
+  }
+
+  soql-builder-limit .validation-error {
+    color: var(--vscode-inputValidation-errorForeground, var(--vscode-errorForeground, #f48771));
+    font-size: 0.92em;
   }
 
   soql-builder-from .status {

--- a/packages/soql-builder-ui/src/components/soqlBuilderElement.ts
+++ b/packages/soql-builder-ui/src/components/soqlBuilderElement.ts
@@ -14,11 +14,15 @@ import { soqlBuilderElementStyles } from './soqlBuilderElement.styles.js';
 export { SoqlBuilderActionEvent } from './soqlBuilderActionEvent.js';
 
 export type SoqlBuilderLabels = {
+  readonly allRows: string;
   readonly clearAllFields: string;
   readonly count: string;
   readonly fields: string;
   readonly from: string;
   readonly inputs: string;
+  readonly invalidLimit: string;
+  readonly limit: string;
+  readonly limitPlaceholder: string;
   readonly loading: string;
   readonly noDefaultOrg: string;
   readonly noResults: string;
@@ -64,6 +68,7 @@ export class SoqlBuilderElement extends LitElement {
     const hasRecoverableFieldsError = state.query.parseErrors.some(error =>
       ['EMPTY', 'NOSELECT', 'NOSELECTIONS'].includes(error.type)
     );
+    const recoverableLimitError = state.query.parseErrors.find(error => error.type === 'INCOMPLETELIMIT');
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- an empty statement must still render as `nothing`, unlike a merely-unset one; `??` would not collapse ''
     const queryPreview = state.query.originalSoqlStatement ? state.query.originalSoqlStatement : nothing;
     return html`
@@ -107,6 +112,19 @@ export class SoqlBuilderElement extends LitElement {
                       }}
                       .selectedFieldNames=${state.query.fields}
                     ></soql-builder-fields>
+                  </div>
+                  <div class="control">
+                    <soql-builder-limit
+                      .allRows=${state.query.allRows}
+                      .labels=${{
+                        allRows: this.labels.allRows,
+                        invalid: this.labels.invalidLimit,
+                        limit: this.labels.limit,
+                        placeholder: this.labels.limitPlaceholder
+                      }}
+                      .limit=${state.query.limit}
+                      .recoverableErrorMessage=${recoverableLimitError?.message}
+                    ></soql-builder-limit>
                   </div>
                 </form>
                 <section class="preview" role="status" aria-live="polite">

--- a/packages/soql-builder-ui/src/components/soqlLimitElement.ts
+++ b/packages/soql-builder-ui/src/components/soqlLimitElement.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { VscodeCheckbox } from '@vscode-elements/elements/dist/vscode-checkbox/index.js';
+import { VscodeTextfield } from '@vscode-elements/elements/dist/vscode-textfield/index.js';
+import * as Match from 'effect/Match';
+import * as Predicate from 'effect/Predicate';
+import { html, LitElement, nothing } from 'lit';
+import { property } from 'lit/decorators/property.js';
+import { query } from 'lit/decorators/query.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { soqlLimitFromInput, type SoqlLimit } from '../domain.js';
+import { SoqlBuilderActionEvent } from './soqlBuilderActionEvent.js';
+
+const LIMIT_ERROR_ID = 'soql-limit-error';
+
+export type SoqlLimitLabels = {
+  readonly allRows: string;
+  readonly invalid: string;
+  readonly limit: string;
+  readonly placeholder: string;
+};
+
+const limitPresentation = Match.type<SoqlLimit>().pipe(
+  Match.tagsExhaustive({
+    Empty: () => ({ input: '', invalid: false }),
+    Invalid: ({ input }) => ({ input, invalid: true }),
+    Valid: ({ value }) => ({ input: String(value), invalid: false })
+  })
+);
+
+export class SoqlLimitElement extends LitElement {
+  @property({ type: Boolean })
+  public accessor allRows = false;
+
+  @property({ attribute: false })
+  public accessor labels!: SoqlLimitLabels;
+
+  @property({ attribute: false })
+  public accessor limit: SoqlLimit = { _tag: 'Empty' };
+
+  @property({ attribute: false })
+  public accessor recoverableErrorMessage: string | undefined;
+
+  @query('vscode-textfield')
+  private accessor textfield: VscodeTextfield | null = null;
+
+  protected override createRenderRoot(): HTMLElement | DocumentFragment {
+    // Keep both form-associated VSCode controls in the builder form's tree. A nested shadow root would prevent
+    // ElementInternals from discovering that outer form.
+    return this;
+  }
+
+  protected override updated(): void {
+    const textfield = this.textfield;
+    if (!textfield) return;
+
+    void textfield.updateComplete.then(() => this.syncTextfieldAriaState());
+  }
+
+  protected override render() {
+    const presentation = limitPresentation(this.limit);
+    const errorMessage = presentation.invalid ? this.labels.invalid : this.recoverableErrorMessage;
+    const invalid = Predicate.isNotUndefined(errorMessage);
+
+    return html`
+      <label class="label" for="soql-limit">
+        ${this.labels.limit}${invalid ? html`<span class="required" aria-hidden="true">*</span>` : nothing}
+      </label>
+      <div class="input limit-input">
+        <vscode-textfield
+          id="soql-limit"
+          name="limit"
+          type="number"
+          min="0"
+          step="1"
+          .max=${Number.MAX_SAFE_INTEGER}
+          .label=${this.labels.limit}
+          .placeholder=${this.labels.placeholder}
+          .invalid=${invalid}
+          .value=${presentation.input}
+          aria-invalid=${invalid ? 'true' : 'false'}
+          aria-describedby=${ifDefined(invalid ? LIMIT_ERROR_ID : undefined)}
+          @change=${this.handleLimitChange}
+          @input=${this.handleLimitChange}
+        ></vscode-textfield>
+        ${invalid ? html`<span id=${LIMIT_ERROR_ID} class="validation-error">${errorMessage}</span>` : nothing}
+      </div>
+      <div class="input all-rows-input">
+        <vscode-checkbox name="allRows" .checked=${this.allRows} @change=${this.handleAllRowsChange}
+          >${this.labels.allRows}</vscode-checkbox
+        >
+      </div>
+    `;
+  }
+
+  private syncTextfieldAriaState(): void {
+    const input = this.textfield?.wrappedElement;
+    if (!input) return;
+
+    const presentation = limitPresentation(this.limit);
+    const errorMessage = presentation.invalid ? this.labels.invalid : this.recoverableErrorMessage;
+    const invalid = Predicate.isNotUndefined(errorMessage);
+    input.setAttribute('aria-invalid', invalid ? 'true' : 'false');
+    if (invalid) {
+      // An ID reference cannot cross from the control's shadow root to this adapter's light DOM. Mirror the
+      // localized message onto the actual accessible input so assistive technology receives the description.
+      input.setAttribute('aria-description', errorMessage);
+    } else {
+      input.removeAttribute('aria-description');
+    }
+  }
+
+  private readonly handleLimitChange = (event: Event): void => {
+    const textfield = event.currentTarget;
+    if (textfield instanceof VscodeTextfield) {
+      this.dispatchEvent(
+        new SoqlBuilderActionEvent({
+          _tag: 'LimitChanged',
+          limit: soqlLimitFromInput(textfield.value)
+        })
+      );
+    }
+  };
+
+  private readonly handleAllRowsChange = (event: Event): void => {
+    const checkbox = event.currentTarget;
+    if (checkbox instanceof VscodeCheckbox) {
+      this.dispatchEvent(
+        new SoqlBuilderActionEvent({
+          _tag: 'AllRowsChanged',
+          allRows: checkbox.checked
+        })
+      );
+    }
+  };
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'soql-builder-limit': SoqlLimitElement;
+  }
+}

--- a/packages/soql-builder-ui/src/register.ts
+++ b/packages/soql-builder-ui/src/register.ts
@@ -8,6 +8,7 @@
 import { SoqlBuilderElement } from './components/soqlBuilderElement.js';
 import { SoqlFieldsElement } from './components/soqlFieldsElement.js';
 import { SoqlFromElement } from './components/soqlFromElement.js';
+import { SoqlLimitElement } from './components/soqlLimitElement.js';
 
 export const registerSoqlBuilderElements = (): void => {
   if (!customElements.get('soql-builder-fields')) {
@@ -15,6 +16,9 @@ export const registerSoqlBuilderElements = (): void => {
   }
   if (!customElements.get('soql-builder-from')) {
     customElements.define('soql-builder-from', SoqlFromElement);
+  }
+  if (!customElements.get('soql-builder-limit')) {
+    customElements.define('soql-builder-limit', SoqlLimitElement);
   }
   if (!customElements.get('soql-builder-app')) {
     customElements.define('soql-builder-app', SoqlBuilderElement);

--- a/packages/soql-builder-ui/test/browser/fixture.ts
+++ b/packages/soql-builder-ui/test/browser/fixture.ts
@@ -163,11 +163,15 @@ window.soqlBuilderHarness = {
     fake = Effect.runSync(makeFakeSoqlBuilderService(latestState));
     element = document.createElement('soql-builder-app');
     element.labels = {
+      allRows: 'Include deleted/archived records',
       clearAllFields: 'Clear All',
       count: 'COUNT()',
       fields: 'Fields',
       from: 'From',
       inputs: 'Query inputs',
+      invalidLimit: 'Enter a whole number greater than or equal to 0.',
+      limit: 'Limit',
+      limitPlaceholder: 'Limit...',
       loading: 'Loading...',
       noDefaultOrg: 'No default org',
       noResults: 'No results found.',

--- a/packages/soql-builder-ui/test/browser/helpers.ts
+++ b/packages/soql-builder-ui/test/browser/helpers.ts
@@ -25,6 +25,10 @@ export const fieldsSelect = (page: Page): Locator => builder(page).locator('vsco
 
 export const countCheckbox = (page: Page): Locator => builder(page).locator('vscode-checkbox[name="count"]');
 
+export const limitTextfield = (page: Page): Locator => builder(page).locator('vscode-textfield[name="limit"]');
+
+export const allRowsCheckbox = (page: Page): Locator => builder(page).locator('vscode-checkbox[name="allRows"]');
+
 export const clearAllFieldsButton = (page: Page): Locator =>
   builder(page).locator('vscode-button').filter({ hasText: 'Clear All' });
 
@@ -61,6 +65,29 @@ export const selectValue = async (control: Locator, value: string | readonly str
   }, value);
 };
 
+export const setTextfieldValue = async (
+  control: Locator,
+  value: string,
+  eventType: 'change' | 'input'
+): Promise<void> => {
+  await control.evaluate(
+    (node, next) => {
+      if (!('value' in node)) throw new Error('Expected a VSCode Elements control with a public value property');
+      node.value = next.value;
+      node.dispatchEvent(new Event(next.eventType, { bubbles: true, composed: true }));
+    },
+    { eventType, value }
+  );
+};
+
+export const setCheckboxChecked = async (control: Locator, checked: boolean): Promise<void> => {
+  await control.evaluate((node, nextChecked) => {
+    if (!('checked' in node)) throw new Error('Expected a VSCode Elements checkbox with a public checked property');
+    node.checked = nextChecked;
+    node.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+  }, checked);
+};
+
 /**
  * The only intentional shadow-root traversal in the harness. It verifies VSCode Elements' ElementInternals-backed
  * form association, which is not observable through an accessibility locator or the host element's attributes.
@@ -71,13 +98,19 @@ export const expectFormAssociation = async (page: Page): Promise<void> => {
     const form = root?.querySelector<HTMLFormElement>('form');
     const object = root?.querySelector<HTMLElement & { form: HTMLFormElement | null }>('vscode-single-select');
     const fields = root?.querySelector<HTMLElement & { form: HTMLFormElement | null }>('vscode-multi-select');
+    const limit = root?.querySelector<HTMLElement & { form: HTMLFormElement | null }>('vscode-textfield');
+    const allRows = root?.querySelector<HTMLElement & { form: HTMLFormElement | null }>(
+      'vscode-checkbox[name="allRows"]'
+    );
     return {
+      allRowsForm: allRows?.form === form,
       fieldsForm: fields?.form === form,
+      limitForm: limit?.form === form,
       objectForm: object?.form === form
     };
   });
 
-  expect(association).toEqual({ fieldsForm: true, objectForm: true });
+  expect(association).toEqual({ allRowsForm: true, fieldsForm: true, limitForm: true, objectForm: true });
 };
 
 export const emitState = (page: Page, overrides: StateOverrides): Promise<void> =>

--- a/packages/soql-builder-ui/test/browser/soqlBuilderMount.spec.ts
+++ b/packages/soql-builder-ui/test/browser/soqlBuilderMount.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { expect, test } from '@playwright/test';
-import { expectFormAssociation, fieldsSelect, fromSelect, mountBuilder } from './helpers.js';
+import { expectFormAssociation, fieldsSelect, fromSelect, limitTextfield, mountBuilder } from './helpers.js';
 
 test('mounts with accessible roles, labels, keyboard focus, and form association', async ({ page }) => {
   await mountBuilder(page, { query: { sObject: 'Account' } });
@@ -15,6 +15,8 @@ test('mounts with accessible roles, labels, keyboard focus, and form association
     await expect(page.getByRole('form', { name: 'Query inputs' })).toBeVisible();
     await expect(page.getByRole('combobox', { name: 'From' })).toBeVisible();
     await expect(page.getByRole('combobox', { name: 'Fields' })).toBeVisible();
+    await expect(page.getByRole('spinbutton', { name: 'Limit' })).toBeVisible();
+    await expect(page.getByRole('checkbox', { name: 'Include deleted/archived records' })).toBeVisible();
     await expect(page.getByRole('status')).toContainText('Query preview');
     await expectFormAssociation(page);
   });
@@ -24,5 +26,10 @@ test('mounts with accessible roles, labels, keyboard focus, and form association
     await expect.poll(() => fromSelect(page).evaluate(node => node.matches(':focus-within'))).toBe(true);
     await page.keyboard.press('Tab');
     await expect.poll(() => fieldsSelect(page).evaluate(node => node.matches(':focus-within'))).toBe(true);
+
+    await page.getByRole('spinbutton', { name: 'Limit' }).focus();
+    await expect.poll(() => limitTextfield(page).evaluate(node => node.matches(':focus-within'))).toBe(true);
+    await page.keyboard.press('Tab');
+    await expect(page.getByRole('checkbox', { name: 'Include deleted/archived records' })).toBeFocused();
   });
 });

--- a/packages/soql-builder-ui/test/browser/soqlFromThemes.spec.ts
+++ b/packages/soql-builder-ui/test/browser/soqlFromThemes.spec.ts
@@ -26,7 +26,7 @@ const themes = [
   }
 ] as const;
 
-test('uses VS Code theme tokens in light, dark, and high-contrast themes', async ({ page }) => {
+test('uses VS Code validation theme tokens in light, dark, and high-contrast themes', async ({ page }) => {
   await mountBuilder(page, {
     metadata: { objects: [] },
     query: {
@@ -36,6 +36,12 @@ test('uses VS Code theme tokens in light, dark, and high-contrast themes', async
           lineNumber: 1,
           message: 'Expected an object after FROM',
           type: 'INCOMPLETEFROM'
+        },
+        {
+          charInLine: 20,
+          lineNumber: 1,
+          message: 'Expected a number after LIMIT',
+          type: 'INCOMPLETELIMIT'
         }
       ]
     }
@@ -61,6 +67,13 @@ test('uses VS Code theme tokens in light, dark, and high-contrast themes', async
         .poll(() =>
           builder(page)
             .locator('soql-builder-from .required')
+            .evaluate(node => getComputedStyle(node).color)
+        )
+        .toBe(theme.error);
+      await expect
+        .poll(() =>
+          builder(page)
+            .locator('soql-builder-limit .validation-error')
             .evaluate(node => getComputedStyle(node).color)
         )
         .toBe(theme.error);

--- a/packages/soql-builder-ui/test/browser/soqlLimitActions.spec.ts
+++ b/packages/soql-builder-ui/test/browser/soqlLimitActions.spec.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect, test } from '@playwright/test';
+import { allRowsCheckbox, limitTextfield, mountBuilder, setCheckboxChecked, setTextfieldValue } from './helpers.js';
+
+test('dispatches typed Limit and All Rows actions through VSCode Elements public APIs', async ({ page }) => {
+  await mountBuilder(page, { query: { sObject: 'Account' } });
+
+  await test.step('maps input and change events to explicit limit states', async () => {
+    await setTextfieldValue(limitTextfield(page), '25', 'input');
+    await setTextfieldValue(limitTextfield(page), '50', 'change');
+    await setTextfieldValue(limitTextfield(page), '-1', 'input');
+    await setTextfieldValue(limitTextfield(page), '', 'change');
+  });
+
+  await test.step('maps checkbox changes to All Rows actions', async () => {
+    await setCheckboxChecked(allRowsCheckbox(page), true);
+    await setCheckboxChecked(allRowsCheckbox(page), false);
+  });
+
+  await expect
+    .poll(() => page.evaluate(() => window.soqlBuilderHarness.recordedActions()))
+    .toEqual([
+      { _tag: 'LimitChanged', limit: { _tag: 'Valid', value: 25 } },
+      { _tag: 'LimitChanged', limit: { _tag: 'Valid', value: 50 } },
+      { _tag: 'LimitChanged', limit: { _tag: 'Invalid', input: '-1' } },
+      { _tag: 'LimitChanged', limit: { _tag: 'Empty' } },
+      { _tag: 'AllRowsChanged', allRows: true },
+      { _tag: 'AllRowsChanged', allRows: false }
+    ]);
+});

--- a/packages/soql-builder-ui/test/browser/soqlLimitStates.spec.ts
+++ b/packages/soql-builder-ui/test/browser/soqlLimitStates.spec.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect, test } from '@playwright/test';
+import { allRowsCheckbox, emitState, limitTextfield, mountBuilder } from './helpers.js';
+
+test('renders restored, invalid, recoverable-error, and external Limit and All Rows states', async ({ page }) => {
+  await test.step('restores a valid limit and checked All Rows state', async () => {
+    await mountBuilder(page, {
+      query: { allRows: true, limit: { _tag: 'Valid', value: 10 }, sObject: 'Account' }
+    });
+    await expect(limitTextfield(page)).toHaveJSProperty('value', '10');
+    await expect(allRowsCheckbox(page)).toHaveJSProperty('checked', true);
+  });
+
+  await test.step('reflects external updates', async () => {
+    await emitState(page, { query: { allRows: false, limit: { _tag: 'Empty' } } });
+    await expect(limitTextfield(page)).toHaveJSProperty('value', '');
+    await expect(allRowsCheckbox(page)).toHaveJSProperty('checked', false);
+  });
+
+  await test.step('associates local validation errors with the numeric input', async () => {
+    await emitState(page, { query: { limit: { _tag: 'Invalid', input: '1.5' }, parseErrors: [] } });
+    const error = page.getByText('Enter a whole number greater than or equal to 0.', { exact: true });
+    await expect(error).toBeVisible();
+    await expect(limitTextfield(page)).toHaveAttribute('aria-invalid', 'true');
+    await expect(limitTextfield(page)).toHaveAttribute('aria-describedby', 'soql-limit-error');
+    await expect(page.getByRole('spinbutton', { name: 'Limit' })).toHaveAttribute('aria-invalid', 'true');
+    await expect(page.getByRole('spinbutton', { name: 'Limit' })).toHaveAccessibleDescription(
+      'Enter a whole number greater than or equal to 0.'
+    );
+  });
+
+  await test.step('renders the parser message for a recoverable incomplete LIMIT clause', async () => {
+    await emitState(page, {
+      query: {
+        limit: { _tag: 'Empty' },
+        parseErrors: [
+          {
+            charInLine: 36,
+            lineNumber: 1,
+            message: 'The LIMIT keyword must be followed by a number.',
+            type: 'INCOMPLETELIMIT'
+          }
+        ]
+      }
+    });
+    const errorMessage = 'The LIMIT keyword must be followed by a number.';
+    await expect(page.getByText(errorMessage, { exact: true })).toBeVisible();
+    await expect(page.getByText('Limit*', { exact: true })).toBeVisible();
+    await expect(page.getByRole('spinbutton', { name: 'Limit' })).toHaveAccessibleDescription(errorMessage);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

- Adds Lit `Limit` and `All Rows` controls with restored, external-update, and invalid-input states.
- Routes both actions through the Effect service so valid queries update the preview, document, saved state, and telemetry model without dropping existing clauses.
- Keeps malformed Limit input local until it becomes valid, preventing invalid SOQL from reaching the editor.
- Adds browser and service coverage for actions, state restoration, keyboard focus, accessible validation, and VS Code themes.
- Adds reusable Lit webview architecture, testing, and VSCode Elements guidance.
- Synchronizes generated `@salesforce/vscode-services` package metadata with current develop.

### What issues does this PR fix or reference?
@W-23928682@

### Functionality Before

The Lit SOQL Builder had no controls for `LIMIT` or `ALL ROWS`.

### Functionality After

Users can enter or remove a non-negative integer Limit and toggle All Rows. The controls preserve existing query clauses and restored state, surface accessible validation, and remain synchronized with external document edits.

### Testing

- Pre-commit: 103 applicable scripts passed.
- Pre-push: 84 applicable scripts passed.