### PR TITLE
chore: Fix circular dependency in salesforcedx-vscode-lwc test support and add check:circular-deps - W-23566390

### DIFF
--- a/.claude/plans/W-23566390.md
+++ b/.claude/plans/W-23566390.md
@@ -1,0 +1,34 @@
+# W-23566390
+
+## Context
+
+- GUS subject: Fix circular dependency in salesforcedx-vscode-lwc test support and add check:circular-deps [ai-auto] [repo:forcedotcom/salesforcedx-vscode].
+- `testRunner/testRunner.ts` imports the `workspace` barrel; that barrel imports `getCliArgsFromJestArgs.ts`; `getCliArgsFromJestArgs.ts` imports `TestRunType` back from `testRunner.ts`.
+- Move the shared type to the existing test-support types module so workspace argument construction no longer depends on the test runner.
+- `packages/salesforcedx-vscode-lwc/package.json` already defines the Wireit-backed `check:circular-deps` script and makes `lint` depend on it; preserve that configuration rather than duplicating it.
+
+## Phases
+
+### 1. Remove the test-support dependency cycle
+
+Commit: `fix: remove circular dependency from LWC test support`
+
+- Add `TestRunType` to `packages/salesforcedx-vscode-lwc/src/testSupport/types/index.ts`.
+- Import `TestRunType` from the types module in `packages/salesforcedx-vscode-lwc/src/testSupport/testRunner/testRunner.ts`; remove its local declaration.
+- Import `TestRunType` from the types module in `packages/salesforcedx-vscode-lwc/src/testSupport/workspace/getCliArgsFromJestArgs.ts`.
+- Keep runtime behavior and Jest CLI argument generation unchanged.
+
+## Skills to apply
+
+- `typescript`: type-only shared definition and imports.
+- `wireit`: validate the existing circular-dependency check through its package script.
+- `verification`: run package-scoped compile, lint, tests, and the explicit dependency check.
+- `concise`: keep this plan direct and implementation-focused.
+
+## Verification
+
+1. Run `npm install` from the repository root.
+2. Run `WIREIT_CACHE=none npm run check:circular-deps -w salesforcedx-vscode-lwc`.
+3. Run `WIREIT_CACHE=none npm run compile -w salesforcedx-vscode-lwc`.
+4. Run `WIREIT_CACHE=none npm run lint -w salesforcedx-vscode-lwc`.
+5. Run `WIREIT_CACHE=none npm test -w salesforcedx-vscode-lwc`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -46880,7 +46880,7 @@
     },
     "packages/salesforcedx-vscode-services-types": {
       "name": "@salesforce/vscode-services",
-      "version": "67.17.7",
+      "version": "67.17.8",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.43",

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/testRunner/testRunner.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/testRunner/testRunner.ts
@@ -11,12 +11,10 @@ import * as vscode from 'vscode';
 import { nls } from '../../messages';
 import { getRuntime } from '../../services/runtime';
 import { telemetryService } from '../../telemetry';
-import { isTestCaseInfo, TestExecutionInfo } from '../types';
+import { isTestCaseInfo, type TestExecutionInfo, type TestRunType } from '../types';
 import { workspace, workspaceService } from '../workspace';
 import { SfTask, taskService } from './taskService';
 import { testResultsWatcher } from './testResultsWatcher';
-
-export type TestRunType = 'run' | 'debug' | 'watch';
 
 /**
  * Returns the path to pass to Jest's --runTestsByPath.

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/types/index.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/types/index.ts
@@ -13,6 +13,8 @@ import { URI } from 'vscode-uri';
  */
 export type TestResultStatus = 'passed' | 'failed' | 'skipped' | 'unknown';
 
+export type TestRunType = 'run' | 'debug' | 'watch';
+
 /**
  * Test Result type contains the test result status.
  * For now, failure messages are stored in DiagnosticCollection instead of here.

--- a/packages/salesforcedx-vscode-lwc/src/testSupport/workspace/getCliArgsFromJestArgs.ts
+++ b/packages/salesforcedx-vscode-lwc/src/testSupport/workspace/getCliArgsFromJestArgs.ts
@@ -4,8 +4,8 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import type { TestRunType } from '../types';
 import { workspace } from 'vscode';
-import { TestRunType } from '../testRunner/testRunner';
 
 /**
  * Returns workspace specific jest args from CLI arguments and test run type

--- a/packages/salesforcedx-vscode-services-types/package.json
+++ b/packages/salesforcedx-vscode-services-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/vscode-services",
-  "version": "67.17.7",
+  "version": "67.17.8",
   "description": "TypeScript type definitions for Salesforce VS Code Services extension API",
   "author": "Salesforce",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
### What issues does this PR fix or reference?

@W-23566390@

### What changed and why?

- Moved the shared `TestRunType` definition into the test-support types module.
- Updated the test runner and Jest argument helper to import the type from that module.
- Removed the circular dependency between the test runner and workspace support while preserving runtime behavior and Jest argument generation.
- Kept the existing Wireit-backed `check:circular-deps` configuration as the validation mechanism.
- Synchronized `@salesforce/vscode-services` package metadata and lockfile to version `67.17.8`.
