### PR TITLE
chore: Add .cursor/worktrees.json npm ci - W-24101240

### DIFF
--- a/.claude/plans/W-24101240.md
+++ b/.claude/plans/W-24101240.md
@@ -1,0 +1,22 @@
+# W-24101240: Add Cursor worktree dependency installation
+
+## Context
+
+Cursor-created worktrees need their own dependencies. Add `.cursor/worktrees.json` so Cursor runs the repository's lockfile-based `npm ci` install after creating each worktree.
+
+## Phases
+
+### 1. Configure Cursor worktree setup
+
+- Add `.cursor/worktrees.json` with `setup-worktree` containing only `npm ci`.
+- Commit message: `chore: install dependencies in Cursor worktrees`
+
+## Skills to apply
+
+- `concise`: keep the configuration and change description minimal.
+- `verification`: validate the JSON and execute the configured command.
+
+## Verification
+
+- Parse `.cursor/worktrees.json` as JSON and assert `setup-worktree` equals `["npm ci"]`.
+- Run `npm ci` from the repository root; require a successful exit.

--- a/.cursor/worktrees.json
+++ b/.cursor/worktrees.json
@@ -1,0 +1,3 @@
+{
+  "setup-worktree": ["npm ci"]
+}


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-24101240@

### What changed and why?
Added `.cursor/worktrees.json` with `setup-worktree: ["npm ci"]` so Cursor-created worktrees install lockfile-pinned dependencies automatically.

### Verification
- JSON configuration validated.
- `npm ci` completed successfully.
