### PR TITLE
feat(apex): add Effect foundation - W-23839365

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45973,6 +45973,7 @@
       "version": "9.0.7",
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@effect/platform": "^0.96.1",
         "@salesforce/core": "^9.1.9",
         "@salesforce/kit": "^4.0.0",
         "fast-glob": "^3.3.2",
@@ -45980,6 +45981,7 @@
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.2.0",
+        "effect": "^3.21.2",
         "json-stream-stringify": "^3.1.7"
       },
       "devDependencies": {
@@ -45989,7 +45991,6 @@
         "@types/istanbul-lib-report": "^3.0.3",
         "@types/istanbul-reports": "^3.0.4",
         "@types/sinon": "^17.0.3",
-        "effect": "^3.21.2",
         "prettier": "3.8.3",
         "sinon": "^17.0.1"
       },
@@ -46855,6 +46856,7 @@
         "@opentelemetry/sdk-trace-base": "2.10.0",
         "@opentelemetry/sdk-trace-node": "2.8.0",
         "@opentelemetry/sdk-trace-web": "2.8.0",
+        "@salesforce/apex-node": "*",
         "@salesforce/core": "^9.1.9",
         "@salesforce/o11y-reporter": "^1.8.5",
         "@salesforce/salesforcedx-utils": "*",
@@ -46880,7 +46882,7 @@
     },
     "packages/salesforcedx-vscode-services-types": {
       "name": "@salesforce/vscode-services",
-      "version": "67.17.7",
+      "version": "67.17.8",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.43",
@@ -46893,6 +46895,7 @@
         "@opentelemetry/sdk-trace-base": "2.10.0",
         "@opentelemetry/sdk-trace-node": "2.8.0",
         "@opentelemetry/sdk-trace-web": "2.8.0",
+        "@salesforce/apex-node": "*",
         "@salesforce/core": "^9.1.9",
         "@salesforce/source-deploy-retrieve": "^13.2.0",
         "@salesforce/source-tracking": "^8.0.0",

--- a/packages/salesforcedx-apex/README.md
+++ b/packages/salesforcedx-apex/README.md
@@ -9,6 +9,11 @@ Note: Please report any issues via the [Issues tab](https://github.com/forcedotc
 
 <br/>
 
+## API entry points
+
+- `@salesforce/apex-node` is the backward-compatible Promise and class API.
+- `@salesforce/apex-node/effect` is the primary API for new Effect operations, schemas, errors, and host capabilities.
+
 ## Getting Started
 
 If you're interested in contributing, take a look at the [CONTRIBUTING](./CONTRIBUTING.md) guide.

--- a/packages/salesforcedx-apex/docs/adr/0004-public-api-contract.md
+++ b/packages/salesforcedx-apex/docs/adr/0004-public-api-contract.md
@@ -3,14 +3,15 @@
 The next `@salesforce/apex-node` major protects the package root used by known
 CLI and public GitHub consumers. The baseline intentionally excludes unused
 runtime exports, public implementation helpers, VS Code-only reporters, and the
-legacy `lib/src/tests/types.js` path.
+legacy `lib/src/tests/types.js` path. New Effect APIs are published separately
+from `@salesforce/apex-node/effect`.
 
 Effect schemas record the JSON-representable contracts under `schemas/`.
 Package lint fails when the generated JSON Schema differs from the checked-in
 contract, and build-time type assertions keep the schemas aligned with the
 exported TypeScript types. A focused test protects the target runtime exports
-and root-only package `exports` map. Co-repo TypeScript consumers continue to
-compile against the class and callback APIs that JSON Schema cannot represent.
+and package `exports` map. Co-repo TypeScript consumers continue to compile
+against class, capability, and callback APIs that JSON Schema cannot represent.
 
 Intentional API changes require review plus an explicit schema update. Internal
 modules can otherwise move or change without altering the approved schema.

--- a/packages/salesforcedx-apex/docs/adr/0005-effect-api-and-host-boundaries.md
+++ b/packages/salesforcedx-apex/docs/adr/0005-effect-api-and-host-boundaries.md
@@ -23,7 +23,7 @@ This supersedes the direction proposed in closed [PR 7599](https://github.com/fo
 ## Consequences
 
 - Traditional consumers do not receive `Effect.Effect` return types or need to run Effects, although Effect is a package runtime dependency and may appear behind schema-derived declarations.
-- `./effect` is a deliberate public API expansion with its own API Extractor report, package-export test, and packed-consumer validation.
+- `./effect` is a deliberate public API expansion covered by the JSON-schema contract, package-export test, and packed-consumer validation.
 - Wire schemas decode untrusted transport and persisted data; domain schemas define normalized public values. Capability objects such as connections, streams, callbacks, and cancellation handles are not schema-modeled.
 - The foundation adds structure, exports, errors, and layers only. Execute, log, test, coverage, streaming, reporter, and file behavior migrates in their respective work items.
 - Promise adapters may depend on Effect implementations; Effect implementations must not call legacy service classes.

--- a/packages/salesforcedx-apex/package.json
+++ b/packages/salesforcedx-apex/package.json
@@ -11,9 +11,14 @@
     ".": {
       "types": "./out/src/index.d.ts",
       "default": "./out/src/index.js"
+    },
+    "./effect": {
+      "types": "./out/src/effect/index.d.ts",
+      "default": "./out/src/effect/index.js"
     }
   },
   "dependencies": {
+    "@effect/platform": "^0.96.1",
     "@salesforce/core": "^9.1.9",
     "@salesforce/kit": "^4.0.0",
     "fast-glob": "^3.3.2",
@@ -21,6 +26,7 @@
     "istanbul-lib-coverage": "^3.2.2",
     "istanbul-lib-report": "^3.0.1",
     "istanbul-reports": "^3.2.0",
+    "effect": "^3.21.2",
     "json-stream-stringify": "^3.1.7"
   },
   "devDependencies": {
@@ -30,7 +36,6 @@
     "@types/istanbul-lib-report": "^3.0.3",
     "@types/istanbul-reports": "^3.0.4",
     "@types/sinon": "^17.0.3",
-    "effect": "^3.21.2",
     "prettier": "3.8.3",
     "sinon": "^17.0.1"
   },
@@ -53,6 +58,7 @@
     "check:circular-deps": "wireit",
     "clean": "shx rm -rf node_modules out dist coverage .wireit .eslintcache .circular-deps.json",
     "test:compile": "wireit",
+    "test:packed-web": "wireit",
     "test": "wireit"
   },
   "versionedIndependently": true,
@@ -109,7 +115,8 @@
     "test": {
       "command": "jest",
       "dependencies": [
-        "test:compile"
+        "test:compile",
+        "test:packed-web"
       ],
       "files": [
         "src/**/*.ts",
@@ -120,6 +127,20 @@
       "output": [
         "coverage"
       ]
+    },
+    "test:packed-web": {
+      "command": "node scripts/verify-packed-web-consumer.mjs",
+      "dependencies": [
+        "compile"
+      ],
+      "files": [
+        "out/**",
+        "package.json",
+        "scripts/verify-packed-web-consumer.mjs",
+        "../../scripts/bundling/*.js",
+        "../../scripts/bundling/*.mjs"
+      ],
+      "output": []
     },
     "lint": {
       "command": "eslint --color --cache --cache-location .eslintcache .",
@@ -139,7 +160,7 @@
       "output": []
     },
     "check:circular-deps": {
-      "command": "dpdm -T --no-warning --no-tree --exit-code circular:1 --output .circular-deps.json src/index.ts",
+      "command": "dpdm -T --no-warning --no-tree --exit-code circular:1 --output .circular-deps.json src/index.ts src/effect/index.ts",
       "dependencies": [
         "compile"
       ],

--- a/packages/salesforcedx-apex/schemas/README.md
+++ b/packages/salesforcedx-apex/schemas/README.md
@@ -1,8 +1,9 @@
 # Public JSON API schema
 
 `public-api.schema.json` is generated from Effect schemas and records every
-JSON-representable data contract in the supported `@salesforce/apex-node` API.
-Use the named entries under `$defs` when inspecting an individual contract.
+JSON-representable data contract in the supported `@salesforce/apex-node` root
+and `@salesforce/apex-node/effect` APIs. Use the named entries under `$defs`
+when inspecting an individual contract.
 
 Run `npm run schema:check -w @salesforce/apex-node` to verify the checked-in
 schema or `npm run schema:update -w @salesforce/apex-node` after an intentional

--- a/packages/salesforcedx-apex/schemas/public-api.schema.json
+++ b/packages/salesforcedx-apex/schemas/public-api.schema.json
@@ -1,6 +1,16 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$defs": {
+    "ApexConnectionError": {
+      "type": "object",
+      "required": ["message", "_tag"],
+      "properties": {
+        "message": { "type": "string" },
+        "cause": { "type": "string" },
+        "_tag": { "type": "string", "enum": ["ApexConnectionError"] }
+      },
+      "additionalProperties": false
+    },
     "ApexCodeCoverage": {
       "type": "object",
       "required": ["done", "totalSize", "records"],
@@ -380,6 +390,35 @@
       },
       "additionalProperties": false
     },
+    "ApexOperationError": {
+      "type": "object",
+      "required": ["operation", "message", "_tag"],
+      "properties": {
+        "operation": { "$ref": "#/$defs/NonEmptyTrimmedString" },
+        "message": { "type": "string" },
+        "cause": { "type": "string" },
+        "_tag": { "type": "string", "enum": ["ApexOperationError"] }
+      },
+      "additionalProperties": false
+    },
+    "NonEmptyTrimmedString": {
+      "type": "string",
+      "description": "a non empty string",
+      "title": "nonEmptyString",
+      "pattern": "^\\S[\\s\\S]*\\S$|^\\S$|^$",
+      "minLength": 1
+    },
+    "ApexResponseDecodeError": {
+      "type": "object",
+      "required": ["operation", "message", "_tag"],
+      "properties": {
+        "operation": { "$ref": "#/$defs/NonEmptyTrimmedString" },
+        "message": { "type": "string" },
+        "cause": { "type": "string" },
+        "_tag": { "type": "string", "enum": ["ApexResponseDecodeError"] }
+      },
+      "additionalProperties": false
+    },
     "AsyncTestArrayConfiguration": {
       "type": "object",
       "required": ["tests", "testLevel"],
@@ -676,6 +715,7 @@
     }
   },
   "anyOf": [
+    { "$ref": "#/$defs/ApexConnectionError" },
     { "$ref": "#/$defs/ApexCodeCoverage" },
     { "$ref": "#/$defs/ApexCodeCoverageAggregate" },
     { "$ref": "#/$defs/ApexCodeCoverageAggregateRecord" },
@@ -692,6 +732,8 @@
     { "$ref": "#/$defs/ApexTestResultOutcome" },
     { "$ref": "#/$defs/ApexTestRunResultStatus" },
     { "$ref": "#/$defs/ApexTestSetupData" },
+    { "$ref": "#/$defs/ApexOperationError" },
+    { "$ref": "#/$defs/ApexResponseDecodeError" },
     { "$ref": "#/$defs/AsyncTestArrayConfiguration" },
     { "$ref": "#/$defs/AsyncTestConfiguration" },
     { "$ref": "#/$defs/CodeCoverageResult" },

--- a/packages/salesforcedx-apex/scripts/generatePublicApiSchema.ts
+++ b/packages/salesforcedx-apex/scripts/generatePublicApiSchema.ts
@@ -45,6 +45,7 @@ import * as Schema from 'effect/Schema';
 import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import * as Prettier from 'prettier';
+import { ApexConnectionError, ApexOperationError, ApexResponseDecodeError } from '../src/effect';
 
 const optional = Schema.optional;
 const StringArray = Schema.Array(Schema.String);
@@ -388,6 +389,7 @@ const ApexTestProgressValueSchema = Schema.Union(
 ).annotations({ identifier: 'ApexTestProgressValue' });
 
 const PublicApiSchema = Schema.Union(
+  ApexConnectionError,
   ApexCodeCoverageSchema,
   ApexCodeCoverageAggregateSchema,
   ApexCodeCoverageAggregateRecordSchema,
@@ -404,6 +406,8 @@ const PublicApiSchema = Schema.Union(
   ApexTestResultOutcomeSchema,
   ApexTestRunResultStatusSchema,
   ApexTestSetupDataSchema,
+  ApexOperationError,
+  ApexResponseDecodeError,
   AsyncTestArrayConfigurationSchema,
   AsyncTestConfigurationSchema,
   CodeCoverageResultSchema,

--- a/packages/salesforcedx-apex/scripts/verify-packed-web-consumer.mjs
+++ b/packages/salesforcedx-apex/scripts/verify-packed-web-consumer.mjs
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { commonConfigBrowser } from '../../../scripts/bundling/web.mjs';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const tempParent = join(packageRoot, 'temp');
+mkdirSync(tempParent, { recursive: true });
+const consumerRoot = mkdtempSync(join(tempParent, 'packed-web-consumer-'));
+
+try {
+  const packResult = JSON.parse(
+    execFileSync('npm', ['pack', '--json', '--pack-destination', consumerRoot], {
+      cwd: packageRoot,
+      encoding: 'utf8',
+      env: { ...process.env, npm_config_cache: join(consumerRoot, '.npm-cache') }
+    })
+  );
+  const tarballPath = join(consumerRoot, packResult[0].filename);
+  const installedPackage = join(consumerRoot, 'node_modules', '@salesforce', 'apex-node');
+  mkdirSync(installedPackage, { recursive: true });
+  execFileSync('tar', ['-xzf', tarballPath, '--strip-components=1', '-C', installedPackage]);
+
+  const effectEntry = join(consumerRoot, 'effect-consumer.mjs');
+  writeFileSync(
+    effectEntry,
+    "import { ApexConnectionProvider, ApexOperationError } from '@salesforce/apex-node/effect';\n" +
+      'globalThis.apexEffectApi = { ApexConnectionProvider, ApexOperationError };\n'
+  );
+  await build({
+    entryPoints: [effectEntry],
+    bundle: true,
+    conditions: ['import', 'module', 'default'],
+    format: 'esm',
+    platform: 'browser',
+    write: false
+  });
+
+  const fullEntry = join(consumerRoot, 'full-consumer.mjs');
+  writeFileSync(
+    fullEntry,
+    "import { TestService } from '@salesforce/apex-node';\n" +
+      "import { ApexConnectionProvider } from '@salesforce/apex-node/effect';\n" +
+      'globalThis.apexNodeApi = { TestService, ApexConnectionProvider };\n'
+  );
+  await build({
+    ...commonConfigBrowser,
+    entryPoints: [fullEntry],
+    sourcemap: false,
+    write: false
+  });
+} finally {
+  rmSync(consumerRoot, { recursive: true, force: true });
+}

--- a/packages/salesforcedx-apex/src/effect/capabilities/connection.ts
+++ b/packages/salesforcedx-apex/src/effect/capabilities/connection.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import type { Connection } from '@salesforce/core';
+import * as Context from 'effect/Context';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+import { ApexConnectionError, causeMessage } from '../errors';
+
+/** Host capability used by Apex operations to obtain their current Salesforce connection. */
+export type ApexConnectionProvider = {
+  readonly getConnection: Effect.Effect<Connection, ApexConnectionError>;
+  readonly getConnectionForOrg: (orgId: string) => Effect.Effect<Connection, ApexConnectionError>;
+};
+
+/** Host-neutral connection capability for the primary Effect API. */
+export const ApexConnectionProvider = Context.GenericTag<ApexConnectionProvider>(
+  '@salesforce/apex-node/ApexConnectionProvider'
+);
+
+/** Creates a connection provider backed by a fixed connection, as used by CLI and class-facade consumers. */
+export const makeApexConnectionProvider = (connection: Connection): ApexConnectionProvider => ({
+  getConnection: Effect.succeed(connection),
+  getConnectionForOrg: orgId =>
+    Effect.try({
+      try: () => connection.getAuthInfoFields().orgId,
+      catch: cause =>
+        new ApexConnectionError({
+          message: `Unable to read the org identity for '${orgId}'`,
+          cause: causeMessage(cause)
+        })
+    }).pipe(
+      Effect.flatMap(observedOrgId =>
+        observedOrgId === orgId
+          ? Effect.succeed(connection)
+          : Effect.fail(
+              new ApexConnectionError({
+                message: `Expected connection for org '${orgId}', but received '${observedOrgId ?? 'unknown'}'`
+              })
+            )
+      )
+    )
+});
+
+/** Provides a fixed Salesforce connection to Apex Effect operations. */
+export const apexConnectionLayer = (connection: Connection): Layer.Layer<ApexConnectionProvider> =>
+  Layer.succeed(ApexConnectionProvider, makeApexConnectionProvider(connection));

--- a/packages/salesforcedx-apex/src/effect/errors.ts
+++ b/packages/salesforcedx-apex/src/effect/errors.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { isError } from 'effect/Predicate';
+import * as Schema from 'effect/Schema';
+
+const OperationErrorFields = {
+  operation: Schema.NonEmptyTrimmedString,
+  message: Schema.String,
+  cause: Schema.optional(Schema.String)
+};
+
+/** A Salesforce connection could not be supplied to an Apex operation. */
+export class ApexConnectionError extends Schema.TaggedError<ApexConnectionError>('ApexConnectionError')(
+  'ApexConnectionError',
+  {
+    message: Schema.String,
+    cause: Schema.optional(Schema.String)
+  }
+) {}
+
+/** A request made by an Apex operation failed. */
+export class ApexOperationError extends Schema.TaggedError<ApexOperationError>('ApexOperationError')(
+  'ApexOperationError',
+  OperationErrorFields
+) {}
+
+/** An Apex operation received a response that did not match its public schema. */
+export class ApexResponseDecodeError extends Schema.TaggedError<ApexResponseDecodeError>('ApexResponseDecodeError')(
+  'ApexResponseDecodeError',
+  OperationErrorFields
+) {}
+
+/** Produces the serializable cause carried by public operation errors. */
+export const causeMessage = (cause: unknown): string => (isError(cause) ? cause.message : String(cause));

--- a/packages/salesforcedx-apex/src/effect/index.ts
+++ b/packages/salesforcedx-apex/src/effect/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+export { ApexConnectionProvider, apexConnectionLayer, makeApexConnectionProvider } from './capabilities/connection';
+export { ApexConnectionError, ApexOperationError, ApexResponseDecodeError, causeMessage } from './errors';

--- a/packages/salesforcedx-apex/src/effect/internal/classRunner.ts
+++ b/packages/salesforcedx-apex/src/effect/internal/classRunner.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import type { Connection } from '@salesforce/core';
+import * as Effect from 'effect/Effect';
+import { ApexConnectionProvider, makeApexConnectionProvider } from '../capabilities/connection';
+
+/** Promise boundary shared by traditional class facades while their implementation moves to Effect. */
+export class ApexClassRunner {
+  private readonly connectionProvider: ApexConnectionProvider;
+
+  public constructor(connection: Connection) {
+    this.connectionProvider = makeApexConnectionProvider(connection);
+  }
+
+  public runPromise<A, E>(operation: Effect.Effect<A, E, ApexConnectionProvider>): Promise<A> {
+    return Effect.runPromise(Effect.provideService(operation, ApexConnectionProvider, this.connectionProvider));
+  }
+}

--- a/packages/salesforcedx-apex/test/api/publicApi.test.ts
+++ b/packages/salesforcedx-apex/test/api/publicApi.test.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import * as publicApi from '../../src';
+import * as effectApi from '../../src/effect';
 import * as packageJson from '../../package.json';
 
 describe('@salesforce/apex-node public API', () => {
@@ -26,11 +27,27 @@ describe('@salesforce/apex-node public API', () => {
     ]);
   });
 
-  it('restricts consumers to the target major-version package entry point', () => {
+  it('exports the Effect foundation from its isolated entry point', () => {
+    expect(Object.keys(effectApi).sort()).toEqual([
+      'ApexConnectionError',
+      'ApexConnectionProvider',
+      'ApexOperationError',
+      'ApexResponseDecodeError',
+      'apexConnectionLayer',
+      'causeMessage',
+      'makeApexConnectionProvider'
+    ]);
+  });
+
+  it('restricts consumers to the target major-version package entry points', () => {
     expect(packageJson.exports).toEqual({
       '.': {
         types: './out/src/index.d.ts',
         default: './out/src/index.js'
+      },
+      './effect': {
+        types: './out/src/effect/index.d.ts',
+        default: './out/src/effect/index.js'
       }
     });
   });

--- a/packages/salesforcedx-apex/test/effect/foundation.test.ts
+++ b/packages/salesforcedx-apex/test/effect/foundation.test.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import type { Connection } from '@salesforce/core';
+import * as Effect from 'effect/Effect';
+import { ApexConnectionError, ApexConnectionProvider, makeApexConnectionProvider } from '../../src/effect';
+import { ApexClassRunner } from '../../src/effect/internal/classRunner';
+
+const connectionFor = (orgId: string): Connection =>
+  ({ getAuthInfoFields: () => ({ orgId }) }) as unknown as Connection;
+
+describe('apex-node Effect foundation', () => {
+  it('provides a fixed connection to Effect operations', async () => {
+    const connection = connectionFor('00D-current');
+    const provider = makeApexConnectionProvider(connection);
+
+    await expect(Effect.runPromise(provider.getConnection)).resolves.toBe(connection);
+    await expect(Effect.runPromise(provider.getConnectionForOrg('00D-current'))).resolves.toBe(connection);
+  });
+
+  it('fails with a tagged error when a fixed connection belongs to another org', async () => {
+    const exit = await makeApexConnectionProvider(connectionFor('00D-other'))
+      .getConnectionForOrg('00D-expected')
+      .pipe(Effect.flip, Effect.runPromise);
+
+    expect(exit).toBeInstanceOf(ApexConnectionError);
+    expect(exit).toMatchObject({
+      _tag: 'ApexConnectionError',
+      message: "Expected connection for org '00D-expected', but received '00D-other'"
+    });
+  });
+
+  it('runs an Effect operation behind the traditional class boundary', async () => {
+    const connection = connectionFor('00D-current');
+    const runner = new ApexClassRunner(connection);
+    const operation = ApexConnectionProvider.pipe(Effect.flatMap(provider => provider.getConnection));
+
+    await expect(runner.runPromise(operation)).resolves.toBe(connection);
+  });
+});

--- a/packages/salesforcedx-vscode-services-types/package.json
+++ b/packages/salesforcedx-vscode-services-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/vscode-services",
-  "version": "67.17.7",
+  "version": "67.17.8",
   "description": "TypeScript type definitions for Salesforce VS Code Services extension API",
   "author": "Salesforce",
   "license": "BSD-3-Clause",
@@ -75,6 +75,7 @@
     "@opentelemetry/sdk-trace-base": "2.10.0",
     "@opentelemetry/sdk-trace-node": "2.8.0",
     "@opentelemetry/sdk-trace-web": "2.8.0",
+    "@salesforce/apex-node": "*",
     "@salesforce/core": "^9.1.9",
     "@salesforce/source-deploy-retrieve": "^13.2.0",
     "@salesforce/source-tracking": "^8.0.0",

--- a/packages/salesforcedx-vscode-services-types/scripts/syncDeps.ts
+++ b/packages/salesforcedx-vscode-services-types/scripts/syncDeps.ts
@@ -38,6 +38,7 @@ const syncDeps = (): void => {
     '@opentelemetry/sdk-trace-base',
     '@opentelemetry/sdk-trace-node',
     '@opentelemetry/sdk-trace-web',
+    '@salesforce/apex-node',
     '@salesforce/core',
     '@salesforce/source-deploy-retrieve',
     '@salesforce/source-tracking',

--- a/packages/salesforcedx-vscode-services/package.json
+++ b/packages/salesforcedx-vscode-services/package.json
@@ -40,6 +40,7 @@
     "@opentelemetry/sdk-trace-base": "2.10.0",
     "@opentelemetry/sdk-trace-node": "2.8.0",
     "@opentelemetry/sdk-trace-web": "2.8.0",
+    "@salesforce/apex-node": "*",
     "@salesforce/core": "^9.1.9",
     "@salesforce/o11y-reporter": "^1.8.5",
     "@salesforce/salesforcedx-utils": "*",
@@ -98,6 +99,7 @@
       "clean": "if-file-deleted",
       "dependencies": [
         "build:icons",
+        "../salesforcedx-apex:compile",
         "generate-types",
         "../salesforcedx-utils:compile",
         "../salesforcedx-vscode-i18n:compile"

--- a/packages/salesforcedx-vscode-services/src/core/apexNodeCapabilities.ts
+++ b/packages/salesforcedx-vscode-services/src/core/apexNodeCapabilities.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { ApexConnectionError, ApexConnectionProvider, causeMessage } from '@salesforce/apex-node/effect';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+import { ConnectionService } from './connectionService';
+
+const connectionError = (cause: unknown): ApexConnectionError =>
+  new ApexConnectionError({
+    message: 'Unable to resolve a Salesforce connection for the Apex operation',
+    cause: causeMessage(cause)
+  });
+
+/** Adapts the services extension's dynamic connection service to apex-node's host-neutral capability. */
+export const ApexNodeConnectionProviderLayer = Layer.effect(
+  ApexConnectionProvider,
+  Effect.map(ConnectionService, connectionService => ({
+    getConnection: connectionService.getConnection().pipe(Effect.mapError(connectionError)),
+    getConnectionForOrg: orgId => connectionService.getConnectionForOrg(orgId).pipe(Effect.mapError(connectionError))
+  }))
+);

--- a/packages/salesforcedx-vscode-services/src/index.ts
+++ b/packages/salesforcedx-vscode-services/src/index.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import type { Resource } from '@effect/opentelemetry';
+import type { ApexConnectionProvider } from '@salesforce/apex-node/effect';
 import * as Context from 'effect/Context';
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
@@ -19,6 +20,7 @@ import { getActiveMetadataOperationRef } from './core/activeMetadataOperationRef
 import { AliasService } from './core/alias';
 import { watchAliasFile } from './core/aliasFileWatcher';
 import { ApexLogService } from './core/apexLogService';
+import { ApexNodeConnectionProviderLayer } from './core/apexNodeCapabilities';
 import { ArtifactProjectionSchemas } from './core/artifactProjection';
 import { ComponentSetService } from './core/componentSetService';
 import { watchConfigFiles } from './core/configFileWatcher';
@@ -89,6 +91,7 @@ export type SalesforceVSCodeServicesApi = {
     /** contains most of the dependencies prebuilt in the services extension */
     prebuiltServicesDependencies: Context.Context<
       | AliasService
+      | ApexConnectionProvider
       | ApexLogService
       | ChannelService
       | ComponentSetService
@@ -122,6 +125,7 @@ export type SalesforceVSCodeServicesApi = {
       | WorkspaceService
     >;
     ApexLogService: typeof ApexLogService;
+    ApexNodeConnectionProviderLayer: typeof ApexNodeConnectionProviderLayer;
     AliasService: typeof AliasService;
     ArtifactProjectionSchemas: typeof ArtifactProjectionSchemas;
     TemplateService: typeof TemplateService;
@@ -543,6 +547,7 @@ export const activate = async (context: vscode.ExtensionContext): Promise<Salesf
       services: {
         prebuiltServicesDependencies: builtContext,
         ApexLogService,
+        ApexNodeConnectionProviderLayer,
         AliasService,
         ArtifactProjectionSchemas,
         TemplateService,

--- a/packages/salesforcedx-vscode-services/src/servicesLayers.ts
+++ b/packages/salesforcedx-vscode-services/src/servicesLayers.ts
@@ -8,6 +8,7 @@
 import * as Layer from 'effect/Layer';
 import { AliasService } from './core/alias';
 import { ApexLogService } from './core/apexLogService';
+import { ApexNodeConnectionProviderLayer } from './core/apexNodeCapabilities';
 import { ComponentSetService } from './core/componentSetService';
 import { ConfigService } from './core/configService';
 import { ConnectionService } from './core/connectionService';
@@ -46,7 +47,7 @@ import { WorkspaceService } from './vscode/workspaceService';
  * Global service Defaults (same for all extensions). Leaf module to avoid circular dependency
  * when deriving runtime type from `typeof globalLayers`.
  */
-export const globalLayers = Layer.mergeAll(
+const baseGlobalLayers = Layer.mergeAll(
   AliasService.Default,
   TemplateService.Default,
   ExtensionContextService.Default,
@@ -83,3 +84,5 @@ export const globalLayers = Layer.mergeAll(
   TraceFlagService.Default,
   WorkspaceService.Default
 );
+
+export const globalLayers = ApexNodeConnectionProviderLayer.pipe(Layer.provideMerge(baseGlobalLayers));

--- a/packages/salesforcedx-vscode-services/test/jest/core/apexNodeCapabilities.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/apexNodeCapabilities.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { ApexConnectionError, ApexConnectionProvider } from '@salesforce/apex-node/effect';
+import type { Connection } from '@salesforce/core';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+import { ApexNodeConnectionProviderLayer } from '../../../src/core/apexNodeCapabilities';
+import { ConnectionService, NoTargetOrgConfiguredError } from '../../../src/core/connectionService';
+
+const connection = { getAuthInfoFields: () => ({ orgId: '00D-current' }) } as unknown as Connection;
+
+const runWithConnectionService = <A, E>(
+  operation: Effect.Effect<A, E, ApexConnectionProvider>,
+  getConnection: InstanceType<typeof ConnectionService>['getConnection']
+): Promise<A> => {
+  const connectionServiceLayer = Layer.succeed(
+    ConnectionService,
+    ConnectionService.make({
+      getConnection,
+      getConnectionForOrg: () => getConnection()
+    } as unknown as InstanceType<typeof ConnectionService>)
+  );
+  const layer = ApexNodeConnectionProviderLayer.pipe(Layer.provide(connectionServiceLayer));
+  return Effect.runPromise(operation.pipe(Effect.provide(layer)));
+};
+
+describe('ApexNodeConnectionProviderLayer', () => {
+  it('delegates connection lookup to the services ConnectionService', async () => {
+    const operation = ApexConnectionProvider.pipe(Effect.flatMap(provider => provider.getConnection));
+
+    await expect(runWithConnectionService(operation, () => Effect.succeed(connection))).resolves.toBe(connection);
+  });
+
+  it('maps host-specific connection failures to the apex-node capability error', async () => {
+    const operation = ApexConnectionProvider.pipe(
+      Effect.flatMap(provider => provider.getConnection),
+      Effect.flip
+    );
+    const hostError = new NoTargetOrgConfiguredError({ message: 'No target org configured' });
+
+    await expect(runWithConnectionService(operation, () => Effect.fail(hostError))).resolves.toMatchObject({
+      _tag: 'ApexConnectionError',
+      cause: 'No target org configured'
+    } satisfies Partial<ApexConnectionError>);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

- Adds the primary `@salesforce/apex-node/effect` entry point with typed operation errors, a connection capability, fixed-connection layers, and the class-facade Promise bridge.
- Provides the Apex connection capability through the VS Code services runtime without migrating existing Apex behavior.
- Protects the new surface with JSON Schema, runtime-export tests, and a packed browser-consumer bundle test that exercises the ADR 0003 filesystem boundary.

### What issues does this PR fix or reference?

@W-23839365@

### Functionality Before

`@salesforce/apex-node` exposed only its Promise/class API and had no host-neutral Effect connection capability.

### Functionality After

Effect consumers can import the isolated `./effect` API. The services extension supplies its dynamic connection provider through the shared runtime, while the existing root API remains unchanged.

### Validation

- Repository pre-commit workflow completed: 95 ran, 9 cached/skipped
- Repository pre-push workflow completed: 81 ran, 103 cached/skipped
- Apex: 31 suites, 303 passed, 1 skipped
- Services: 60 suites, 507 passed
- Packed browser-consumer, schema, circular-dependency, lint, compile, formatting, and lockfile checks passed
