### PR TITLE
feat(release): generate weekly changelog delta, keep full history on develop - W-24144092

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -6,7 +6,7 @@ review: never
 
 # Changelog Polish
 
-Improve the automated changelog delta committed to `develop` by `promote-nightly-to-prerelease.yml`.
+Improve the automated changelog delta committed to `develop` by `promote-to-prerelease.yml`.
 
 Scope: the all-extensions release changelog at `packages/salesforcedx-vscode/CHANGELOG.md`. Root `CHANGELOG.md` contains full historical changelog (automatically prepended by `scripts/prepend-release-changelog.js`, run as part of the same promote job) — do not edit manually. Per-package `CHANGELOG.md` files (e.g. `packages/salesforcedx-vscode-i18n/CHANGELOG.md`) are scoped to their own package and out of scope here.
 
@@ -145,11 +145,11 @@ Use these `chore:` subjects for polish commits on `develop`:
 
 ## Reference: changelog lifecycle
 
-These describe the pipeline behavior in `promote-nightly-to-prerelease.yml`, `scripts/generate-release-delta-changelog.ts` + `scripts/change-log-generator-utils.ts`. Background context for understanding auto-generated commits; typically not interacted with during polish.
+These describe the pipeline behavior in `promote-to-prerelease.yml`, `scripts/generate-release-delta-changelog.ts` + `scripts/change-log-generator-utils.ts`. Background context for understanding auto-generated commits; typically not interacted with during polish.
 
 ### Generate → Prepend → Polish → Relabel
 
-1. **Generation + Prepend** (`promote-nightly-to-prerelease.yml`'s `changelog` job, weekly on `develop`): `npm run changelog:delta` writes this week's delta to `packages/salesforcedx-vscode/CHANGELOG.md`, then `scripts/prepend-release-changelog.js` immediately copies that same content into root `CHANGELOG.md`. Both are labeled with the **prerelease** version (e.g. `67.17.9`).
+1. **Generation + Prepend** (`promote-to-prerelease.yml`'s `changelog` job, weekly on `develop`): `npm run changelog:delta` writes this week's delta to `packages/salesforcedx-vscode/CHANGELOG.md`, then `scripts/prepend-release-changelog.js` immediately copies that same content into root `CHANGELOG.md`. Both are labeled with the **prerelease** version (e.g. `67.17.9`).
 2. **Polish** (`develop`, this skill): Human edits `packages/salesforcedx-vscode/CHANGELOG.md` any time before the next `build-release.yml` run. **Note:** because prepend already ran in step 1, root `CHANGELOG.md`'s copy of this version's section is *not* automatically re-synced by a polish edit — see the open question below if this matters for your case.
 3. **Relabel to stable** (`build-release.yml`, next Wednesday 7 AM UTC): pulls develop's current `packages/salesforcedx-vscode/CHANGELOG.md` (picking up any polish from step 2), relabels the header from the prerelease version to the stable version, and bakes it into the stable VSIX.
 4. **Relabel history** (`publishVSCode.yml`, on final stable publish): relabels the same header in develop's `CHANGELOG.md` and `packages/salesforcedx-vscode/CHANGELOG.md` from prerelease → stable version, so the committed history matches what shipped.

--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -1,28 +1,29 @@
 ---
 name: changelog
-description: Polish the automated CHANGELOG for a release branch. Removes GUS refs, categorizes under-the-cover changes, improves customer-facing descriptions. Use when preparing/reviewing the changelog on a release branch, or when user mentions changelog quality.
+description: Polish the automated CHANGELOG on develop before the next stable build. Removes GUS refs, categorizes under-the-cover changes, improves customer-facing descriptions. Use when preparing/reviewing the changelog after a weekly prerelease promotion, or when user mentions changelog quality.
 review: never
 ---
 
 # Changelog Polish
 
-Improve the automated changelog generated on release branches (`release/vM.m.P`).
+Improve the automated changelog delta committed to `develop` by `promote-nightly-to-prerelease.yml`.
 
-Scope: the all-extensions release changelog at `packages/salesforcedx-vscode/CHANGELOG.md`. Root `CHANGELOG.md` contains full historical changelog (automatically updated by `scripts/prepend-release-changelog.js` on merge) — do not edit manually. Per-package `CHANGELOG.md` files (e.g. `packages/salesforcedx-vscode-i18n/CHANGELOG.md`) are scoped to their own package and out of scope here.
+Scope: the all-extensions release changelog at `packages/salesforcedx-vscode/CHANGELOG.md`. Root `CHANGELOG.md` contains full historical changelog (automatically prepended by `scripts/prepend-release-changelog.js`, run as part of the same promote job) — do not edit manually. Per-package `CHANGELOG.md` files (e.g. `packages/salesforcedx-vscode-i18n/CHANGELOG.md`) are scoped to their own package and out of scope here.
 
 ## When to use
 
 - User invokes `/changelog` or asks to prepare/review the changelog
-- On a release branch with a `chore: generated CHANGELOG` commit
+- On `develop`, after a `chore: changelog for prerelease vX.Y.Z` commit lands
+- **Timing matters**: polish it *before* `build-release.yml`'s next scheduled run (Wednesdays, 7 AM UTC). That job reads develop's current `packages/salesforcedx-vscode/CHANGELOG.md`, relabels the header to the stable version, and bakes it into the stable VSIX. Once that's run, the content is frozen inside the built artifact — fixing it afterward means manually re-injecting into the release's VSIX asset, not editing this file.
 
 ## File location
 
-`packages/salesforcedx-vscode/CHANGELOG.md`
+`packages/salesforcedx-vscode/CHANGELOG.md` on `develop`
 
 ## Workflow
 
-1. **Read** the current changelog file
-2. **Identify** the automated commit: `git log --oneline -- packages/salesforcedx-vscode/CHANGELOG.md | grep "generated CHANGELOG"`
+1. **Checkout/pull `develop`** and **read** the current changelog file
+2. **Identify** the automated commit: `git log --oneline -- packages/salesforcedx-vscode/CHANGELOG.md | grep "changelog for prerelease"`
 3. **For each entry**, fetch PR context: `gh pr view <number> --json title,body,commits,labels`. In the body, look for a **"What issues does this PR fix or reference?"** section and extract any issue or discussion numbers linked there.
 4. **Apply** the rules below to produce a polished draft
 5. **Present** the revised changelog to the user for approval before writing
@@ -122,14 +123,15 @@ The automation lists the same PR under every package it touched. Consolidate to 
 
 After user approves the polished changelog:
 
-1. Stage **only** the changelog file: `git add packages/salesforcedx-vscode/CHANGELOG.md`
-2. Verify no other files are staged: `git diff --cached --name-only` must show only `packages/salesforcedx-vscode/CHANGELOG.md`. If other files appear, unstage them before committing.
-3. Commit: `git commit -m "chore: update CHANGELOG.md [skip ci]"`
-4. Push: `git push`
+1. Make sure you're on `develop` and up to date: `git checkout develop && git pull`
+2. Stage **only** the changelog file: `git add packages/salesforcedx-vscode/CHANGELOG.md`
+3. Verify no other files are staged: `git diff --cached --name-only` must show only `packages/salesforcedx-vscode/CHANGELOG.md`. If other files appear, unstage them before committing.
+4. Commit: `git commit -m "chore: polish changelog [skip ci]"`
+5. Push: `git push origin develop`
 
 Never include other file changes in this commit.
 
-Use these `chore:` subjects for polish commits on the release branch:
+Use these `chore:` subjects for polish commits on `develop`:
 
 - `chore: polish changelog`
 - `chore: write into sentences`
@@ -143,24 +145,25 @@ Use these `chore:` subjects for polish commits on the release branch:
 
 ## Reference: changelog lifecycle
 
-These rules describe the auto-generator behavior in `scripts/create-release-notes.ts` + `scripts/change-log-generator-utils.ts`. Background context for understanding auto-generated commits; typically not interacted with during polish.
+These describe the pipeline behavior in `promote-nightly-to-prerelease.yml`, `scripts/generate-release-delta-changelog.ts` + `scripts/change-log-generator-utils.ts`. Background context for understanding auto-generated commits; typically not interacted with during polish.
 
-### Polish → Merge → Prepend
+### Generate → Prepend → Polish → Relabel
 
-1. **Generation** (release branch): `scripts/create-release-notes.ts` writes to `packages/salesforcedx-vscode/CHANGELOG.md`
-2. **Polish** (release branch, this skill): Human edits `packages/salesforcedx-vscode/CHANGELOG.md`
-3. **Merge** (GHA workflow): Release branch → main → develop
-4. **Prepend** (GHA workflow): `scripts/prepend-release-changelog.js` copies package CHANGELOG to root `CHANGELOG.md`
+1. **Generation + Prepend** (`promote-nightly-to-prerelease.yml`'s `changelog` job, weekly on `develop`): `npm run changelog:delta` writes this week's delta to `packages/salesforcedx-vscode/CHANGELOG.md`, then `scripts/prepend-release-changelog.js` immediately copies that same content into root `CHANGELOG.md`. Both are labeled with the **prerelease** version (e.g. `67.17.9`).
+2. **Polish** (`develop`, this skill): Human edits `packages/salesforcedx-vscode/CHANGELOG.md` any time before the next `build-release.yml` run. **Note:** because prepend already ran in step 1, root `CHANGELOG.md`'s copy of this version's section is *not* automatically re-synced by a polish edit — see the open question below if this matters for your case.
+3. **Relabel to stable** (`build-release.yml`, next Wednesday 7 AM UTC): pulls develop's current `packages/salesforcedx-vscode/CHANGELOG.md` (picking up any polish from step 2), relabels the header from the prerelease version to the stable version, and bakes it into the stable VSIX.
+4. **Relabel history** (`publishVSCode.yml`, on final stable publish): relabels the same header in develop's `CHANGELOG.md` and `packages/salesforcedx-vscode/CHANGELOG.md` from prerelease → stable version, so the committed history matches what shipped.
 
-The script validates structure (version format, file existence, non-empty content), runs idempotently (skips if version already in root), and reports specific errors (ENOSPC, EACCES, missing files).
+`prepend-release-changelog.js` validates structure (version format, file existence, non-empty content), runs idempotently (skips if version already in root), and reports specific errors (ENOSPC, EACCES, missing files).
 
 ### Generation rules
 
-These describe the auto-generator behavior in `scripts/create-release-notes.ts` + `scripts/change-log-generator-utils.ts`. Background context for what arrives in the auto-generated commit; you don't interact with them during polish.
+These describe the auto-generator behavior in `scripts/generate-release-delta-changelog.ts` + `scripts/change-log-generator-utils.ts`. Background context for what arrives in the auto-generated commit; you don't interact with them during polish.
 
-- Auto-generated by `Create Release Branch` GHA via `npm run changelog`
-- Commit: `chore: generated CHANGELOG for release/vXX.YY.ZZ`
-- Human-edited afterward on release branch before publish (this skill)
+- Auto-generated by the `Promote Nightly to Pre-release` GHA's `changelog` job via `npm run changelog:delta`, committed directly to `develop`
+- Commit: `chore: changelog for prerelease vXX.YY.ZZ [skip ci]`
+- Range is since the previous week's promoted prerelease, not since the last stable release — unlike the legacy `npm run changelog` generator, it does **not** dedupe against PRs already present in the file (the range is disjoint by construction, so there's nothing to dedupe against)
+- Human-edited afterward on `develop` before the next stable build (this skill)
 - If nothing releasable (all `chore`/`ci` etc.), script exits, no entry added
 
 ### Format
@@ -197,7 +200,7 @@ These describe the auto-generator behavior in `scripts/create-release-notes.ts` 
 
 - Requires conventional `type(scope): message` + trailing `(#PR)` to appear in changelog
 - Strips `[W-XXXXXXXX]` GUS refs; uppercases first char
-- Skips entries whose PR# already exists in file (rerun-safe)
+- The legacy `npm run changelog` generator skips entries whose PR# already exists in the file (rerun-safe); `npm run changelog:delta` does not, since its range is disjoint by construction (see Generation rules above)
 
 ### Dedupe / merge rules (post-generation)
 

--- a/.github/actions/commitAndPushToDevelop/action.yml
+++ b/.github/actions/commitAndPushToDevelop/action.yml
@@ -1,0 +1,50 @@
+name: commitAndPushToDevelop
+description: "Stages files, commits if there are changes, and pushes to develop, retrying on a concurrent-push race"
+
+inputs:
+  files:
+    description: 'Space-separated list of file paths to git add'
+    required: true
+  message:
+    description: 'Commit message'
+    required: true
+
+outputs:
+  committed:
+    description: "'true' if a commit was made and pushed; 'false' if there was nothing to commit"
+    value: ${{ steps.commit.outputs.committed }}
+
+runs:
+  using: composite
+  steps:
+    - id: commit
+      shell: bash
+      env:
+        FILES: ${{ inputs.files }}
+        MESSAGE: ${{ inputs.message }}
+      run: |
+        git add $FILES
+        if git diff --cached --quiet; then
+          echo "No changes to commit"
+          echo "committed=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        git commit -m "$MESSAGE"
+
+        pushed=false
+        for attempt in 1 2 3 4 5; do
+          if git pull --rebase origin develop && git push origin develop; then
+            pushed=true
+            break
+          fi
+          echo "Push attempt $attempt failed, retrying in $((attempt * 5))s..."
+          sleep $((attempt * 5))
+        done
+
+        if [ "$pushed" != "true" ]; then
+          echo "::error::Failed to push to develop after 5 attempts"
+          exit 1
+        fi
+
+        echo "committed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -327,7 +327,7 @@ jobs:
         uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
 
       - name: Relabel this week's changelog for stable release
-        # promote-nightly-to-prerelease.yml already generated and committed this week's
+        # promote-to-prerelease.yml already generated and committed this week's
         # delta to develop (labeled with the prerelease version); pull that exact content
         # and relabel its header to the stable version being built here. Emergency
         # pre-releases skip this -- they don't go through the weekly promote cycle. Stable

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -326,6 +326,30 @@ jobs:
       - name: Install dependencies with updated versions
         uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
 
+      - name: Relabel this week's changelog for stable release
+        # promote-nightly-to-prerelease.yml already generated and committed this week's
+        # delta to develop (labeled with the prerelease version); pull that exact content
+        # and relabel its header to the stable version being built here. Emergency
+        # pre-releases skip this -- they don't go through the weekly promote cycle. Stable
+        # hotfixes built via startFromRef also skip it (SOURCE_TAG there is an arbitrary
+        # ref, not a nightly tag), keeping whatever changelog is already in the working tree.
+        if: steps.calculate-version.outputs.is_prerelease != 'true'
+        env:
+          RELEASE_VERSION: ${{ steps.calculate-version.outputs.version }}
+          SOURCE_TAG: ${{ steps.detect-tag.outputs.tag }}
+        run: |
+          if [[ ! "$SOURCE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-nightly\.develop\.[0-9]{8}$ ]]; then
+            echo "Source ref '$SOURCE_TAG' is not a nightly tag (hotfix/startFromRef build) - nothing to relabel."
+            exit 0
+          fi
+          PRERELEASE_VERSION=$(echo "$SOURCE_TAG" | grep -oP '\d+\.\d+\.\d+' | head -1)
+
+          git fetch origin develop
+          git show origin/develop:packages/salesforcedx-vscode/CHANGELOG.md > packages/salesforcedx-vscode/CHANGELOG.md
+          node scripts/relabel-changelog-version.js "$PRERELEASE_VERSION" "$RELEASE_VERSION" packages/salesforcedx-vscode/CHANGELOG.md
+
+          echo "✓ Relabeled changelog v$PRERELEASE_VERSION → v$RELEASE_VERSION"
+
       - name: Build VSIXs
         run: npm run vscode:package
 

--- a/.github/workflows/promote-nightly-to-prerelease.yml
+++ b/.github/workflows/promote-nightly-to-prerelease.yml
@@ -57,9 +57,89 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           required-checks: '["nightly-release / package / Package", "nightly-release / Create GitHub Releases"]'
 
-  # Step 3: Promote to prerelease (only runs if gate-check passed)
-  promote:
+  # Step 3: Generate this week's changelog delta (commits since last week's promoted
+  # prerelease), bake it into the pack's prerelease VSIX asset so the Marketplace/Open VSX
+  # Changelog tab shows only this week's changes, and commit the same delta to develop so
+  # root CHANGELOG.md keeps the full cumulative history. Must complete before `promote`,
+  # since the reusable promote workflow re-downloads this exact release asset.
+  changelog:
     needs: [find-nightly, gate-check]
+    if: ${{ inputs.dry-run != true }}
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
+      NIGHTLY_TAG: ${{ needs.find-nightly.outputs.nightly-tag }}
+      NIGHTLY_SHA: ${{ needs.find-nightly.outputs.commit-sha }}
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ secrets.IDEE_GH_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ vars.NODE_VERSION || 'lts/*' }}
+
+      - uses: ./.github/actions/gitConfig
+        with:
+          email: ${{ secrets.IDEE_GH_EMAIL }}
+
+      - uses: salesforcecli/github-workflows/.github/actions/npmInstallWithRetries@main
+
+      - name: Determine prerelease version
+        id: version
+        run: |
+          VERSION=$(echo "$NIGHTLY_TAG" | grep -oP '\d+\.\d+\.\d+' | head -1)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not extract version from nightly tag: $NIGHTLY_TAG"
+            exit 1
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Generate this week's changelog delta
+        env:
+          PRERELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: npx ts-node scripts/generate-release-delta-changelog.ts "$PRERELEASE_VERSION" "$NIGHTLY_SHA"
+
+      - name: Inject changelog into the prerelease VSIX
+        env:
+          PRERELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          VSIX="salesforcedx-vscode-${PRERELEASE_VERSION}.vsix"
+          gh release download "$NIGHTLY_TAG" --pattern "$VSIX" --clobber
+
+          # vsce stores the file lowercase inside the vsix; must match exactly or zip
+          # adds a second, differently-cased entry instead of replacing this one.
+          mkdir -p extension
+          cp packages/salesforcedx-vscode/CHANGELOG.md extension/changelog.md
+          zip "$VSIX" extension/changelog.md
+
+          gh release upload "$NIGHTLY_TAG" "$VSIX" --clobber
+          rm -rf extension "$VSIX"
+
+      - name: Commit changelog delta to develop (full history)
+        env:
+          PRERELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          node scripts/prepend-release-changelog.js
+          git add packages/salesforcedx-vscode/CHANGELOG.md CHANGELOG.md
+          if git diff --cached --quiet; then
+            echo "No changelog changes to commit"
+          else
+            git commit -m "chore: changelog for prerelease v${PRERELEASE_VERSION} [skip ci]"
+            git pull --rebase origin develop
+            git push origin develop
+          fi
+
+  # Step 4: Promote to prerelease (only runs if gate-check passed and changelog is baked in).
+  # `changelog` is skipped (not failed) in dry-run mode, so allow skipped through as well as
+  # success -- otherwise dry-run would never reach the reusable workflow's own dry-run path.
+  promote:
+    needs: [find-nightly, gate-check, changelog]
+    if: always() && needs.gate-check.result == 'success' && (needs.changelog.result == 'success' || needs.changelog.result == 'skipped')
     uses: salesforcecli/github-workflows/.github/workflows/vscode-promote-prerelease.yml@main
     with:
       release-tag: ${{ needs.find-nightly.outputs.nightly-tag }}

--- a/.github/workflows/promote-to-prerelease.yml
+++ b/.github/workflows/promote-to-prerelease.yml
@@ -156,7 +156,10 @@ jobs:
           # adds a second, differently-cased entry instead of replacing this one.
           mkdir -p extension
           cp packages/salesforcedx-vscode/CHANGELOG.md extension/changelog.md
-          zip "$VSIX" extension/changelog.md
+          # -X: omit Unix UID/GID + timestamp extra fields. vsce's own zip writer never
+          # sets them; without -X, Open VSX's scanner blocks the whole VSIX with
+          # "contains zip entries with potentially harmful extra fields".
+          zip -X "$VSIX" extension/changelog.md
 
           gh release upload "$NIGHTLY_TAG" "$VSIX" --clobber
           rm -rf extension "$VSIX"

--- a/.github/workflows/promote-to-prerelease.yml
+++ b/.github/workflows/promote-to-prerelease.yml
@@ -146,7 +146,7 @@ jobs:
         id: delta
         env:
           PRERELEASE_VERSION: ${{ steps.version.outputs.version }}
-        run: npx ts-node scripts/generate-release-delta-changelog.ts "$PRERELEASE_VERSION" "$NIGHTLY_SHA"
+        run: npm run changelog:delta -- "$PRERELEASE_VERSION" "$NIGHTLY_SHA"
 
       - name: Inject changelog into the prerelease VSIX
         # Skip when nothing new was generated (e.g. only chore/ci commits this week) --

--- a/.github/workflows/promote-to-prerelease.yml
+++ b/.github/workflows/promote-to-prerelease.yml
@@ -105,7 +105,9 @@ jobs:
   # since the reusable promote workflow re-downloads this exact release asset.
   changelog:
     needs: [find-nightly, gate-check]
-    if: ${{ inputs.dry-run != true }}
+    # A custom `if:` replaces (not augments) GitHub Actions' implicit needs-success gate,
+    # so gate-check's success must be checked explicitly here too -- same as `promote` below.
+    if: always() && needs.gate-check.result == 'success' && inputs.dry-run != true
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
@@ -141,11 +143,16 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Generate this week's changelog delta
+        id: delta
         env:
           PRERELEASE_VERSION: ${{ steps.version.outputs.version }}
         run: npx ts-node scripts/generate-release-delta-changelog.ts "$PRERELEASE_VERSION" "$NIGHTLY_SHA"
 
       - name: Inject changelog into the prerelease VSIX
+        # Skip when nothing new was generated (e.g. only chore/ci commits this week) --
+        # otherwise this would re-ship last week's changelog mislabeled with this week's
+        # version, since the file is untouched from the last run.
+        if: steps.delta.outputs.generated == 'true'
         env:
           PRERELEASE_VERSION: ${{ steps.version.outputs.version }}
         run: |
@@ -165,6 +172,7 @@ jobs:
           rm -rf extension "$VSIX"
 
       - name: Commit changelog delta to develop (full history)
+        if: steps.delta.outputs.generated == 'true'
         env:
           PRERELEASE_VERSION: ${{ steps.version.outputs.version }}
         run: |
@@ -174,8 +182,21 @@ jobs:
             echo "No changelog changes to commit"
           else
             git commit -m "chore: changelog for prerelease v${PRERELEASE_VERSION} [skip ci]"
-            git pull --rebase origin develop
-            git push origin develop
+
+            pushed=false
+            for attempt in 1 2 3 4 5; do
+              if git pull --rebase origin develop && git push origin develop; then
+                pushed=true
+                break
+              fi
+              echo "Push attempt $attempt failed, retrying in $((attempt * 5))s..."
+              sleep $((attempt * 5))
+            done
+
+            if [ "$pushed" != "true" ]; then
+              echo "::error::Failed to push changelog to develop after 5 attempts"
+              exit 1
+            fi
           fi
 
   # Step 4: Promote to prerelease (only runs if gate-check passed and changelog is baked in).

--- a/.github/workflows/promote-to-prerelease.yml
+++ b/.github/workflows/promote-to-prerelease.yml
@@ -171,33 +171,16 @@ jobs:
           gh release upload "$NIGHTLY_TAG" "$VSIX" --clobber
           rm -rf extension "$VSIX"
 
-      - name: Commit changelog delta to develop (full history)
+      - name: Prepend delta to root CHANGELOG (full history)
         if: steps.delta.outputs.generated == 'true'
-        env:
-          PRERELEASE_VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          node scripts/prepend-release-changelog.js
-          git add packages/salesforcedx-vscode/CHANGELOG.md CHANGELOG.md
-          if git diff --cached --quiet; then
-            echo "No changelog changes to commit"
-          else
-            git commit -m "chore: changelog for prerelease v${PRERELEASE_VERSION} [skip ci]"
+        run: node scripts/prepend-release-changelog.js
 
-            pushed=false
-            for attempt in 1 2 3 4 5; do
-              if git pull --rebase origin develop && git push origin develop; then
-                pushed=true
-                break
-              fi
-              echo "Push attempt $attempt failed, retrying in $((attempt * 5))s..."
-              sleep $((attempt * 5))
-            done
-
-            if [ "$pushed" != "true" ]; then
-              echo "::error::Failed to push changelog to develop after 5 attempts"
-              exit 1
-            fi
-          fi
+      - name: Commit changelog delta to develop
+        if: steps.delta.outputs.generated == 'true'
+        uses: ./.github/actions/commitAndPushToDevelop
+        with:
+          files: packages/salesforcedx-vscode/CHANGELOG.md CHANGELOG.md
+          message: "chore: changelog for prerelease v${{ steps.version.outputs.version }} [skip ci]"
 
   # Step 4: Promote to prerelease (only runs if gate-check passed and changelog is baked in).
   # `changelog` is skipped (not failed) in dry-run mode, so allow skipped through as well as

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -167,7 +167,7 @@ jobs:
       changeCaseId: ${{ needs.ctc-open.outputs.changeCaseId }}
       status: Not Implemented
 
-  # promote-nightly-to-prerelease.yml committed this week's changelog delta to develop
+  # promote-to-prerelease.yml committed this week's changelog delta to develop
   # labeled with the prerelease version. Now that it has shipped stable, relabel that same
   # develop history entry (root CHANGELOG.md + the pack's CHANGELOG.md) to the stable version.
   relabel-changelog:

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -215,8 +215,21 @@ jobs:
             echo "No changelog changes to commit"
           else
             git commit -m "chore: relabel changelog v${PRERELEASE_VERSION} to v${RELEASE_VERSION} [skip ci]"
-            git pull --rebase origin develop
-            git push origin develop
+
+            pushed=false
+            for attempt in 1 2 3 4 5; do
+              if git pull --rebase origin develop && git push origin develop; then
+                pushed=true
+                break
+              fi
+              echo "Push attempt $attempt failed, retrying in $((attempt * 5))s..."
+              sleep $((attempt * 5))
+            done
+
+            if [ "$pushed" != "true" ]; then
+              echo "::error::Failed to push relabeled changelog to develop after 5 attempts"
+              exit 1
+            fi
           fi
 
   # Set repo variable CBW_TRIGGER_ENABLED=false to disable dispatch to code-builder-web.

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -127,6 +127,58 @@ jobs:
       changeCaseId: ${{ needs.ctc-open.outputs.changeCaseId }}
       status: Not Implemented
 
+  # promote-nightly-to-prerelease.yml committed this week's changelog delta to develop
+  # labeled with the prerelease version. Now that it has shipped stable, relabel that same
+  # develop history entry (root CHANGELOG.md + the pack's CHANGELOG.md) to the stable version.
+  relabel-changelog:
+    needs: [prepare-release-metadata, publish]
+    if: needs.publish.result == 'success' && !inputs.dry-run
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.IDEE_GH_TOKEN }}
+      RELEASE_TAG: ${{ needs.prepare-release-metadata.outputs.RELEASE_TAG }}
+      RELEASE_VERSION: ${{ needs.prepare-release-metadata.outputs.CBW_RELEASE_VERSION }}
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+          token: ${{ secrets.IDEE_GH_TOKEN }}
+
+      - uses: ./.github/actions/gitConfig
+        with:
+          email: ${{ secrets.IDEE_GH_EMAIL }}
+
+      - name: Relabel develop's changelog history to the stable version
+        run: |
+          # build-release.yml always writes "Built from nightly: `<tag>`" for stable builds,
+          # even when the source was startFromRef rather than an actual nightly tag -- the
+          # nightly-tag-shaped grep below naturally no-ops for those (no promoted delta to relabel).
+          NIGHTLY_TAG=$(gh release view "$RELEASE_TAG" --json body -q .body | grep -oP '(?<=Built from nightly:.{0,10}`)v[\d.]+-nightly\.develop\.\d+' || true)
+          if [ -z "$NIGHTLY_TAG" ]; then
+            echo "No 'Built from nightly' reference found in release $RELEASE_TAG (likely a hotfix/startFromRef build) - skipping relabel."
+            exit 0
+          fi
+
+          PRERELEASE_VERSION=$(echo "$NIGHTLY_TAG" | grep -oP '\d+\.\d+\.\d+' | head -1)
+          if [ -z "$PRERELEASE_VERSION" ] || [ "$PRERELEASE_VERSION" = "$RELEASE_VERSION" ]; then
+            echo "Nothing to relabel (no prerelease version found, or already matches stable version)."
+            exit 0
+          fi
+
+          node scripts/relabel-changelog-version.js "$PRERELEASE_VERSION" "$RELEASE_VERSION" CHANGELOG.md
+          node scripts/relabel-changelog-version.js "$PRERELEASE_VERSION" "$RELEASE_VERSION" packages/salesforcedx-vscode/CHANGELOG.md
+
+          git add CHANGELOG.md packages/salesforcedx-vscode/CHANGELOG.md
+          if git diff --cached --quiet; then
+            echo "No changelog changes to commit"
+          else
+            git commit -m "chore: relabel changelog v${PRERELEASE_VERSION} to v${RELEASE_VERSION} [skip ci]"
+            git pull --rebase origin develop
+            git push origin develop
+          fi
+
   # Set repo variable CBW_TRIGGER_ENABLED=false to disable dispatch to code-builder-web.
   # Default (unset): dispatch after publish. Use when publishing without CBW promotion.
   # Uses repository_dispatch (not workflow_call) because GitHub Actions blocks

--- a/.github/workflows/publishVSCode.yml
+++ b/.github/workflows/publishVSCode.yml
@@ -190,7 +190,8 @@ jobs:
         with:
           email: ${{ secrets.IDEE_GH_EMAIL }}
 
-      - name: Relabel develop's changelog history to the stable version
+      - name: Determine prerelease version to relabel
+        id: relabel-version
         run: |
           # build-release.yml always writes "Built from nightly: `<tag>`" for stable builds,
           # even when the source was startFromRef rather than an actual nightly tag -- the
@@ -198,39 +199,33 @@ jobs:
           NIGHTLY_TAG=$(gh release view "$RELEASE_TAG" --json body -q .body | grep -oP '(?<=Built from nightly:.{0,10}`)v[\d.]+-nightly\.develop\.\d+' || true)
           if [ -z "$NIGHTLY_TAG" ]; then
             echo "No 'Built from nightly' reference found in release $RELEASE_TAG (likely a hotfix/startFromRef build) - skipping relabel."
+            echo "prerelease_version=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           PRERELEASE_VERSION=$(echo "$NIGHTLY_TAG" | grep -oP '\d+\.\d+\.\d+' | head -1)
           if [ -z "$PRERELEASE_VERSION" ] || [ "$PRERELEASE_VERSION" = "$RELEASE_VERSION" ]; then
             echo "Nothing to relabel (no prerelease version found, or already matches stable version)."
+            echo "prerelease_version=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
+          echo "prerelease_version=$PRERELEASE_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Relabel develop's changelog history to the stable version
+        if: steps.relabel-version.outputs.prerelease_version != ''
+        env:
+          PRERELEASE_VERSION: ${{ steps.relabel-version.outputs.prerelease_version }}
+        run: |
           node scripts/relabel-changelog-version.js "$PRERELEASE_VERSION" "$RELEASE_VERSION" CHANGELOG.md
           node scripts/relabel-changelog-version.js "$PRERELEASE_VERSION" "$RELEASE_VERSION" packages/salesforcedx-vscode/CHANGELOG.md
 
-          git add CHANGELOG.md packages/salesforcedx-vscode/CHANGELOG.md
-          if git diff --cached --quiet; then
-            echo "No changelog changes to commit"
-          else
-            git commit -m "chore: relabel changelog v${PRERELEASE_VERSION} to v${RELEASE_VERSION} [skip ci]"
-
-            pushed=false
-            for attempt in 1 2 3 4 5; do
-              if git pull --rebase origin develop && git push origin develop; then
-                pushed=true
-                break
-              fi
-              echo "Push attempt $attempt failed, retrying in $((attempt * 5))s..."
-              sleep $((attempt * 5))
-            done
-
-            if [ "$pushed" != "true" ]; then
-              echo "::error::Failed to push relabeled changelog to develop after 5 attempts"
-              exit 1
-            fi
-          fi
+      - name: Commit relabeled changelog to develop
+        if: steps.relabel-version.outputs.prerelease_version != ''
+        uses: ./.github/actions/commitAndPushToDevelop
+        with:
+          files: CHANGELOG.md packages/salesforcedx-vscode/CHANGELOG.md
+          message: "chore: relabel changelog v${{ steps.relabel-version.outputs.prerelease_version }} to v${{ env.RELEASE_VERSION }} [skip ci]"
 
   # Set repo variable CBW_TRIGGER_ENABLED=false to disable dispatch to code-builder-web.
   # Default (unset): dispatch after publish. Use when publishing without CBW promotion.

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "postinstall": "wireit",
     "bootstrap": "npm install",
     "changelog": "ts-node ./scripts/create-release-notes.ts",
+    "changelog:delta": "ts-node ./scripts/generate-release-delta-changelog.ts",
     "clean": "npm run clean -ws --if-present && git clean -xfd",
     "clean:build": "node scripts/clean-build-artifacts.js",
     "clean:spans": "shx rm -rf ~/.sf/vscode-spans && shx mkdir -p ~/.sf/vscode-spans",

--- a/scripts/change-log-generator-utils.ts
+++ b/scripts/change-log-generator-utils.ts
@@ -65,7 +65,7 @@ function getCommits(releaseBranch: string, previousBranch: string): string[] {
 /**
  * Parse the commits and return them as a list of hashmaps.
  */
-function parseCommits(commits: string[]): CommitMap[] {
+function parseCommits(commits: string[], dedupeAgainstExisting = true): CommitMap[] {
   logger(`\nStep 4: Determine which commits we want to share in the changelog`);
   let commitMaps: CommitMap[] = [];
   for (let i = 0; i < commits.length; i++) {
@@ -74,7 +74,7 @@ function parseCommits(commits: string[]): CommitMap[] {
       commitMaps.push(commitMap);
     }
   }
-  return filterExistingPREntries(commitMaps);
+  return dedupeAgainstExisting ? filterExistingPREntries(commitMaps) : commitMaps;
 }
 
 function buildMapFromCommit(commit: string): CommitMap {
@@ -266,4 +266,24 @@ export function updateChangeLog(remoteReleaseBranch: string, remotePreviousBranc
     console.log(`No commits found, so we can skip this week's release. Carry on!`);
     process.exit(0);
   }
+}
+
+/**
+ * Generates a changelog for commits in (fromRef, toRef], overwriting CHANGE_LOG_PATH with
+ * only that range. Unlike updateChangeLog, this operates on the current working tree (no
+ * branch checkout) and doesn't dedupe against the existing file, since the range is fresh
+ * and disjoint by construction. Returns false and leaves the file untouched when the range
+ * has no qualifying commits.
+ */
+export function generateDeltaChangeLog(fromRef: string, toRef: string, version: string): boolean {
+  const parsedCommits = parseCommits(getCommits(toRef, fromRef), false);
+  if (parsedCommits.length === 0) {
+    console.log(`No qualifying commits found between ${fromRef} and ${toRef}. Skipping changelog generation.`);
+    return false;
+  }
+
+  const groupedMessages = getMessagesGroupedByPackage(parsedCommits, '');
+  const changeLog = getChangeLogText(version, groupedMessages);
+  writeChangeLog(changeLog);
+  return true;
 }

--- a/scripts/generate-release-delta-changelog.ts
+++ b/scripts/generate-release-delta-changelog.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { execSync } from 'node:child_process';
+import { generateDeltaChangeLog } from './change-log-generator-utils';
+
+const [, , version, toRefArg, fromRefArg] = process.argv;
+
+if (!version || !toRefArg) {
+  console.error('Usage: generate-release-delta-changelog.ts <version> <toRef> [fromRef]');
+  process.exit(1);
+}
+
+const toRef = toRefArg;
+
+/**
+ * Auto-detects the previous weekly prerelease baseline: the newest marketplace-prerelease
+ * tracking tag (set by last week's promote run) if present, else the newest nightly.develop
+ * tag that isn't the one currently being promoted (first-ever run, before any tracking tag
+ * exists).
+ */
+function detectPreviousPrereleaseRef(): string {
+  const trackingTag = execSync("git tag -l 'marketplace-prerelease-*' --sort=-creatordate", { encoding: 'utf8' })
+    .trim()
+    .split('\n')
+    .filter(Boolean)[0];
+  if (trackingTag) {
+    return trackingTag;
+  }
+
+  const currentSha = execSync(`git rev-parse ${toRef}`, { encoding: 'utf8' }).trim();
+  const nightlyTag = execSync("git tag -l 'v*-nightly.develop.*' --sort=-version:refname", { encoding: 'utf8' })
+    .trim()
+    .split('\n')
+    .filter(tag => tag && execSync(`git rev-parse ${tag}^{commit}`, { encoding: 'utf8' }).trim() !== currentSha)[0];
+
+  if (!nightlyTag) {
+    console.error('Could not auto-detect a previous prerelease baseline. Pass fromRef explicitly.');
+    process.exit(1);
+  }
+  return nightlyTag;
+}
+
+const fromRef = fromRefArg || detectPreviousPrereleaseRef();
+
+console.log(`Generating changelog for ${version}: (${fromRef}, ${toRef}]`);
+generateDeltaChangeLog(fromRef, toRef, version);

--- a/scripts/generate-release-delta-changelog.ts
+++ b/scripts/generate-release-delta-changelog.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { execSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
 import { generateDeltaChangeLog } from './change-log-generator-utils';
 
 const [, , version, toRefArg, fromRefArg] = process.argv;
@@ -18,9 +19,10 @@ const toRef = toRefArg;
 
 /**
  * Auto-detects the previous weekly prerelease baseline: the newest marketplace-prerelease
- * tracking tag (set by last week's promote run) if present, else the newest nightly.develop
- * tag that isn't the one currently being promoted (first-ever run, before any tracking tag
- * exists).
+ * tracking tag (set by last week's promote run) if present, else the last stable release
+ * tag. The stable tag (not the latest nightly, which is cut daily) is the correct fallback
+ * for the pipeline's first-ever run, before any tracking tag exists -- it covers everything
+ * since what actually shipped to users, instead of just ~1 day of nightly commits.
  */
 function detectPreviousPrereleaseRef(): string {
   const trackingTag = execSync("git tag -l 'marketplace-prerelease-*' --sort=-creatordate", { encoding: 'utf8' })
@@ -31,20 +33,23 @@ function detectPreviousPrereleaseRef(): string {
     return trackingTag;
   }
 
-  const currentSha = execSync(`git rev-parse ${toRef}`, { encoding: 'utf8' }).trim();
-  const nightlyTag = execSync("git tag -l 'v*-nightly.develop.*' --sort=-version:refname", { encoding: 'utf8' })
+  const stableTag = execSync("git tag -l 'v[0-9]*' --sort=-version:refname", { encoding: 'utf8' })
     .trim()
     .split('\n')
-    .filter(tag => tag && execSync(`git rev-parse ${tag}^{commit}`, { encoding: 'utf8' }).trim() !== currentSha)[0];
+    .filter(tag => tag && !tag.includes('-nightly.'))[0];
 
-  if (!nightlyTag) {
+  if (!stableTag) {
     console.error('Could not auto-detect a previous prerelease baseline. Pass fromRef explicitly.');
     process.exit(1);
   }
-  return nightlyTag;
+  return stableTag;
 }
 
 const fromRef = fromRefArg || detectPreviousPrereleaseRef();
 
 console.log(`Generating changelog for ${version}: (${fromRef}, ${toRef}]`);
-generateDeltaChangeLog(fromRef, toRef, version);
+const generated = generateDeltaChangeLog(fromRef, toRef, version);
+
+if (process.env.GITHUB_OUTPUT) {
+  appendFileSync(process.env.GITHUB_OUTPUT, `generated=${generated}\n`);
+}

--- a/scripts/prepend-release-changelog.js
+++ b/scripts/prepend-release-changelog.js
@@ -13,19 +13,9 @@
  * The script reads the package CHANGELOG and prepends to root if the version isn't already there.
  */
 
-const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
-
-// Validate we're at repo root
-function getRepoRoot() {
-  try {
-    return execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim();
-  } catch {
-    console.error('❌ Error: Not in a git repository');
-    process.exit(1);
-  }
-}
+const { getRepoRoot } = require('./repo-root');
 
 const REPO_ROOT = getRepoRoot();
 const ROOT_CHANGELOG_PATH = path.join(REPO_ROOT, 'CHANGELOG.md');

--- a/scripts/relabel-changelog-version.js
+++ b/scripts/relabel-changelog-version.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+/**
+ * Rewrites a changelog's `# <fromVersion> ...` header to `# <toVersion> ...`, preserving
+ * everything else on that line (e.g. the date). Used to relabel a prerelease's changelog
+ * entry with its stable version once the prerelease ships as a stable release.
+ *
+ * Idempotent: no-op if the fromVersion header isn't found (e.g. already relabeled).
+ *
+ * Usage:
+ *   node scripts/relabel-changelog-version.js <fromVersion> <toVersion> [filePath]
+ *
+ * filePath defaults to the repo-root CHANGELOG.md.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const [, , fromVersion, toVersion, filePathArg] = process.argv;
+
+if (!fromVersion || !toVersion) {
+  console.error('Usage: relabel-changelog-version.js <fromVersion> <toVersion> [filePath]');
+  process.exit(1);
+}
+
+function getRepoRoot() {
+  try {
+    return execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim();
+  } catch {
+    console.error('Error: Not in a git repository');
+    process.exit(1);
+  }
+}
+
+const filePath = filePathArg ? path.resolve(filePathArg) : path.join(getRepoRoot(), 'CHANGELOG.md');
+
+if (!fs.existsSync(filePath)) {
+  console.error(`Error: File not found at ${filePath}`);
+  process.exit(1);
+}
+
+const content = fs.readFileSync(filePath, 'utf8');
+const escapedFrom = fromVersion.replace(/\./g, '\\.');
+const headerRegex = new RegExp(`^# ${escapedFrom}(\\s.*)?$`, 'm');
+const match = headerRegex.exec(content);
+
+if (!match) {
+  console.log(`No "# ${fromVersion}" header found in ${filePath}. Nothing to relabel (already applied or absent).`);
+  process.exit(0);
+}
+
+const relabeled = content.replace(headerRegex, `# ${toVersion}${match[1] ?? ''}`);
+fs.writeFileSync(filePath, relabeled, 'utf8');
+console.log(`Relabeled "# ${fromVersion}" -> "# ${toVersion}" in ${filePath}`);

--- a/scripts/relabel-changelog-version.js
+++ b/scripts/relabel-changelog-version.js
@@ -15,22 +15,13 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { getRepoRoot } = require('./repo-root');
 
 const [, , fromVersion, toVersion, filePathArg] = process.argv;
 
 if (!fromVersion || !toVersion) {
   console.error('Usage: relabel-changelog-version.js <fromVersion> <toVersion> [filePath]');
   process.exit(1);
-}
-
-function getRepoRoot() {
-  try {
-    return execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim();
-  } catch {
-    console.error('Error: Not in a git repository');
-    process.exit(1);
-  }
 }
 
 const filePath = filePathArg ? path.resolve(filePathArg) : path.join(getRepoRoot(), 'CHANGELOG.md');

--- a/scripts/repo-root.js
+++ b/scripts/repo-root.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+/**
+ * Shared helper for locating the repo root from any CWD. Used by changelog scripts that
+ * read/write files at fixed repo-relative paths (root CHANGELOG.md, packages/.../CHANGELOG.md).
+ */
+
+const { execSync } = require('child_process');
+
+function getRepoRoot() {
+  try {
+    return execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim();
+  } catch {
+    console.error('Error: Not in a git repository');
+    process.exit(1);
+  }
+}
+
+module.exports = { getRepoRoot };


### PR DESCRIPTION
### What does this PR do?

Changelog generation was orphaned by the migration to `build-release.yml` — the only generator was wired into the deprecated release-branch flow, so nothing regenerated `packages/salesforcedx-vscode/CHANGELOG.md` for nightly/prerelease/stable publishes. This wires it back in, scoped to just the current week's changes, while `develop` keeps the full cumulative history separately. Verified end-to-end multiple times on the `salesforcedx-vscode-ci-testing` sandbox (real nightly tags, real VSIX injection, real publish attempts).

- `promote-to-prerelease.yml` (renamed from `promote-nightly-to-prerelease.yml` by an unrelated merge from `develop`, which also brought in its `isHotfix` gate-check step): new `changelog` job generates this week's delta (since the last promoted prerelease), injects it into the pack's prerelease VSIX asset before publish, and commits it to `develop` (`packages/salesforcedx-vscode/CHANGELOG.md`), prepending the same delta into root `CHANGELOG.md` for full history
- `build-release.yml`: pulls that delta from `develop` and relabels its header from the prerelease version to the stable version before baking it into the stable VSIX
- `publishVSCode.yml`: relabels the same entry in `develop`'s history (root + package `CHANGELOG.md`) from prerelease → stable once the release actually ships
- New scripts: `scripts/generate-release-delta-changelog.ts` (ref/tag-scoped delta generator, reuses the existing commit-parsing/grouping logic) and `scripts/relabel-changelog-version.js` (idempotent header relabel)
- `scripts/change-log-generator-utils.ts`: adds `generateDeltaChangeLog`, makes PR-dedup optional (delta ranges are disjoint by construction, nothing to dedupe against)
- Updates the `/changelog` skill doc, which still described the old release-branch model — now documents the develop-based generate → prepend → polish → relabel lifecycle and the timing window for polishing before `build-release.yml`'s next run

**Fixes found from a `/code-review` pass and real `ci-testing` runs, folded into this PR:**
- `zip`'s default Unix UID/GID + timestamp extra fields on the re-zipped changelog entry made Open VSX reject the whole VSIX ("contains zip entries with potentially harmful extra fields"); `zip -X` omits them, matching vsce's own zip writer
- The `changelog` job's custom `if:` replaced (rather than augmented) the implicit needs-success gate, so it could run and push to `develop` even if `gate-check` failed — now checks `needs.gate-check.result` explicitly
- A week with zero qualifying commits silently left the changelog file stale but still exited 0, so the next VSIX would ship last week's entry mislabeled with this week's version — the generator now emits a `generated` output and downstream steps skip when nothing changed
- The bootstrap fallback (before any `marketplace-prerelease-*` tracking tag exists) picked the latest nightly tag, cut daily, yielding a ~1-day delta instead of covering everything since the last real release — now falls back to the last stable tag
- Both `develop`-push sequences (`changelog` job, `publishVSCode.yml`'s `relabel-changelog` job) had no retry after `git pull --rebase`, so a concurrent push failed the job outright; both now retry with backoff via a new shared `.github/actions/commitAndPushToDevelop` composite action
- Deduplicated `getRepoRoot()` (was copy-pasted into the new `relabel-changelog-version.js` from `prepend-release-changelog.js`) into `scripts/repo-root.js`
- The new `changelog:delta` npm script was added but bypassed (workflow called `ts-node` directly); now invoked via `npm run changelog:delta`

### What issues does this PR fix or reference?
@W-24144092@

### Functionality Before

### Functionality After
