### PR TITLE
chore: Free Playwright web port 3001 after timed-out try-run so sequential retry can start - W-24142840

### DIFF
--- a/.claude/plans/W-24142840.md
+++ b/.claude/plans/W-24142840.md
@@ -1,0 +1,23 @@
+# W-24142840
+
+## Context
+
+`.github/workflows/playwrightVscodeExtE2E.yml` gives the web `try-run` 5 minutes. If GitHub Actions times it out, its VS Code Web server can keep port 3001 occupied. The later Playwright run then fails on the occupied port, preventing the sequential retry from running its tests. Explicitly terminate the port-3001 listener after a failed `try-run` before continuing.
+
+## Phases
+
+1. **Clean up the timed-out web server**
+   - Update `.github/workflows/playwrightVscodeExtE2E.yml`.
+   - After `try-run`, when its outcome is `failure`, terminate the process listening on TCP port 3001 before browser installation or another Playwright invocation.
+   - Keep the existing parallel run and sequential `--last-failed` retry unchanged.
+   - Commit: `fix(e2e): free web port after try-run timeout - W-24142840`
+
+## Skills to apply
+
+- `playwright-e2e`: follow the repository's documented port-3001 cleanup command and existing retry flow.
+- `verification`: validate the changed GitHub Actions workflow.
+
+## Verification
+
+- Run `npm run check:actions` from the repository root.
+- Confirm the cleanup step is failure-gated, precedes every later web-test invocation in the job, and leaves the sequential retry command unchanged.

--- a/.github/workflows/playwrightVscodeExtE2E.yml
+++ b/.github/workflows/playwrightVscodeExtE2E.yml
@@ -67,6 +67,10 @@ jobs:
         run: |
           npm run test:web -w @salesforce/playwright-vscode-ext
 
+      - name: Stop VS Code Web server after failed try-run
+        if: steps.try-run.outcome == 'failure'
+        run: lsof -ti :3001 | xargs --no-run-if-empty kill -9
+
       - uses: ./.github/actions/cache-vscode-web
         if: steps.try-run.outcome == 'failure'
         with:


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-24142840@

### What changed and why?
Added a failure-gated cleanup step to terminate any process listening on port 3001 after the web `try-run` fails. This prevents a timed-out VS Code Web server from blocking subsequent Playwright runs, while leaving the existing parallel run and sequential `--last-failed` retry unchanged.

`npm run check:actions` passes.
