### PR TITLE
chore: Do not re-tag FsServiceError for display-only wrappers - W-24140996

### DIFF
--- a/.claude/plans/W-24140996.md
+++ b/.claude/plans/W-24140996.md
@@ -1,0 +1,36 @@
+# W-24140996: Do not re-tag FsServiceError for display-only wrappers
+
+## Context
+
+`generateEsrMD` catches `FsServiceError` from ESR file reads, YAML generation, writes, and editor opens, then converts it to `EsrWriteFailed` only to provide display text. This discards the original error tag before the command boundary handles it. Preserve `FsServiceError` through these display-only wrappers while retaining its existing operation, path, cause, and message details.
+
+Files:
+
+- `packages/salesforcedx-vscode-apex-oas/src/oas/externalServiceRegistrationManager.ts`
+- `packages/salesforcedx-vscode-apex-oas/test/jest/oas/externalServiceRegistrationManager.test.ts`
+
+## Phases
+
+### 1. Preserve FsServiceError from ESR file operations
+
+- Remove `EsrWriteFailed`, `toEsrWriteFailed`, and the `FsServiceError` catches that re-tag failures in `generateEsrMD`.
+- Let the original `FsServiceError` propagate from reads, decomposed YAML generation, writes, and editor opens.
+- Commit: `fix: preserve FsServiceError in ESR generation`
+
+### 2. Cover ESR FsServiceError propagation
+
+- Add focused tests proving `generateEsrMD` retains the original `FsServiceError` tag and details for failed file operations.
+- Commit: `test: cover ESR FsServiceError propagation`
+
+## Skills to apply
+
+- `effect-best-practices`: preserve typed Effect failures until the command/display boundary.
+- `typescript`: keep error types inferred and avoid casts or duplicate error shapes.
+- `unit-test-critic`: test observable error propagation, not Effect internals.
+- `verification`: run targeted and package-level checks after the change.
+
+## Verification
+
+- Run the focused `externalServiceRegistrationManager` Jest tests.
+- Run the `salesforcedx-vscode-apex-oas` package tests, typecheck, and lint.
+- Confirm the diff contains no remaining `EsrWriteFailed` conversion and no unrelated changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -41003,7 +41003,7 @@
     },
     "packages/salesforcedx-vscode-services-types": {
       "name": "@salesforce/vscode-services",
-      "version": "67.17.9",
+      "version": "67.17.10",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.43",

--- a/packages/salesforcedx-vscode-apex-oas/src/messages/i18n.ts
+++ b/packages/salesforcedx-vscode-apex-oas/src/messages/i18n.ts
@@ -23,7 +23,6 @@ export const messages = {
   apex_class_no_eligible_methods:
     'The Apex Class %s has no methods eligible for OpenAPI document generation. Ineligible methods: %s. Ensure the methods are public or global and carry the required annotations.',
   apex_lsp_not_ready: 'The Apex Language Server is still starting up. Wait for indexing to finish, then try again.',
-  artifact_failed: 'Failed to save the artifact: %s',
   cannot_gather_context: 'An error occurred while gathering context for the Apex class.',
   cannot_get_apexoaseligibility_response: 'Failed to get response through apexoas/isEligible from Apex Language Server',
   check_openapi_doc_succeeded: 'Validated OpenAPI Document %s successfully',

--- a/packages/salesforcedx-vscode-apex-oas/src/oas/externalServiceRegistrationManager.ts
+++ b/packages/salesforcedx-vscode-apex-oas/src/oas/externalServiceRegistrationManager.ts
@@ -27,11 +27,6 @@ import {
 } from '../oasUtils';
 
 /** @ExportTaggedError */
-export class EsrWriteFailed extends Data.TaggedError('EsrWriteFailed')<{
-  readonly message: string;
-}> {}
-
-/** @ExportTaggedError */
 export class EsrPathResolutionFailed extends Data.TaggedError('EsrPathResolutionFailed')<{
   readonly message: string;
 }> {}
@@ -46,11 +41,6 @@ export type EsrContext = {
   newPath: string;
   providerType: string | undefined;
 };
-
-const toEsrWriteFailed = (e: { function: string; filePath: string; cause: { message: string } }) =>
-  new EsrWriteFailed({
-    message: nls.localize('artifact_failed', `${e.function} failed for ${e.filePath}: ${e.cause.message}`)
-  });
 
 /** Type guard to check if an object is an OpenAPI OperationObject */
 const isOperationObject = (op: unknown): op is OpenAPIV3.OperationObject =>
@@ -354,15 +344,11 @@ export const generateEsrMD = Effect.fn('ApexOas.Esr.generateEsrMD')(function* (
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const fsService = api.services.FsService;
   const exists = yield* fsService.fileOrFolderExists(ctx.newPath);
-  const existingContent = exists
-    ? yield* fsService.readFile(ctx.newPath).pipe(Effect.catchTag('FsServiceError', toEsrWriteFailed))
-    : undefined;
+  const existingContent = exists ? yield* fsService.readFile(ctx.newPath) : undefined;
   //Step 1: Build the content of the ESR Xml file
-  const updatedContent = yield* buildESRXml(ctx, existingContent).pipe(
-    Effect.catchTag('FsServiceError', toEsrWriteFailed)
-  );
+  const updatedContent = yield* buildESRXml(ctx, existingContent);
   //Step 2: Write OpenAPI Document to File
-  yield* writeAndOpenEsrFile(ctx, updatedContent).pipe(Effect.catchTag('FsServiceError', toEsrWriteFailed));
+  yield* writeAndOpenEsrFile(ctx, updatedContent);
   // Step 3: If the user chose to merge, open a diff between the original and new ESR files
   yield* displayFileDifferences(ctx);
 

--- a/packages/salesforcedx-vscode-apex-oas/test/jest/oas/externalServiceRegistrationManager.test.ts
+++ b/packages/salesforcedx-vscode-apex-oas/test/jest/oas/externalServiceRegistrationManager.test.ts
@@ -11,9 +11,11 @@ import * as Layer from 'effect/Layer';
 import { XMLParser } from 'fast-xml-parser';
 import * as path from 'node:path';
 import type { OpenAPIV3 } from 'openapi-types';
+import { FsService, FsServiceError } from 'salesforcedx-vscode-services/src/vscode/fsService';
 import { UserCancellationError } from 'salesforcedx-vscode-services/src/vscode/prompts/promptService';
 import * as vscode from 'vscode';
 import { nls } from '../../../src/messages/nls';
+import type { ProcessorInputOutput } from '../../../src/oas/documentProcessorPipeline/processorStep';
 import {
   buildESRXml,
   buildESRYaml,
@@ -21,6 +23,7 @@ import {
   type EsrContext,
   extractInfoProperties,
   type FullPath,
+  generateEsrMD,
   getFolderForArtifact,
   getOperationsFromYaml,
   handleExistingESR,
@@ -71,6 +74,40 @@ const baseOasSpec: OpenAPIV3.Document = {
 } as OpenAPIV3.Document;
 
 const baseFullPath: FullPath = ['/path/to/original', '/path/to/new'];
+
+const processedOasResult: ProcessorInputOutput = {
+  openAPIDoc: baseOasSpec,
+  errors: []
+};
+
+const buildFsService = (
+  overrides: Partial<InstanceType<typeof FsService>>
+): Partial<InstanceType<typeof FsService>> => ({
+  fileOrFolderExists: () => Effect.succeed(false),
+  writeFile: () => Effect.void,
+  ...overrides
+});
+
+const runGenerateAndGetFailure = (isESRDecomposed: boolean, fsService: Partial<InstanceType<typeof FsService>>) => {
+  const layer = Layer.succeed(ExtensionProviderService, {
+    getServicesApi: Effect.succeed({ services: { FsService: fsService } })
+  } as unknown as ExtensionProviderService);
+  return Effect.runPromise(
+    generateEsrMD(isESRDecomposed, processedOasResult, [
+      '/path/to/Test.externalServiceRegistration-meta.xml',
+      '/path/to/Test.externalServiceRegistration-meta.xml'
+    ]).pipe(
+      Effect.provide(layer),
+      Effect.provideService(FsService, fsService as InstanceType<typeof FsService>),
+      Effect.flip
+    )
+  );
+};
+
+const buildFsServiceError = (operation: string, filePath: string) => {
+  const cause = new Error(`${operation} failed`);
+  return new FsServiceError({ cause, message: cause.message, function: operation, filePath });
+};
 
 const buildCtx = (overrides: Partial<EsrContext> = {}): EsrContext => ({
   isESRDecomposed: false,
@@ -265,6 +302,52 @@ describe('externalServiceRegistrationManager', () => {
         ) as Effect.Effect<void, never, never>
       );
       expect(writeFile).toHaveBeenCalledWith('/path/to/esr.yaml', 'safeSpec');
+    });
+  });
+
+  describe('generateEsrMD', () => {
+    const esrPath = '/path/to/Test.externalServiceRegistration-meta.xml';
+    const yamlPath = '/path/to/Test.yaml';
+
+    it('preserves FsServiceError from reading an existing ESR', async () => {
+      const error = buildFsServiceError('readFile', esrPath);
+
+      const failure = await runGenerateAndGetFailure(
+        false,
+        buildFsService({
+          fileOrFolderExists: () => Effect.succeed(true),
+          readFile: () => Effect.fail(error)
+        })
+      );
+
+      expect(failure).toStrictEqual(error);
+    });
+
+    it('preserves FsServiceError from writing decomposed YAML', async () => {
+      const error = buildFsServiceError('writeFile', yamlPath);
+
+      const failure = await runGenerateAndGetFailure(true, buildFsService({ writeFile: () => Effect.fail(error) }));
+
+      expect(failure).toStrictEqual(error);
+    });
+
+    it('preserves FsServiceError from writing ESR XML', async () => {
+      const error = buildFsServiceError('writeFile', esrPath);
+
+      const failure = await runGenerateAndGetFailure(false, buildFsService({ writeFile: () => Effect.fail(error) }));
+
+      expect(failure).toStrictEqual(error);
+    });
+
+    it('preserves FsServiceError from opening the generated ESR', async () => {
+      const error = buildFsServiceError('showTextDocument', esrPath);
+
+      const failure = await runGenerateAndGetFailure(
+        false,
+        buildFsService({ showTextDocument: () => Effect.fail(error) })
+      );
+
+      expect(failure).toStrictEqual(error);
     });
   });
 });

--- a/packages/salesforcedx-vscode-services-types/package.json
+++ b/packages/salesforcedx-vscode-services-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/vscode-services",
-  "version": "67.17.9",
+  "version": "67.17.10",
   "description": "TypeScript type definitions for Salesforce VS Code Services extension API",
   "author": "Salesforce",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
### What issues does this PR fix or reference?

@W-24140996@

### What changed and why?

- Removed `EsrWriteFailed` conversion from `generateEsrMD`.
- Preserved the original `FsServiceError` through ESR reads, YAML generation, file writes, and editor opens, including its operation, path, cause, and message.
- Added focused tests covering each failure path.
- Removed the unused `artifact_failed` localization message.
- Updated the services-types package patch version and lockfile.

This keeps typed filesystem failures intact until the command boundary handles display formatting.
