### PR TITLE
chore: Remove unused deps (@salesforce/ts-types, glob, rxjs) from salesforcedx-vscode-core - W-23557324

### DIFF
--- a/.claude/plans/W-23557324.md
+++ b/.claude/plans/W-23557324.md
@@ -1,0 +1,34 @@
+# W-23557324
+
+## Context
+
+`salesforcedx-vscode-core` declares unused direct dependencies on `@salesforce/ts-types`, `glob`, and `rxjs`. Remove those declarations and update the root npm lockfile so installation metadata matches the package manifest.
+
+Files:
+
+- `packages/salesforcedx-vscode-core/package.json`
+- `package-lock.json`
+
+## Phases
+
+### 1. Remove unused core dependencies
+
+- Delete `@salesforce/ts-types`, `glob`, and `rxjs` from `salesforcedx-vscode-core` dependencies.
+- Run `npm install` from the repository root to update `package-lock.json`.
+- Commit message: `chore: remove unused core dependencies`
+
+## Skills to apply
+
+- `packageJson`: preserve repository dependency conventions.
+- `verification`: run repository checks appropriate to `salesforcedx-vscode-core`.
+
+## Verification
+
+- Confirm the 3 dependencies are absent from `packages/salesforcedx-vscode-core/package.json` and its workspace entry in `package-lock.json`.
+- `npm run compile -w salesforcedx-vscode-core`
+- `npm run lint -w salesforcedx-vscode-core`
+- `npm test -w salesforcedx-vscode-core`
+- `npm run vscode:bundle -w salesforcedx-vscode-core`
+- `npm run check:knip`
+- `npm run test:web -w salesforcedx-vscode-core -- --retries 0`
+- `npm run test:desktop -w salesforcedx-vscode-core -- --retries 0`

--- a/package-lock.json
+++ b/package-lock.json
@@ -4287,6 +4287,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
       "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -21863,6 +21864,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -22292,6 +22294,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
       "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "foreground-child": "^3.3.1",
@@ -24837,6 +24840,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
       "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^9.0.0"
@@ -34154,6 +34158,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/pako": {
@@ -34444,6 +34449,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
       "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -34460,6 +34466,7 @@
       "version": "11.2.6",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
       "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -46670,14 +46677,11 @@
         "@salesforce/o11y-reporter": "^1.8.5",
         "@salesforce/salesforcedx-utils-vscode": "*",
         "@salesforce/source-deploy-retrieve": "^13.2.0",
-        "@salesforce/ts-types": "^3.0.0",
         "@salesforce/vscode-i18n": "*",
         "@salesforce/vscode-service-provider": "^1.5.0",
         "applicationinsights": "1.8.10",
         "effect": "^3.21.2",
         "fast-xml-parser": "^5.7.1",
-        "glob": "^11.1.0",
-        "rxjs": "^7.8.2",
         "vscode-uri": "^3.1.0"
       },
       "devDependencies": {
@@ -46686,15 +46690,6 @@
       },
       "engines": {
         "vscode": "^1.90.0"
-      }
-    },
-    "packages/salesforcedx-vscode-core/node_modules/@salesforce/ts-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/ts-types/-/ts-types-3.0.1.tgz",
-      "integrity": "sha512-NWkveMYT2I3O7EAYwWHi6/ba2YUwp9MFi/zJzA+czK5MVqJfdD6FZbiQrTbALZNvFzgFSdq9BvHm6ygRmtROzw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=22.0.0"
       }
     },
     "packages/salesforcedx-vscode-expanded": {

--- a/packages/salesforcedx-vscode-core/package.json
+++ b/packages/salesforcedx-vscode-core/package.json
@@ -33,14 +33,11 @@
     "@salesforce/o11y-reporter": "^1.8.5",
     "@salesforce/salesforcedx-utils-vscode": "*",
     "@salesforce/source-deploy-retrieve": "^13.2.0",
-    "@salesforce/ts-types": "^3.0.0",
     "@salesforce/vscode-i18n": "*",
     "@salesforce/vscode-service-provider": "^1.5.0",
     "applicationinsights": "1.8.10",
     "effect": "^3.21.2",
     "fast-xml-parser": "^5.7.1",
-    "glob": "^11.1.0",
-    "rxjs": "^7.8.2",
     "vscode-uri": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### What issues does this PR fix or reference?

@W-23557324@

### What changed and why?

- Removed unused direct dependencies `@salesforce/ts-types`, `glob`, and `rxjs` from `salesforcedx-vscode-core`.
- Regenerated `package-lock.json` to match the updated package manifest.

This keeps the core package dependency declarations limited to packages it directly uses.
