### PR TITLE
DO NOT MERGE: diagnose Web Console auth-info remote failure

### DIFF
--- a/packages/salesforcedx-vscode-services/src/core/connectionService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/connectionService.ts
@@ -116,11 +116,16 @@ export class FailedToListAuthorizationsError extends Schema.TaggedError<FailedTo
   }
 ) {}
 
-/** side effect: save the auth info in the background */
-const createWebAuthInfo = (instanceUrl: string, accessToken: string) =>
+/**
+ * Create browser auth without the OAuth user-info lookup. Web Console supplies a session token, and some
+ * impersonated sessions reject that lookup even though the token is valid for normal API requests. AuthInfo
+ * saving remains a background side effect (and is a no-op for session-token auth).
+ */
+export const createWebAuthInfo = (instanceUrl: string, accessToken: string) =>
   Effect.tryPromise({
     try: () =>
       AuthInfo.create({
+        username: accessToken,
         accessTokenOptions: { accessToken, loginUrl: instanceUrl, instanceUrl }
       }),
     catch: error => {
@@ -203,8 +208,12 @@ const connectionCache = Effect.runSync(
   })
 );
 
-const resolveUsername = (conn: Connection): string | undefined =>
-  conn.getUsername() ?? conn.getAuthInfoFields().username;
+/** The access-token auth path uses the token as AuthInfo's internal username; never expose it as an org username. */
+export const resolveUsername = (conn: Connection): string | undefined => {
+  const fields = conn.getAuthInfoFields();
+  const username = conn.getUsername() ?? fields.username;
+  return username === fields.accessToken ? undefined : username;
+};
 
 type IdentityResult = { username: string; userId: string };
 

--- a/packages/salesforcedx-vscode-services/test/jest/core/connectionService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/connectionService.test.ts
@@ -20,8 +20,10 @@ import { AliasService } from '../../../src/core/alias';
 import { ConfigService } from '../../../src/core/configService';
 import {
   ConnectionService,
+  createWebAuthInfo,
   InactiveOrgOperationError,
   NoTargetOrgConfiguredError,
+  resolveUsername,
   updateDefaultOrgIdentity
 } from '../../../src/core/connectionService';
 import { getDefaultOrgRef } from '../../../src/core/defaultOrgRef';
@@ -39,6 +41,7 @@ const USERNAME = 'expired@test.com';
 const ALIAS = 'ExpiredOrg';
 const INSTANCE_URL = 'https://expired.my.salesforce.com';
 const LOGIN_BUTTON = 'Login';
+const WEB_ACCESS_TOKEN = '00Dxx0000000001!opaque_session_token';
 
 const mockConfigService = (targetOrg: string | undefined = ALIAS): Layer.Layer<ConfigService> =>
   Layer.succeed(
@@ -438,6 +441,37 @@ describe('updateDefaultOrgIdentity', () => {
       instanceName: 'USA9S',
       username: 'user@example.com'
     });
+  });
+});
+
+describe('browser access-token auth', () => {
+  beforeEach(() => {
+    authInfoCreateMock.mockReset();
+  });
+
+  it('uses the session token as AuthInfo username to avoid the OAuth user-info lookup', async () => {
+    const authInfo = { getFields: () => ({}), save: jest.fn() } as unknown as AuthInfo;
+    authInfoCreateMock.mockResolvedValue(authInfo);
+
+    await Effect.runPromise(createWebAuthInfo(INSTANCE_URL, WEB_ACCESS_TOKEN));
+
+    expect(authInfoCreateMock).toHaveBeenCalledWith({
+      username: WEB_ACCESS_TOKEN,
+      accessTokenOptions: {
+        accessToken: WEB_ACCESS_TOKEN,
+        loginUrl: INSTANCE_URL,
+        instanceUrl: INSTANCE_URL
+      }
+    });
+  });
+
+  it('does not expose the session token as the org username', () => {
+    const conn = {
+      getUsername: () => WEB_ACCESS_TOKEN,
+      getAuthInfoFields: () => ({ accessToken: WEB_ACCESS_TOKEN, orgId: '00Dxx0000000001' })
+    } as unknown as Connection;
+
+    expect(resolveUsername(conn)).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
> [!CAUTION]
> **DO NOT MERGE.** This PR records an unconfirmed diagnosis and an experimental fix. The suspected failure mode has not been reproduced or validated in the affected environment.

### What does this PR do?

Tests the hypothesis that Web Console session-token authentication fails because `AuthInfo.create` treats the token as OAuth authentication and calls the remote user-info endpoint.

The experimental change:

- supplies the session token as `AuthInfo`'s internal username to select token authentication and avoid the user-info lookup;
- prevents that token from being exposed as the resolved org username; and
- adds focused unit coverage for both behaviors.

### What issues does this PR fix or reference?

None. This diagnostic PR has no associated work item.

### Functionality Before

The suspected path creates `AuthInfo` without a username. That may initiate a remote OAuth user-info request. Some impersonated sessions can reject that request even while the session token remains valid for normal API calls, causing authentication initialization to fail.

This diagnosis is not yet confirmed.

### Functionality After

The experimental path avoids the suspected user-info request and retains the session token only as an internal authentication value.

Before this PR can be considered for merge, the failure must be reproduced, the rejected remote call confirmed, and this change validated against the affected Web Console and impersonation flows.
