### PR TITLE
chore: bump @salesforce/templates to v66.15.0 W-24054539

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8970,9 +8970,9 @@
       }
     },
     "node_modules/@salesforce/templates": {
-      "version": "66.14.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-66.14.0.tgz",
-      "integrity": "sha512-4tmVFM3/9GefMXmhAoVA43qC4Zq6ir3rWQ8fEJimGizCo6qjsNs9gn1e3nQKldXSgXlt1T6SB0tgnMgsZnp2og==",
+      "version": "66.15.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/templates/-/templates-66.15.0.tgz",
+      "integrity": "sha512-wOFos8lh/xsswuRs7z3o6D8pCtmScC0LJ0Jzbzz6SxZGxYKoI09NpgXwvCOzZkLRqyCYNUknQi0UplOP2PaIOw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/kit": "^4.0.0",
@@ -40987,7 +40987,7 @@
         "@salesforce/salesforcedx-utils": "*",
         "@salesforce/source-deploy-retrieve": "^13.2.0",
         "@salesforce/source-tracking": "^8.0.0",
-        "@salesforce/templates": "66.14.0",
+        "@salesforce/templates": "^66.15.0",
         "@salesforce/vscode-i18n": "*",
         "@vscode/extension-telemetry": "^1.0.0",
         "effect": "^3.21.2",

--- a/packages/salesforcedx-vscode-services-types/package.json
+++ b/packages/salesforcedx-vscode-services-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/vscode-services",
-  "version": "67.17.9",
+  "version": "67.17.10",
   "description": "TypeScript type definitions for Salesforce VS Code Services extension API",
   "author": "Salesforce",
   "license": "BSD-3-Clause",

--- a/packages/salesforcedx-vscode-services/package.json
+++ b/packages/salesforcedx-vscode-services/package.json
@@ -45,7 +45,7 @@
     "@salesforce/salesforcedx-utils": "*",
     "@salesforce/source-deploy-retrieve": "^13.2.0",
     "@salesforce/source-tracking": "^8.0.0",
-    "@salesforce/templates": "^66.14.0",
+    "@salesforce/templates": "^66.15.0",
     "@salesforce/vscode-i18n": "*",
     "@vscode/extension-telemetry": "^1.0.0",
     "effect": "^3.21.2",


### PR DESCRIPTION
<!--- PR title: <type>(optional scope): <description> - W-XXXXXXXX — append GUS work item at the end (space, hyphen, space, W-). Conventional commits: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
This PR bumps the @salesforce/template dependency version to 66.15.0

### What issues does this PR fix or reference?
@W-24054539@
