### PR TITLE
fix(release): close test-coverage gaps in emergency/hotfix release paths - W-23900552

### DIFF
--- a/.claude/skills/patch-release/SKILL.md
+++ b/.claude/skills/patch-release/SKILL.md
@@ -118,7 +118,7 @@ gh workflow run build-release.yml \
 
 Creates GitHub pre-release with VSIXs. Uses version from source's package.json files (must be unique, not already published to marketplace). No automated version bump — tags source ref with nightly format tag.
 
-**Validation:** Unit tests (compile + test) run at 2 stages: (1) build-release.yml at build time (fast fail on develop's dispatch-trigger SHA); (2) promote-to-prerelease.yml (authoritative gate, tests exact hotfix commit being promoted when isHotfix=true). E2E & full PR review skipped; ensure ref carefully reviewed before use.
+**Validation:** Unit tests (compile + test) run at the authoritative gate: promote-to-prerelease.yml tests exact hotfix commit being promoted when isHotfix=true. E2E & full PR review skipped; ensure ref carefully reviewed before use.
 
 ### Step 2: Publish to marketplace as pre-release
 
@@ -151,7 +151,7 @@ gh workflow run build-release.yml \
   --repo forcedotcom/salesforcedx-vscode
 ```
 
-Creates isolated `release-staging/v67.12.1` branch with version bump. Unit tests (compile + test) run automatically before tagging. E2E tests and full PR review are skipped. Test VSIXs and publish as stable release.
+Creates isolated `release-staging/v67.12.1` branch with version bump. publishVSCode.yml and publishOpenVSX.yml test the commit (compile + test, isHotfix=true) before publishing. E2E tests and full PR review are skipped. Test VSIXs and publish as stable release.
 
 ## References
 

--- a/.claude/skills/patch-release/SKILL.md
+++ b/.claude/skills/patch-release/SKILL.md
@@ -59,10 +59,11 @@ Run manual QA tests. See [docs/release-testing-guide.md](../../../docs/release-t
 
 ### 6. Publish to marketplace
 
-If tests pass:
+If tests pass, dispatch both workflows for full coverage (VS Code Marketplace + Open VSX):
 
 ```sh
-gh workflow run publishVSCode.yml -f releaseVersion="67.12.1" --repo forcedotcom/salesforcedx-vscode
+gh workflow run publishVSCode.yml -f version="v67.12.1" -f isHotfix=true --repo forcedotcom/salesforcedx-vscode
+gh workflow run publishOpenVSX.yml -f release-tag="v67.12.1" -f isHotfix=true --repo forcedotcom/salesforcedx-vscode
 ```
 
 ### 7. Cherry-pick fixes to develop
@@ -117,11 +118,14 @@ gh workflow run build-release.yml \
 
 Creates GitHub pre-release with VSIXs. Uses version from source's package.json files (must be unique, not already published to marketplace). No automated version bump — tags source ref with nightly format tag.
 
+**Validation:** Unit tests (compile + test) run at 2 stages: (1) build-release.yml at build time (fast fail on develop's dispatch-trigger SHA); (2) promote-to-prerelease.yml (authoritative gate, tests exact hotfix commit being promoted when isHotfix=true). E2E & full PR review skipped; ensure ref carefully reviewed before use.
+
 ### Step 2: Publish to marketplace as pre-release
 
 ```sh
-gh workflow run promote-nightly-to-prerelease.yml \
+gh workflow run promote-to-prerelease.yml \
   -f releaseTag="v67.13.7-nightly.develop.20260820" \
+  -f isHotfix=true \
   --repo forcedotcom/salesforcedx-vscode
 ```
 
@@ -147,7 +151,7 @@ gh workflow run build-release.yml \
   --repo forcedotcom/salesforcedx-vscode
 ```
 
-Creates isolated `release-staging/v67.12.1` branch with version bump. Test and publish as stable release.
+Creates isolated `release-staging/v67.12.1` branch with version bump. Unit tests (compile + test) run automatically before tagging. E2E tests and full PR review are skipped. Test VSIXs and publish as stable release.
 
 ## References
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -4,13 +4,13 @@ on:
   schedule:
     # Wednesdays at 7 AM UTC
     # Builds stable release from LAST week's marketplace pre-release (which has been tested for 7+ days)
-    # IMPORTANT: Runs BEFORE promote-nightly-to-prerelease (8 AM) to ensure we build from last week's
+    # IMPORTANT: Runs BEFORE promote-to-prerelease (8 AM) to ensure we build from last week's
     # tested prerelease, not the one being promoted today
     - cron: '0 7 * * 3'
   workflow_dispatch:
     inputs:
       startFromRef:
-        description: 'Any git ref (tag/branch/SHA) to build from. Overrides prereleaseTag. ⚠️ WARNING: Bypasses nightly validation - ensure ref is reviewed/merged to develop before using.'
+        description: 'Any git ref (tag/branch/SHA) to build from. Overrides prereleaseTag. ⚠️ WARNING: Bypasses nightly validation. Unit tests (compile + test) run automatically; E2E and full PR review are still skipped. Ensure ref is reviewed/merged to develop before using.'
         required: false
         type: string
       prereleaseTag:
@@ -106,7 +106,7 @@ jobs:
 
           else
             # Priority 3: Auto-detect latest nightly published to marketplace as prerelease
-            # The promote-nightly-to-prerelease workflow (nightly → marketplace prerelease) creates
+            # The promote-to-prerelease workflow (nightly → marketplace prerelease) creates
             # marketplace-prerelease-* tracking tags pointing to the Wednesday candidate commit
             TRACKING_TAG=$(git tag -l 'marketplace-prerelease-*' --sort=-creatordate | head -1)
 
@@ -144,6 +144,14 @@ jobs:
           fi
 
           echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+          # startFromRef bypasses nightly validation, so it's the only source that
+          # hasn't already passed develop's required unit-test checks - see used_start_from_ref below
+          if [ -n "$START_FROM_REF" ]; then
+            echo "used_start_from_ref=true" >> $GITHUB_OUTPUT
+          else
+            echo "used_start_from_ref=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Calculate release version
         id: calculate-version
@@ -301,6 +309,21 @@ jobs:
           echo "Checking out source ref for emergency pre-release: $SOURCE_REF"
           git checkout "$SOURCE_REF"
           echo "✓ Checked out source at $(git rev-parse HEAD)"
+
+      - name: Install dependencies for emergency ref
+        if: steps.detect-tag.outputs.used_start_from_ref == 'true'
+        uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
+
+      - name: Test emergency ref before tagging
+        if: steps.detect-tag.outputs.used_start_from_ref == 'true'
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+          WIREIT_PARALLEL: 1
+        run: |
+          # startFromRef skips develop's required unit-test checks (build-and-test / unit-tests),
+          # so run them here before tagging - this is the only gate this code path gets
+          npm run compile
+          npm run test
 
       - name: Create and push release tag
         env:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       startFromRef:
-        description: 'Any git ref (tag/branch/SHA) to build from. Overrides prereleaseTag. ⚠️ WARNING: Bypasses nightly validation. Unit tests (compile + test) run automatically; E2E and full PR review are still skipped. Ensure ref is reviewed/merged to develop before using.'
+        description: 'Any git ref (tag/branch/SHA) to build from. Overrides prereleaseTag. ⚠️ WARNING: Bypasses nightly validation and runs no tests here - promote-to-prerelease.yml/publishVSCode.yml/publishOpenVSX.yml test the commit directly (isHotfix=true) before it goes live. Ensure ref is reviewed/merged to develop before using.'
         required: false
         type: string
       prereleaseTag:
@@ -144,14 +144,6 @@ jobs:
           fi
 
           echo "tag=$TAG" >> $GITHUB_OUTPUT
-
-          # startFromRef bypasses nightly validation, so it's the only source that
-          # hasn't already passed develop's required unit-test checks - see used_start_from_ref below
-          if [ -n "$START_FROM_REF" ]; then
-            echo "used_start_from_ref=true" >> $GITHUB_OUTPUT
-          else
-            echo "used_start_from_ref=false" >> $GITHUB_OUTPUT
-          fi
 
       - name: Calculate release version
         id: calculate-version
@@ -309,21 +301,6 @@ jobs:
           echo "Checking out source ref for emergency pre-release: $SOURCE_REF"
           git checkout "$SOURCE_REF"
           echo "✓ Checked out source at $(git rev-parse HEAD)"
-
-      - name: Install dependencies for emergency ref
-        if: steps.detect-tag.outputs.used_start_from_ref == 'true'
-        uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
-
-      - name: Test emergency ref before tagging
-        if: steps.detect-tag.outputs.used_start_from_ref == 'true'
-        env:
-          NODE_OPTIONS: --max-old-space-size=8192
-          WIREIT_PARALLEL: 1
-        run: |
-          # startFromRef skips develop's required unit-test checks (build-and-test / unit-tests),
-          # so run them here before tagging - this is the only gate this code path gets
-          npm run compile
-          npm run test
 
       - name: Create and push release tag
         env:

--- a/.github/workflows/promote-to-prerelease.yml
+++ b/.github/workflows/promote-to-prerelease.yml
@@ -14,7 +14,7 @@ on:
         required: false
         type: string
       isHotfix:
-        description: 'Skip nightly-pipeline gate-check for tags built via build-release.yml startFromRef (which runs its own compile+test gate instead - see .github/workflows/build-release.yml). Do not use for regular nightly tags.'
+        description: 'Skip nightly-pipeline gate-check for tags built via build-release.yml startFromRef, and instead test the exact commit here directly (see "Checkout hotfix commit" below). Do not use for regular nightly tags.'
         required: false
         default: false
         type: boolean

--- a/.github/workflows/promote-to-prerelease.yml
+++ b/.github/workflows/promote-to-prerelease.yml
@@ -1,4 +1,4 @@
-name: Promote Nightly to Pre-release
+name: Promote to Pre-release
 
 on:
   schedule:
@@ -13,13 +13,18 @@ on:
         description: 'Specific release tag to publish (e.g., v67.13.7-nightly.develop.20260820). Leave empty to auto-detect most recent CI-passing nightly.'
         required: false
         type: string
+      isHotfix:
+        description: 'Skip nightly-pipeline gate-check for tags built via build-release.yml startFromRef (which runs its own compile+test gate instead - see .github/workflows/build-release.yml). Do not use for regular nightly tags.'
+        required: false
+        default: false
+        type: boolean
       dry-run:
         description: 'Run in dry-run mode (no actual publishing or tagging)'
         required: false
         default: false
         type: boolean
 
-# NOTE: Concurrency is handled by the reusable workflow (vscode-promote-nightly-to-prerelease.yml)
+# NOTE: Concurrency is handled by the reusable workflow (vscode-promote-prerelease.yml)
 # Do not define it here to avoid deadlock
 
 permissions:
@@ -43,6 +48,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need full history to check out an arbitrary hotfix commit-sha below
 
       - name: Check CI status
         # Gate on the nightly's own build/release success, NOT unit-tests/build-all.
@@ -51,11 +58,45 @@ jobs:
         # exists after squash-merge, so they can't be found on the develop nightly commit.
         # The meaningful, available signals here are that the nightly compiled/packaged the
         # VSIXs and published the GitHub release cleanly.
+        #
+        # Skipped for isHotfix: tags built via build-release.yml's startFromRef never go
+        # through this repo's nightly pipeline, so these check-run names never exist on that
+        # commit regardless of outcome. See "Test hotfix commit directly" below instead.
+        if: ${{ !inputs.isHotfix }}
         uses: salesforcecli/github-workflows/.github/actions/vscode/check-ci-status@main
         with:
           commit-sha: ${{ needs.find-nightly.outputs.commit-sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
           required-checks: '["nightly-release / package / Package", "nightly-release / Create GitHub Releases"]'
+
+      - name: Setup Node.js
+        if: ${{ inputs.isHotfix }}
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
+
+      - name: Checkout hotfix commit
+        # No nightly-pipeline check-runs exist for a hotfix commit (it never went through
+        # build-extension-list/nightly-release), so verify it here instead: check out the
+        # exact commit being promoted and run the same compile+test gate develop's branch
+        # protection would have required had this gone through a normal PR.
+        if: ${{ inputs.isHotfix }}
+        env:
+          COMMIT_SHA: ${{ needs.find-nightly.outputs.commit-sha }}
+        run: git checkout "$COMMIT_SHA"
+
+      - name: Install dependencies for hotfix commit
+        if: ${{ inputs.isHotfix }}
+        uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
+
+      - name: Run tests for hotfix commit
+        if: ${{ inputs.isHotfix }}
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+          WIREIT_PARALLEL: 1
+        run: |
+          npm run compile
+          npm run test
 
   # Step 3: Promote to prerelease (only runs if gate-check passed)
   promote:

--- a/.github/workflows/publishOpenVSX.yml
+++ b/.github/workflows/publishOpenVSX.yml
@@ -15,6 +15,11 @@ on:
         description: 'Download and inspect VSIXs without publishing or polling Open VSX'
         type: boolean
         default: false
+      isHotfix:
+        description: 'Test the exact release commit directly before publishing. Use for stable hotfixes built via build-release.yml startFromRef, which have no other automated test gate.'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   prepare-release-metadata:
@@ -38,6 +43,41 @@ jobs:
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "version=${TAG#v}" >> $GITHUB_OUTPUT
 
+  # Only needed for stable hotfixes (isHotfix=true): these are built via build-release.yml's
+  # startFromRef, which never goes through develop's branch protection or any nightly pipeline,
+  # so there's no existing signal that the release commit was tested. Skipped for normal releases,
+  # which already passed develop's required checks before ever becoming a release tag.
+  gate-check:
+    needs: [prepare-release-metadata]
+    if: github.event.inputs.isHotfix == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need full history to check out the release tag below
+
+      - name: Checkout hotfix commit
+        env:
+          RELEASE_TAG: ${{ needs.prepare-release-metadata.outputs.RELEASE_TAG }}
+        run: git checkout "$RELEASE_TAG"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
+
+      - name: Install dependencies for hotfix commit
+        uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
+
+      - name: Run tests for hotfix commit
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+          WIREIT_PARALLEL: 1
+        run: |
+          npm run compile
+          npm run test
+
   ctc-open:
     needs: [prepare-release-metadata]
     if: inputs.dry-run != true
@@ -45,8 +85,8 @@ jobs:
     secrets: inherit
 
   publish:
-    needs: ['ctc-open', 'prepare-release-metadata']
-    if: always() && needs.prepare-release-metadata.result == 'success' && (inputs.dry-run || needs.ctc-open.result == 'success')
+    needs: ['ctc-open', 'prepare-release-metadata', 'gate-check']
+    if: always() && needs.prepare-release-metadata.result == 'success' && (needs.gate-check.result == 'success' || needs.gate-check.result == 'skipped') && (inputs.dry-run || needs.ctc-open.result == 'success')
     uses: salesforcecli/github-workflows/.github/workflows/openvsx-publish-release-vsix.yml@main
     with:
       release-tag: ${{ needs.prepare-release-metadata.outputs.RELEASE_TAG }}

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -2,7 +2,7 @@ name: Publish Release to Marketplace
 
 # Publishes releases to VS Code Marketplace and Open VSX Registry.
 # Auto-triggers for stable releases. Manual dispatch supports both stable and prerelease tags.
-# For automated nightly prerelease publishing, use promote-nightly-to-prerelease.yml instead.
+# For automated nightly prerelease publishing, use promote-to-prerelease.yml instead.
 # Publishing uses the shared release-asset publisher workflow which auto-detects release type.
 
 on:
@@ -19,6 +19,11 @@ on:
         type: string
       dry-run:
         description: 'Download and inspect VSIXs without publishing or triggering downstream releases'
+        required: false
+        default: false
+        type: boolean
+      isHotfix:
+        description: 'Test the exact release commit directly before publishing. Use for stable hotfixes built via build-release.yml startFromRef, which have no other automated test gate.'
         required: false
         default: false
         type: boolean
@@ -95,6 +100,41 @@ jobs:
           fi
           echo "✅ Release $RELEASE_TAG exists"
 
+  # Only needed for stable hotfixes (isHotfix=true): these are built via build-release.yml's
+  # startFromRef, which never goes through develop's branch protection or any nightly pipeline,
+  # so there's no existing signal that the release commit was tested. Skipped for normal releases,
+  # which already passed develop's required checks before ever becoming a release tag.
+  gate-check:
+    needs: [prepare-release-metadata]
+    if: github.event.inputs.isHotfix == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Need full history to check out the release tag below
+
+      - name: Checkout hotfix commit
+        env:
+          RELEASE_TAG: ${{ needs.prepare-release-metadata.outputs.RELEASE_TAG }}
+        run: git checkout "$RELEASE_TAG"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
+
+      - name: Install dependencies for hotfix commit
+        uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
+
+      - name: Run tests for hotfix commit
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+          WIREIT_PARALLEL: 1
+        run: |
+          npm run compile
+          npm run test
+
   ctc-open:
     needs: [prepare-release-metadata]
     if: inputs.dry-run != true
@@ -102,8 +142,8 @@ jobs:
     secrets: inherit
 
   publish:
-    needs: ['ctc-open', 'prepare-release-metadata', 'verify-release']
-    if: always() && needs.prepare-release-metadata.result == 'success' && needs.verify-release.result == 'success' && (inputs.dry-run || needs.ctc-open.result == 'success')
+    needs: ['ctc-open', 'prepare-release-metadata', 'verify-release', 'gate-check']
+    if: always() && needs.prepare-release-metadata.result == 'success' && needs.verify-release.result == 'success' && (needs.gate-check.result == 'success' || needs.gate-check.result == 'skipped') && (inputs.dry-run || needs.ctc-open.result == 'success')
     uses: salesforcecli/github-workflows/.github/workflows/vscode-publish-release-vsix.yml@main
     with:
       release-tag: ${{ needs.prepare-release-metadata.outputs.RELEASE_TAG }}

--- a/CI-TESTING-PLAN.md
+++ b/CI-TESTING-PLAN.md
@@ -130,7 +130,7 @@ git ls-remote ci-testing | grep release-staging && echo "❌ Staging branch exis
 **Goal:** Verify 3-stage promotion workflow creates tracking tag
 
 **Steps:**
-1. Go to Actions → `promote-nightly-to-prerelease.yml`
+1. Go to Actions → `promote-to-prerelease.yml`
 2. Click "Run workflow"
 3. Leave inputs empty (auto-select latest nightly)
 4. Run workflow

--- a/contributing/publishing.md
+++ b/contributing/publishing.md
@@ -84,7 +84,7 @@ Published releases extract extension names from VSIX filenames in release assets
 
 ### Pre-release Promotion
 
-**Pre-release promotion:** `promote-nightly-to-prerelease.yml` (Wednesdays 8 AM UTC) runs 3-stage pipeline: (1) find-nightly selects most recent nightly (min-tag-age: 0 days); (2) gate-check verifies nightly's build/release success (not unit-tests/build-all, which only exist on PR commits); (3) promote creates tracking tag for release flow. Safe rollback window before general release.
+**Pre-release promotion:** `promote-to-prerelease.yml` (Wednesdays 8 AM UTC) runs 3-stage pipeline: (1) find-nightly selects most recent nightly (min-tag-age: 0 days); (2) gate-check verifies nightly's build/release success, or tests hotfix commit directly when `-f isHotfix=true` (not unit-tests/build-all, which only exist on PR commits); (3) promote creates tracking tag for release flow. Safe rollback window before general release.
 
 **Release build:** See [Build Release from Prerelease](#build-release-from-prerelease) above.
 
@@ -100,6 +100,7 @@ Published releases extract extension names from VSIX filenames in release assets
 2. Trigger [`build-release.yml`](https://github.com/forcedotcom/salesforcedx-vscode/actions/workflows/build-release.yml) to build release VSIXs
 3. Download + test VSIX files from GitHub pre-release
 4. Trigger [`publishVSCode.yml`](https://github.com/forcedotcom/salesforcedx-vscode/actions/workflows/publishVSCode.yml) with version (e.g., `67.12.0`)
+   - For stable hotfixes only (with `-f isHotfix=true`): also dispatch [`publishOpenVSX.yml`](https://github.com/forcedotcom/salesforcedx-vscode/actions/workflows/publishOpenVSX.yml) with `-f release-tag="v67.12.0" -f isHotfix=true` for full registry coverage
 5. Approve marketplace publish gates
 6. Marketplace updates (usually within minutes)
 

--- a/docs/release-testing-guide.md
+++ b/docs/release-testing-guide.md
@@ -61,7 +61,7 @@ Monitor the workflow at: https://github.com/forcedotcom/salesforcedx-vscode/acti
 
 ```bash
 # Promote to marketplace as pre-release
-gh workflow run promote-nightly-to-prerelease.yml \
+gh workflow run promote-to-prerelease.yml \
   -f releaseTag="v67.12.0" \
   --repo forcedotcom/salesforcedx-vscode
 ```
@@ -152,7 +152,7 @@ Follow the testing checklist above.
 ### 3. Publish to Marketplace as Pre-release
 
 ```bash
-gh workflow run promote-nightly-to-prerelease.yml \
+gh workflow run promote-to-prerelease.yml \
   -f releaseTag="v67.12.0" \
   --repo forcedotcom/salesforcedx-vscode
 ```

--- a/docs/release-workflow-architecture.md
+++ b/docs/release-workflow-architecture.md
@@ -24,7 +24,7 @@ Wednesday (Week N - 8 AM UTC) ────────────────�
          │                                                   │
          ▼                                                   │
 ┌─────────────────────────────────────────────────────────────────┐
-│  promote-nightly-to-prerelease.yml (AUTOMATED CRON)             │
+│  promote-to-prerelease.yml (AUTOMATED CRON)                     │
 │  ┌──────────────────────────────────────────────────────────────┤
 │  │ WHAT IT DOES:                                                │
 │  │ ✓ Finds most recent nightly (min-tag-age: 0 days)            │
@@ -120,6 +120,7 @@ EMERGENCY PRE-RELEASE PATH (5 minutes to marketplace) - NEW!             │
    │ │ • Uses version from source's package.json (must    │        │      │
    │ │   be unique, not already published to marketplace) │        │      │
    │ │ • No automated version bump or branch creation     │        │      │
+   │ │ • Runs unit tests (compile + test) before tagging  │        │      │
    │ │ • Builds VSIXs from exact ref                      │        │      │
    │ │ • Creates GitHub pre-release with nightly tag      │        │      │
    │ └────────────────────────────────────────────────────┤        │      │
@@ -127,10 +128,13 @@ EMERGENCY PRE-RELEASE PATH (5 minutes to marketplace) - NEW!             │
            │                                                       │      │
            ▼                                                       │      │
    ┌──────────────────────────────────────────────────────┐
-   │ Step 2: promote-nightly-to-prerelease.yml            │
+   │ Step 2: promote-to-prerelease.yml                    │
    │ -f releaseTag=v67.13.7-nightly.develop.20260821      │
+   │ -f isHotfix=true                                     │
    │ (~2 minutes)                                         │
    │ ┌────────────────────────────────────────────────────┤
+   │ │ • Skips nightly-pipeline gate-check (doesn't exist)│
+   │ │ • Tests hotfix commit directly (compile + test)    │
    │ │ • Publishes to VS Code Marketplace                 │
    │ │ • Publishes to Open VSX                            │
    │ │ • Available to all users immediately               │
@@ -163,14 +167,28 @@ EMERGENCY PATCH RELEASE PATH (Stable version hotfix) - NEW!               │
            │
            ▼
    ┌──────────────────────────────────────────────────────┐
-   │ build-and-release-patch-branch.yml                              │
+   │ build-and-release-patch-branch.yml                   │
    │ • Auto-increments (v67.12.0 → v67.12.1)              │
-   │ • Builds VSIXs                                       │
+   │ • Builds VSIXs (no automated test gate - manual QA   │
+   │   in step 5 below is the only validation)            │
    └───────┬──────────────────────────────────────────────┘
            │
            ▼
    ┌──────────────────────────────────────────────────────┐
-   │ publishVSCode.yml → Marketplace                      │
+   │ Manual QA: download + install VSIXs, smoke test      │
+   └───────┬──────────────────────────────────────────────┘
+           │
+           ▼
+   ┌──────────────────────────────────────────────────────┐
+   │ publishVSCode.yml + publishOpenVSX.yml               │
+   │ Both dispatched with -f isHotfix=true, release-tag   │
+   │ • Test patch commit (compile + test)                 │
+   │ • Publish stable to VS Code Marketplace & Open VSX   │
+   └───────┬──────────────────────────────────────────────┘
+           │
+           ▼
+   ┌──────────────────────────────────────────────────────┐
+   │ LIVE ON BOTH REGISTRIES (as stable)                  │
    └──────────────────────────────────────────────────────┘
                                                                   │       │
 ═══════════════════════════════════════════════════════════════════════════
@@ -230,7 +248,7 @@ Emergency Path: ❌ None (wait 7+ days)
 ```
 WEEK N    Mon       Tue       Wed       Thu       Fri       Sat       Sun
                               │
-                              ├─ promote-nightly-to-prerelease.yml (AUTOMATED 8 AM UTC)
+                              ├─ promote-to-prerelease.yml (AUTOMATED 8 AM UTC)
                               │    • Finds most recent nightly (min-tag-age: 0 days)
                               │    • Gate-checks: verifies nightly build/release success
                               │    • Publishes to marketplace as PRE-RELEASE

--- a/docs/release-workflow-architecture.md
+++ b/docs/release-workflow-architecture.md
@@ -120,7 +120,6 @@ EMERGENCY PRE-RELEASE PATH (5 minutes to marketplace) - NEW!             │
    │ │ • Uses version from source's package.json (must    │        │      │
    │ │   be unique, not already published to marketplace) │        │      │
    │ │ • No automated version bump or branch creation     │        │      │
-   │ │ • Runs unit tests (compile + test) before tagging  │        │      │
    │ │ • Builds VSIXs from exact ref                      │        │      │
    │ │ • Creates GitHub pre-release with nightly tag      │        │      │
    │ └────────────────────────────────────────────────────┤        │      │

--- a/packages/salesforcedx-lwc-language-server/test/lwcServerNode.test.ts
+++ b/packages/salesforcedx-lwc-language-server/test/lwcServerNode.test.ts
@@ -1350,4 +1350,14 @@ describe('lwcServerNode', () => {
       await server.onInitialize(initializeParams);
     });
   });
+
+  // Several tests above call onInitialize() directly (not through setupServerForTest's
+  // stub-drain-restore helper), which schedules a real performDelayedInitialization via
+  // setTimeout(0). Any still-pending one can log after this file's afterAll hooks finish,
+  // hitting an already-restored, torn-down console.info and failing the whole suite with
+  // "Cannot log after tests are done". Registered last so it runs first (Jest's afterAll
+  // hooks run LIFO), draining stragglers while console.info is still mocked above.
+  afterAll(async () => {
+    await new Promise(resolve => setTimeout(resolve, 500));
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Closes test-coverage gaps in the emergency/hotfix release paths added by W-23900552.

### The gap

`startFromRef` (build-release.yml) lets you build a release from any git ref — a hotfix branch, a specific commit — instead of a nightly tag. That's the point: it exists specifically to bypass the normal nightly pipeline for emergencies. But bypassing that pipeline also means bypassing `develop`'s branch protection (required unit tests, build-all, lint), since the ref was never merged through a PR. The commit gets tagged, built into a VSIX, and (via `isHotfix=true`) promoted to a marketplace pre-release or published as stable — with zero automated test coverage anywhere in that path.

This was silent: nothing failed loudly, there was just no test signal at all for hotfix-sourced releases. It surfaced while testing the emergency flow end-to-end on `ci-testing` — `promote-to-prerelease.yml`'s existing gate-check queries GitHub's Checks API for named check-runs (`nightly-release / package / Package`, etc.) on the commit being promoted, but those check-runs only ever get created by the normal nightly pipeline. A hotfix commit built via `startFromRef` never goes through that pipeline, so the check-run lookup returns nothing — not because the code wasn't tested, but because there was never a code path that tested it in the first place.

### The fix

- Adds a compile+test gate to `promote-to-prerelease.yml`, `publishVSCode.yml`, and `publishOpenVSX.yml` (`isHotfix=true`) that checks out the *exact* commit being promoted/published and tests it directly, right before it goes live — replacing the broken check-run lookup with a real, self-verifying test run against the actual code being shipped.
- Removes the equivalent gate from `build-release.yml` itself — it duplicated the three downstream gates and was exposed to unrelated test flakiness at build time (see below). Test coverage for these paths now lives exclusively in the three gates closest to release, not duplicated earlier in the pipeline.
- Renames `promote-nightly-to-prerelease.yml` → `promote-to-prerelease.yml`, since `isHotfix` means the source is no longer always a nightly tag.
- Fixes a dangling-timer test flake in `salesforcedx-lwc-language-server` (`lwcServerNode.test.ts`) that was blocking the new gate: several tests call `onInitialize()` directly without draining the scheduled `performDelayedInitialization`, so a straggler's `Logger.info` call could fire after the suite's `afterAll` restores `console.info`, failing the whole suite with "Cannot log after tests are done." Adds a final `afterAll` (registered last, so it runs first in Jest's teardown order) to drain any pending timer first.

### What issues does this PR fix or reference?
@W-23900552@
