### PR TITLE
fix(services): watch global sf config and alias files for default org - W-24154071

### DIFF
--- a/.claude/skills/services-extension-consumption/SKILL.md
+++ b/.claude/skills/services-extension-consumption/SKILL.md
@@ -222,22 +222,23 @@ Accessor pattern: call methods directly, don't assign to variable first.
 
 ### File Watching
 
-FileWatcherService exposes a PubSub of all workspace file changes (`**/*`). Subscribe and filter:
+`FileChangePubSub` — workspace FS (`**/*`), including project `.sf/config.json`. Filter `event.uri` / `uri.path` / `Utils.*`, not `uri.fsPath`.
+
+Global `~/.sf/config.json` and `~/.sfdx/alias.json`: `HostFileWatcher` (internal, `@salesforce/core/fs`). Not on the public API; services already watch them. See [FileChangePubSub vs HostFileWatcher](../../../packages/salesforcedx-vscode-services/CONTEXT.md#filechangepubsub-vs-hostfilewatcher).
 
 ```typescript
-import * as PubSub from 'effect/PubSub';
 import * as Stream from 'effect/Stream';
 
-const fileWatcher = yield * api.services.FileWatcherService;
+const pubsub = yield* api.services.FileChangePubSub;
 
-yield* Stream.fromPubSub(fileWatcher.pubsub).pipe(
-    Stream.filter(event => /* match event.uri to your pattern */),
-    Stream.runForEach(event =>
-      Effect.sync(() => {
-        // Handle event: { type: 'create'|'change'|'delete', uri }
-      })
-    )
-  );
+yield* Stream.fromPubSub(pubsub).pipe(
+  Stream.filter(event => /* event.uri / uri.path / Utils.*; not uri.fsPath */),
+  Stream.runForEach(event =>
+    Effect.sync(() => {
+      // { type: 'create'|'change'|'delete', uri }
+    })
+  )
+);
 ```
 
 ### Config Watching

--- a/.claude/skills/services-extension-consumption/references/connection-service.md
+++ b/.claude/skills/services-extension-consumption/references/connection-service.md
@@ -60,7 +60,7 @@ const connection = yield* api.services.ConnectionService.getConnection();
 
 - Web: uses settings (instanceUrl, accessToken, apiVersion)
 - Desktop: resolves username/alias from config
-- Cached by username/instanceUrl; cache cleared when SF config files change (watcher) and after org extension refreshes config/state post-auth so `getConnection` reloads `AuthInfo` (avoids stale sessions after token refresh)
+- Cached by username/instanceUrl; cache cleared when global `~/.sf/config.json` (`HostFileWatcher`) or project `.sf/config.json` (`FileChangePubSub`) change, and after org extension refreshes config/state post-auth so `getConnection` reloads `AuthInfo` (avoids stale sessions after token refresh)
 - Auto-updates default org ref (`maybeUpdateDefaultOrgRef`) — skipped when a `username` is passed
 - Ref username: User SOQL when possible; empty → `conn.getUsername()` / AuthInfo `username`
 - Requires `ConfigService`, `SettingsService`

--- a/packages/salesforcedx-vscode-services/CONTEXT.md
+++ b/packages/salesforcedx-vscode-services/CONTEXT.md
@@ -52,3 +52,15 @@
 - The scheme is a document integration point, not a filesystem: there is no `FileSystemProvider`, public write API, or consumer registration.
 - Services owns cache invalidation on workspace/default-org changes and closes documents belonging to an inactive org.
 - Rationale and rejected alternatives: [ADR 0001](./docs/adr/0001-org-catalog-over-shared-vfs.md).
+
+### FileChangePubSub vs HostFileWatcher
+
+- **FileChangePubSub**: workspace FS events (`**/*`) from `FileWatcherLayer`. Project `.sf/config.json`, `sfdx-project.json`, test results, etc.
+- **HostFileWatcher**: host-FS files outside the workspace via `@salesforce/core/fs` (`fs.promises.watch`; node desktop, memfs web). `watchConfigFiles` → `~/.sf/config.json`; `watchAliasFile` → `~/.sfdx/alias.json`.
+- project `.sf/config.json`: `Utils.basename`/`dirname` on `event.uri` (not `fsPath`)
+- global config path: `join(Global.SF_DIR, configFileName)` (host-FS; `node:path` ok)
+- missing file/dir → ENOENT → `HostFileNotFoundError`, retried 250ms via `Schedule.whileInput(isTagged('HostFileNotFoundError'))`; other fs errors → `HostFileWatchError` (not retried)
+- Span `HostFileWatcher.watch` attributes include `path`
+- `watchConfigFiles` isolates `HostFileWatchError` on the global stream so project `.sf/config.json` watching continues
+- HostFileWatcher is internal (`globalLayers`); not on the public `services` API
+- _Avoid_: `FileChangePubSub` / `FileWatcherService` for global `~/.sf/config.json` or `~/.sfdx/alias.json`

--- a/packages/salesforcedx-vscode-services/src/core/aliasFileWatcher.ts
+++ b/packages/salesforcedx-vscode-services/src/core/aliasFileWatcher.ts
@@ -11,10 +11,10 @@ import * as Effect from 'effect/Effect';
 import { isString } from 'effect/Predicate';
 import * as Stream from 'effect/Stream';
 import * as SubscriptionRef from 'effect/SubscriptionRef';
-import { join, normalize } from 'node:path';
-import { FileChangePubSub } from '../vscode/fileChangePubSub';
+import { join } from 'node:path';
 import { AliasService } from './alias';
 import { getDefaultOrgRef } from './defaultOrgRef';
+import { HostFileWatcher } from './hostFileWatcher';
 
 /**
  * Merges a fresh alias list from disk with the current aliases, preserving the primary alias
@@ -29,17 +29,14 @@ const mergeAliases = (currentAliases: readonly string[] | undefined, freshAliase
   return freshAliases;
 };
 
-/** Subscribes to FileChangePubSub, filters to alias.json, debounces, and refreshes defaultOrgRef.aliases.
- * Preserves aliases[0] (the primary display alias) at position 0 for status bar stability. */
+/** Watches `~/.sfdx/alias.json` via HostFileWatcher. */
 export const watchAliasFile = Effect.fn('watchAliasFile')(function* () {
-  const aliasFilePath = normalize(join(Global.SFDX_DIR, 'alias.json'));
-  const [fileChangePubSub, aliasService, ref] = yield* Effect.all(
-    [FileChangePubSub, AliasService, getDefaultOrgRef()],
-    { concurrency: 'unbounded' }
-  );
+  const aliasFilePath = join(Global.SFDX_DIR, 'alias.json');
+  const [hostFileWatcher, aliasService, ref] = yield* Effect.all([HostFileWatcher, AliasService, getDefaultOrgRef()], {
+    concurrency: 'unbounded'
+  });
 
-  yield* Stream.fromPubSub(fileChangePubSub).pipe(
-    Stream.filter(event => normalize(event.uri.fsPath) === aliasFilePath),
+  yield* hostFileWatcher.watch(aliasFilePath).pipe(
     Stream.debounce(Duration.millis(50)),
     Stream.mapEffect(() => SubscriptionRef.get(ref)),
     Stream.map(r => r.username),

--- a/packages/salesforcedx-vscode-services/src/core/configFileWatcher.ts
+++ b/packages/salesforcedx-vscode-services/src/core/configFileWatcher.ts
@@ -8,55 +8,50 @@ import { Config } from '@salesforce/core/config';
 import { Global } from '@salesforce/core/global';
 import * as Duration from 'effect/Duration';
 import * as Effect from 'effect/Effect';
-import * as Option from 'effect/Option';
 import * as Stream from 'effect/Stream';
-import * as SubscriptionRef from 'effect/SubscriptionRef';
-import { join, normalize, sep } from 'node:path';
+import { join } from 'node:path';
+import { Utils, type URI } from 'vscode-uri';
 import { FileChangePubSub } from '../vscode/fileChangePubSub';
-import { AliasService } from './alias';
 import { ConfigService } from './configService';
 import { ConnectionService } from './connectionService';
-import { clearDefaultOrgRef, getDefaultOrgRef } from './defaultOrgRef';
+import { clearDefaultOrgRef } from './defaultOrgRef';
+import { HostFileWatcher } from './hostFileWatcher';
 
-/** Check if a file path is a config file (global or project-specific) */
-const isConfigFile = (path: string, globalConfigPath: string, projectConfigPattern: string): boolean => {
-  const normalizedPath = normalize(path);
-  return normalizedPath === globalConfigPath || normalizedPath.includes(projectConfigPattern);
-};
+const isProjectConfigFile = (uri: URI, configFileName: string): boolean =>
+  Utils.basename(uri) === configFileName && Utils.basename(Utils.dirname(uri)) === Global.SF_STATE_FOLDER;
 
 /**
- * watch the global and local sf/config.json files;
- * reload the connection when they change
- * if the connection fails, clear the defaultOrgRef
- * */
+ * Watch global `~/.sf/config.json` (HostFileWatcher) and project `.sf/config.json` (FileChangePubSub).
+ * Reload connection on change; clear defaultOrgRef if getConnection fails.
+ * Isolates `HostFileWatchError` on the global stream so project watching continues.
+ */
 export const watchConfigFiles = Effect.fn('watchConfigFiles')(function* () {
   const configFileName = Config.getFileName();
-  const globalConfigPath = normalize(join(Global.SF_DIR, configFileName));
-  const projectConfigPattern = `${Global.SF_STATE_FOLDER}${sep}${configFileName}`;
-  const aliasFilePath = normalize(join(Global.SFDX_DIR, 'alias.json'));
+  const globalConfigPath = join(Global.SF_DIR, configFileName);
 
-  const fileChangePubSub = yield* FileChangePubSub;
+  const [fileChangePubSub, hostFileWatcher] = yield* Effect.all([FileChangePubSub, HostFileWatcher], {
+    concurrency: 'unbounded'
+  });
 
-  yield* Stream.fromPubSub(fileChangePubSub).pipe(
-    Stream.filterEffect(event => {
-      if (isConfigFile(event.uri.fsPath, globalConfigPath, projectConfigPattern)) return Effect.succeed(true);
-      if (normalize(event.uri.fsPath) !== aliasFilePath) return Effect.succeed(false);
+  const projectConfigChanges = Stream.fromPubSub(fileChangePubSub).pipe(
+    Stream.filter(event => isProjectConfigFile(event.uri, configFileName))
+  );
+  const globalConfigChanges = hostFileWatcher.watch(globalConfigPath).pipe(
+    Stream.catchTag('HostFileWatchError', error =>
+      Stream.fromEffect(
+        Effect.logWarning('Global config file watch failed; continuing with project config watch', {
+          path: error.path,
+          reason: error.message
+        })
+      ).pipe(Stream.drain)
+    )
+  );
 
-      return Effect.gen(function* () {
-        const [targetOrg, currentOrg] = yield* Effect.all([
-          ConfigService.getTargetOrg(),
-          getDefaultOrgRef().pipe(Effect.flatMap(SubscriptionRef.get))
-        ]);
-        if (!targetOrg || targetOrg === currentOrg.username) return false;
-
-        const resolvedUsername = yield* AliasService.getUsernameFromAlias(targetOrg);
-        return Option.getOrUndefined(resolvedUsername) !== currentOrg.username;
-      });
-    }),
+  yield* Stream.merge(projectConfigChanges, globalConfigChanges).pipe(
     Stream.debounce(Duration.millis(5)),
     Stream.tap(() => ConfigService.invalidateConfigAggregator()),
     Stream.tap(() => ConnectionService.invalidateCachedConnections()),
-    // get connection will cause defaultOrgRef to update, clear the ref if there's any error where we won't have an org connection.
+    // getConnection updates defaultOrgRef; clear on failure.
     Stream.runForEach(() => ConnectionService.getConnection().pipe(Effect.catchAll(() => clearDefaultOrgRef())))
   );
 });

--- a/packages/salesforcedx-vscode-services/src/core/hostFileWatcher.ts
+++ b/packages/salesforcedx-vscode-services/src/core/hostFileWatcher.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import type { FileChangeEvent } from '../vscode/fileChangePubSub';
+import { fs } from '@salesforce/core/fs';
+import * as Duration from 'effect/Duration';
+import * as Effect from 'effect/Effect';
+import { isNotUndefined, isString, isTagged } from 'effect/Predicate';
+import * as Schedule from 'effect/Schedule';
+import * as Schema from 'effect/Schema';
+import * as Stream from 'effect/Stream';
+import { URI } from 'vscode-uri';
+import { unknownToErrorCause } from './shared';
+
+export class HostFileNotFoundError extends Schema.TaggedError<HostFileNotFoundError>()('HostFileNotFoundError', {
+  message: Schema.String,
+  path: Schema.String
+}) {}
+
+export class HostFileWatchError extends Schema.TaggedError<HostFileWatchError>()('HostFileWatchError', {
+  message: Schema.String,
+  path: Schema.String,
+  code: Schema.optional(Schema.String)
+}) {}
+
+type HostFileWatchFailure = HostFileNotFoundError | HostFileWatchError;
+
+const toWatchError = (error: unknown, path: string): HostFileWatchFailure => {
+  const { cause, message } = unknownToErrorCause(error);
+  const code = 'code' in cause && isString(cause.code) ? cause.code : undefined;
+  return code === 'ENOENT'
+    ? new HostFileNotFoundError({ message, path })
+    : new HostFileWatchError({ message, path, ...(isNotUndefined(code) ? { code } : {}) });
+};
+
+/** Watch a host-FS file (not a workspace path). Uses `@salesforce/core/fs` (node on desktop, memfs on web). */
+const watchHostFile = (filePath: string): Stream.Stream<FileChangeEvent, HostFileWatchFailure> =>
+  Stream.unwrap(
+    Effect.try({
+      try: () => fs.promises.watch(filePath),
+      catch: error => toWatchError(error, filePath)
+    }).pipe(
+      Effect.map(iterable =>
+        Stream.fromAsyncIterable(iterable, error => toWatchError(error, filePath)).pipe(
+          Stream.map(
+            (): FileChangeEvent => ({
+              type: 'change',
+              uri: URI.file(filePath)
+            })
+          )
+        )
+      )
+    )
+  ).pipe(
+    Stream.retry(Schedule.spaced(Duration.millis(250)).pipe(Schedule.whileInput(isTagged('HostFileNotFoundError')))),
+    Stream.withSpan('HostFileWatcher.watch', { attributes: { path: filePath } })
+  );
+
+export class HostFileWatcher extends Effect.Service<HostFileWatcher>()('HostFileWatcher', {
+  effect: Effect.succeed({
+    watch: watchHostFile
+  })
+}) {}

--- a/packages/salesforcedx-vscode-services/src/servicesLayers.ts
+++ b/packages/salesforcedx-vscode-services/src/servicesLayers.ts
@@ -12,6 +12,7 @@ import { ComponentSetService } from './core/componentSetService';
 import { ConfigService } from './core/configService';
 import { ConnectionService } from './core/connectionService';
 import { ExecuteAnonymousService } from './core/executeAnonymousService';
+import { HostFileWatcher } from './core/hostFileWatcher';
 import { LightningComponentService } from './core/lightningComponentService';
 import { MetadataChangeNotificationService } from './core/metadataChangeNotificationService';
 import { MetadataDeleteService } from './core/metadataDeleteService';
@@ -54,6 +55,7 @@ export const globalLayers = Layer.mergeAll(
   ExecuteAnonymousService.Default,
   ExtensionsService.Default,
   FileChangePubSub.Default,
+  HostFileWatcher.Default,
   ApexLogService.Default,
   ComponentSetService.Default,
   LightningComponentService.Default,

--- a/packages/salesforcedx-vscode-services/src/vscode/fileWatcherService.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/fileWatcherService.ts
@@ -5,13 +5,11 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Config, Global } from '@salesforce/core';
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
 import * as PubSub from 'effect/PubSub';
 import * as Stream from 'effect/Stream';
 import * as vscode from 'vscode';
-import { URI } from 'vscode-uri';
 import { ChannelService } from './channelService';
 import { FileChangePubSub, type FileChangeEvent } from './fileChangePubSub';
 
@@ -20,33 +18,18 @@ export const FileWatcherLayer = Layer.scopedDiscard(
     const pubsub = yield* FileChangePubSub;
     const channel = yield* ChannelService;
 
-    const patterns: vscode.GlobPattern[] = [
-      '**/*',
-      ...(process.env.ESBUILD_PLATFORM === 'web'
-        ? []
-        : [
-            new vscode.RelativePattern(URI.file(Global.SF_DIR), Config.getFileName()),
-            new vscode.RelativePattern(URI.file(Global.SFDX_DIR), 'alias.json')
-          ])
-    ];
-
-    yield* Effect.forEach(
-      patterns,
-      pattern =>
-        Effect.acquireUseRelease(
-          Effect.sync(() => vscode.workspace.createFileSystemWatcher(pattern)),
-          watcher =>
-            Stream.async<FileChangeEvent>(emit => {
-              watcher.onDidCreate(uri => emit.single({ type: 'create', uri }));
-              watcher.onDidChange(uri => emit.single({ type: 'change', uri }));
-              watcher.onDidDelete(uri => emit.single({ type: 'delete', uri }));
-            }).pipe(Stream.runForEach(event => PubSub.publish(pubsub, event))),
-          watcher =>
-            Effect.sync(() => {
-              watcher.dispose();
-            }).pipe(Effect.withSpan('disposing file watcher'))
-        ),
-      { concurrency: 'unbounded' }
+    yield* Effect.acquireUseRelease(
+      Effect.sync(() => vscode.workspace.createFileSystemWatcher('**/*')),
+      watcher =>
+        Stream.async<FileChangeEvent>(emit => {
+          watcher.onDidCreate(uri => emit.single({ type: 'create', uri }));
+          watcher.onDidChange(uri => emit.single({ type: 'change', uri }));
+          watcher.onDidDelete(uri => emit.single({ type: 'delete', uri }));
+        }).pipe(Stream.runForEach(event => PubSub.publish(pubsub, event))),
+      watcher =>
+        Effect.sync(() => {
+          watcher.dispose();
+        }).pipe(Effect.withSpan('disposing file watcher'))
     ).pipe(Effect.forkScoped);
 
     yield* channel.appendToChannel('FileWatcherService started successfully');

--- a/packages/salesforcedx-vscode-services/test/jest/core/aliasFileWatcher.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/aliasFileWatcher.test.ts
@@ -9,26 +9,23 @@ import * as Effect from 'effect/Effect';
 import * as Fiber from 'effect/Fiber';
 import * as Layer from 'effect/Layer';
 import * as PubSub from 'effect/PubSub';
+import * as Stream from 'effect/Stream';
 import * as SubscriptionRef from 'effect/SubscriptionRef';
 import { URI } from 'vscode-uri';
-import { watchAliasFile } from '../../../src/core/aliasFileWatcher';
 import { AliasService } from '../../../src/core/alias';
+import { watchAliasFile } from '../../../src/core/aliasFileWatcher';
 import { getDefaultOrgRef } from '../../../src/core/defaultOrgRef';
-import { FileChangePubSub, type FileChangeEvent } from '../../../src/vscode/fileChangePubSub';
+import { HostFileWatcher } from '../../../src/core/hostFileWatcher';
+import type { FileChangeEvent } from '../../../src/vscode/fileChangePubSub';
 
 jest.mock('@salesforce/core/global', () => ({
   Global: { SFDX_DIR: '/Users/testuser/.sfdx' }
 }));
 
 const ALIAS_FILE_PATH = '/Users/testuser/.sfdx/alias.json';
-const OTHER_FILE_PATH = '/Users/testuser/.sfdx/config.json';
 
-// ---------------------------------------------------------------------------
-// Layer factories
-// ---------------------------------------------------------------------------
-
-const makeFileChangePubSubLayer = (pubsub: PubSub.PubSub<FileChangeEvent>) =>
-  Layer.succeed(FileChangePubSub, pubsub as unknown as FileChangePubSub);
+const makeHostFileWatcherLayer = (pubsub: PubSub.PubSub<FileChangeEvent>) =>
+  Layer.succeed(HostFileWatcher, { watch: () => Stream.fromPubSub(pubsub) } as unknown as HostFileWatcher);
 
 const makeAliasServiceLayer = (getAliasesFromUsername: jest.Mock) =>
   Layer.succeed(
@@ -41,10 +38,6 @@ const makeAliasServiceLayer = (getAliasesFromUsername: jest.Mock) =>
     })
   );
 
-// ---------------------------------------------------------------------------
-// watchAliasFile – integration tests
-// ---------------------------------------------------------------------------
-
 describe('watchAliasFile', () => {
   beforeEach(async () => {
     await Effect.runPromise(getDefaultOrgRef().pipe(Effect.flatMap(ref => SubscriptionRef.set(ref, {}))));
@@ -52,12 +45,11 @@ describe('watchAliasFile', () => {
 
   const runWatcherTest = async (
     getAliasesFromUsernameMock: jest.Mock,
-    initialOrgInfo: { username?: string; aliases?: string[] },
-    publishUri: string
+    initialOrgInfo: { username?: string; aliases?: string[] }
   ) => {
-    const fileChangePubSub = await Effect.runPromise(PubSub.sliding<FileChangeEvent>(10));
+    const fileChanges = await Effect.runPromise(PubSub.sliding<FileChangeEvent>(10));
     const layer = Layer.mergeAll(
-      makeFileChangePubSubLayer(fileChangePubSub),
+      makeHostFileWatcherLayer(fileChanges),
       makeAliasServiceLayer(getAliasesFromUsernameMock)
     );
 
@@ -68,10 +60,9 @@ describe('watchAliasFile', () => {
 
         const fiber = yield* Effect.provide(Effect.scoped(watchAliasFile()), layer).pipe(Effect.fork);
 
-        // Yield to allow the forked fiber to subscribe before we publish
         yield* Effect.sleep(0);
 
-        yield* PubSub.publish(fileChangePubSub, { type: 'change' as const, uri: URI.file(publishUri) });
+        yield* PubSub.publish(fileChanges, { type: 'change' as const, uri: URI.file(ALIAS_FILE_PATH) });
         yield* Effect.sleep(200);
 
         const result = yield* SubscriptionRef.get(ref);
@@ -85,40 +76,25 @@ describe('watchAliasFile', () => {
 
   it('updates aliases when alias.json changes', async () => {
     const mock = jest.fn().mockReturnValue(Effect.succeed(['myAlias', 'otherAlias']));
-    const result = await runWatcherTest(mock, { username: 'user@example.com', aliases: ['myAlias'] }, ALIAS_FILE_PATH);
+    const result = await runWatcherTest(mock, { username: 'user@example.com', aliases: ['myAlias'] });
     expect(result.aliases).toEqual(['myAlias', 'otherAlias']);
   });
 
   it('preserves the primary alias at position 0 when disk order differs', async () => {
     const mock = jest.fn().mockReturnValue(Effect.succeed(['newAlias', 'originalAlias']));
-    const result = await runWatcherTest(
-      mock,
-      { username: 'user@example.com', aliases: ['originalAlias'] },
-      ALIAS_FILE_PATH
-    );
+    const result = await runWatcherTest(mock, { username: 'user@example.com', aliases: ['originalAlias'] });
     expect(result.aliases).toEqual(['originalAlias', 'newAlias']);
   });
 
   it('falls back to disk order when primary alias was deleted externally', async () => {
     const mock = jest.fn().mockReturnValue(Effect.succeed(['remainingAlias']));
-    const result = await runWatcherTest(
-      mock,
-      { username: 'user@example.com', aliases: ['deletedAlias'] },
-      ALIAS_FILE_PATH
-    );
+    const result = await runWatcherTest(mock, { username: 'user@example.com', aliases: ['deletedAlias'] });
     expect(result.aliases).toEqual(['remainingAlias']);
   });
 
   it('is a no-op when there is no active username in defaultOrgRef', async () => {
     const mock = jest.fn();
-    await runWatcherTest(mock, {}, ALIAS_FILE_PATH);
+    await runWatcherTest(mock, {});
     expect(mock).not.toHaveBeenCalled();
-  });
-
-  it('does not update aliases when a non-alias file changes', async () => {
-    const mock = jest.fn().mockReturnValue(Effect.succeed(['myAlias']));
-    const result = await runWatcherTest(mock, { username: 'user@example.com', aliases: ['myAlias'] }, OTHER_FILE_PATH);
-    expect(mock).not.toHaveBeenCalled();
-    expect(result.aliases).toEqual(['myAlias']);
   });
 });

--- a/packages/salesforcedx-vscode-services/test/jest/core/configFileWatcher.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/configFileWatcher.test.ts
@@ -8,15 +8,15 @@
 import * as Effect from 'effect/Effect';
 import * as Fiber from 'effect/Fiber';
 import * as Layer from 'effect/Layer';
-import * as Option from 'effect/Option';
 import * as PubSub from 'effect/PubSub';
+import * as Stream from 'effect/Stream';
 import * as SubscriptionRef from 'effect/SubscriptionRef';
 import { URI } from 'vscode-uri';
-import { AliasService } from '../../../src/core/alias';
 import { ConfigService } from '../../../src/core/configService';
 import { watchConfigFiles } from '../../../src/core/configFileWatcher';
 import { ConnectionService } from '../../../src/core/connectionService';
 import { getDefaultOrgRef } from '../../../src/core/defaultOrgRef';
+import { HostFileNotFoundError, HostFileWatchError, HostFileWatcher } from '../../../src/core/hostFileWatcher';
 import { FileChangePubSub, type FileChangeEvent } from '../../../src/vscode/fileChangePubSub';
 
 jest.mock('@salesforce/core/global', () => ({
@@ -28,22 +28,18 @@ jest.mock('@salesforce/core/global', () => ({
   }
 }));
 
+const PROJECT_CONFIG = '/Users/test/project/.sf/config.json';
+const GLOBAL_CONFIG = '/Users/test/.sf/config.json';
+const ALIAS_FILE = '/Users/test/.sfdx/alias.json';
+
 describe('watchConfigFiles', () => {
-  const makeLayer = (pubsub: PubSub.PubSub<FileChangeEvent>, resolvedUsername: string) => {
+  const makeLayer = (workspacePubsub: PubSub.PubSub<FileChangeEvent>, hostWatch: HostFileWatcher['watch']) => {
     const invalidateConfigAggregator = jest.fn(() => Effect.void);
     const invalidateCachedConnections = jest.fn(() => Effect.void);
     const getConnection = jest.fn(() => Effect.succeed({} as never));
     const layer = Layer.mergeAll(
-      Layer.succeed(FileChangePubSub, pubsub as unknown as FileChangePubSub),
-      Layer.succeed(
-        AliasService,
-        AliasService.make({
-          getAllAliases: () => Effect.succeed({}),
-          getAliasesFromUsername: () => Effect.succeed([]),
-          getUsernameFromAlias: () => Effect.succeed(Option.some(resolvedUsername)),
-          unsetAliases: () => Effect.void
-        })
-      ),
+      Layer.succeed(FileChangePubSub, workspacePubsub as unknown as FileChangePubSub),
+      Layer.succeed(HostFileWatcher, { watch: hostWatch } as unknown as HostFileWatcher),
       Layer.succeed(
         ConfigService,
         ConfigService.make({
@@ -56,6 +52,17 @@ describe('watchConfigFiles', () => {
     return { getConnection, invalidateCachedConnections, invalidateConfigAggregator, layer };
   };
 
+  const publishAndSettle = async (
+    fiber: Fiber.RuntimeFiber<void, unknown>,
+    pubsub: PubSub.PubSub<FileChangeEvent>,
+    uri: string
+  ) => {
+    await Effect.runPromise(Effect.sleep(10));
+    await Effect.runPromise(PubSub.publish(pubsub, { type: 'change' as const, uri: URI.file(uri) }));
+    await Effect.runPromise(Effect.sleep(100));
+    await fiber.pipe(Fiber.interrupt, Effect.runPromise);
+  };
+
   beforeEach(async () => {
     await Effect.runPromise(
       getDefaultOrgRef().pipe(
@@ -64,43 +71,71 @@ describe('watchConfigFiles', () => {
     );
   });
 
-  it('refreshes the effective target org when its alias resolves to another username', async () => {
-    const pubsub = await Effect.runPromise(PubSub.sliding<FileChangeEvent>(10));
+  it('refreshes when project .sf/config.json changes', async () => {
+    const workspacePubsub = await Effect.runPromise(PubSub.sliding<FileChangeEvent>(10));
+    const hostPubsub = await Effect.runPromise(PubSub.sliding<FileChangeEvent>(10));
     const { getConnection, invalidateCachedConnections, invalidateConfigAggregator, layer } = makeLayer(
-      pubsub,
-      'replacement@example.com'
+      workspacePubsub,
+      () => Stream.fromPubSub(hostPubsub)
     );
 
     const fiber = Effect.runFork(Effect.provide(watchConfigFiles(), layer));
-    await Effect.runPromise(Effect.sleep(10));
-    await Effect.runPromise(
-      PubSub.publish(pubsub, { type: 'change' as const, uri: URI.file('/Users/test/.sfdx/alias.json') })
-    );
-    await Effect.runPromise(Effect.sleep(100));
-    await Effect.runPromise(Fiber.interrupt(fiber));
+    await publishAndSettle(fiber, workspacePubsub, PROJECT_CONFIG);
 
     expect(invalidateConfigAggregator).toHaveBeenCalledTimes(1);
     expect(invalidateCachedConnections).toHaveBeenCalledTimes(1);
     expect(getConnection).toHaveBeenCalledTimes(1);
   });
 
-  it('ignores alias changes that retain the configured target-org resolution', async () => {
-    const pubsub = await Effect.runPromise(PubSub.sliding<FileChangeEvent>(10));
+  it('refreshes when global ~/.sf/config.json changes', async () => {
+    const workspacePubsub = await Effect.runPromise(PubSub.sliding<FileChangeEvent>(10));
+    const hostPubsub = await Effect.runPromise(PubSub.sliding<FileChangeEvent>(10));
     const { getConnection, invalidateCachedConnections, invalidateConfigAggregator, layer } = makeLayer(
-      pubsub,
-      'current@example.com'
+      workspacePubsub,
+      () => Stream.fromPubSub(hostPubsub)
     );
 
     const fiber = Effect.runFork(Effect.provide(watchConfigFiles(), layer));
-    await Effect.runPromise(Effect.sleep(10));
-    await Effect.runPromise(
-      PubSub.publish(pubsub, { type: 'change' as const, uri: URI.file('/Users/test/.sfdx/alias.json') })
+    await publishAndSettle(fiber, hostPubsub, GLOBAL_CONFIG);
+
+    expect(invalidateConfigAggregator).toHaveBeenCalledTimes(1);
+    expect(invalidateCachedConnections).toHaveBeenCalledTimes(1);
+    expect(getConnection).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores workspace alias.json on FileChangePubSub', async () => {
+    const workspacePubsub = await Effect.runPromise(PubSub.sliding<FileChangeEvent>(10));
+    const hostPubsub = await Effect.runPromise(PubSub.sliding<FileChangeEvent>(10));
+    const { getConnection, invalidateCachedConnections, invalidateConfigAggregator, layer } = makeLayer(
+      workspacePubsub,
+      () => Stream.fromPubSub(hostPubsub)
     );
-    await Effect.runPromise(Effect.sleep(100));
-    await Effect.runPromise(Fiber.interrupt(fiber));
+
+    const fiber = Effect.runFork(Effect.provide(watchConfigFiles(), layer));
+    await publishAndSettle(fiber, workspacePubsub, ALIAS_FILE);
 
     expect(invalidateConfigAggregator).not.toHaveBeenCalled();
     expect(invalidateCachedConnections).not.toHaveBeenCalled();
     expect(getConnection).not.toHaveBeenCalled();
+  });
+
+  it('keeps watching project config when global host watch fails', async () => {
+    const workspacePubsub = await Effect.runPromise(PubSub.sliding<FileChangeEvent>(10));
+    const { getConnection, invalidateCachedConnections, invalidateConfigAggregator, layer } = makeLayer(
+      workspacePubsub,
+      () => Stream.fail(new HostFileWatchError({ message: 'EACCES', path: GLOBAL_CONFIG }))
+    );
+
+    const fiber = Effect.runFork(Effect.provide(watchConfigFiles(), layer));
+    await publishAndSettle(fiber, workspacePubsub, PROJECT_CONFIG);
+
+    expect(invalidateConfigAggregator).toHaveBeenCalledTimes(1);
+    expect(invalidateCachedConnections).toHaveBeenCalledTimes(1);
+    expect(getConnection).toHaveBeenCalledTimes(1);
+  });
+
+  it('tags missing vs other host-watch failures separately', () => {
+    expect(new HostFileNotFoundError({ message: 'ENOENT', path: GLOBAL_CONFIG })._tag).toBe('HostFileNotFoundError');
+    expect(new HostFileWatchError({ message: 'EACCES', path: GLOBAL_CONFIG })._tag).toBe('HostFileWatchError');
   });
 });

--- a/packages/salesforcedx-vscode-services/test/jest/vscode/fileWatcherService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/vscode/fileWatcherService.test.ts
@@ -13,38 +13,27 @@ import { ChannelService } from '../../../src/vscode/channelService';
 import { FileChangePubSub } from '../../../src/vscode/fileChangePubSub';
 import { FileWatcherLayer } from '../../../src/vscode/fileWatcherService';
 
-jest.mock('@salesforce/core', () => ({
-  ...jest.requireActual('@salesforce/core'),
-  Config: { getFileName: () => 'config.json' },
-  Global: {
-    SF_DIR: '/Users/test/.sf',
-    SFDX_DIR: '/Users/test/.sfdx'
-  }
-}));
-
 describe('FileWatcherLayer', () => {
-  it('watches the workspace and external Salesforce config files', async () => {
-    const watchers = Array.from({ length: 3 }, () => ({
+  it('watches workspace files only', async () => {
+    const watcher = {
       onDidCreate: jest.fn(),
       onDidChange: jest.fn(),
       onDidDelete: jest.fn(),
       dispose: jest.fn()
-    }));
+    };
     jest
       .mocked(vscode.workspace.createFileSystemWatcher)
-      .mockImplementation(() => watchers.shift() as unknown as vscode.FileSystemWatcher);
+      .mockReturnValue(watcher as unknown as vscode.FileSystemWatcher);
 
     const layer = FileWatcherLayer.pipe(
       Layer.provide(Layer.mergeAll(FileChangePubSub.Default, ChannelService.Default))
     );
-    const fiber = Effect.runFork(Layer.launch(layer));
+    const fiber = layer.pipe(Layer.launch, Effect.runFork);
     await Effect.runPromise(Effect.sleep(10));
 
     const patterns = jest.mocked(vscode.workspace.createFileSystemWatcher).mock.calls.map(([pattern]) => pattern);
-    await Effect.runPromise(Fiber.interrupt(fiber));
+    await fiber.pipe(Fiber.interrupt, Effect.runPromise);
 
-    expect(patterns[0]).toBe('**/*');
-    expect(patterns[1]).toMatchObject({ base: { path: '/Users/test/.sf' }, pattern: 'config.json' });
-    expect(patterns[2]).toMatchObject({ base: { path: '/Users/test/.sfdx' }, pattern: 'alias.json' });
+    expect(patterns).toEqual(['**/*']);
   });
 });


### PR DESCRIPTION
### What does this PR do?

Watch `~/.sf/config.json` and `~/.sfdx/alias.json` via host FS (`HostFileWatcher` / `@salesforce/core/fs`). vscode `createFileSystemWatcher('**/*')` only covers workspace folders, so those homedir writes never refreshed `TargetOrgRef` (status bar / Open Default Org). Project `.sf/config.json` still uses `FileChangePubSub`. Workspace watcher no longer uses `RelativePattern` for those global files.

Related but not this bug: #8005 (CAS in `maybeUpdateDefaultOrgRef`). No shared files.

### What issues does this PR fix or reference?
#8117, @W-24154071@

### Functionality Before
Authorize a second org: picker / `sf org list` show the new default; status bar and Open Default Org stay on the previous org.

### Functionality After
Global config/alias writes on disk update `TargetOrgRef` so the status bar follows the new default.

### Test plan
- [x] Authorize org A, then org B as default (extension auth or CLI). Status bar and Open Default Org show B.
- [x] Change `target-org` in project `.sf/config.json`; connection refreshes.
- [ ] Unit: `configFileWatcher`, `aliasFileWatcher`, `fileWatcherService` tests.