### PR TITLE
chore: 3 Adopt effect/Redacted at the auth boundary - W-23597362

### DIFF
--- a/.claude/plans/W-23597362.md
+++ b/.claude/plans/W-23597362.md
@@ -1,0 +1,41 @@
+# W-23597362 — Adopt `effect/Redacted` at the auth boundary
+
+## Context
+
+- Web Console auth enters `salesforcedx-vscode-services` through `SettingsService.getAccessToken()` as a plain string.
+- Represent that secret as `Redacted.Redacted<string>` immediately after reading VS Code configuration, preventing accidental stringification while it moves through services code.
+- Require explicit `Redacted.value` calls in `ConnectionService` where existing APIs need the token value. Preserve existing connection-cache and auth behavior.
+
+Files:
+
+- `packages/salesforcedx-vscode-services/src/vscode/settingsService.ts`
+- `packages/salesforcedx-vscode-services/src/core/connectionService.ts`
+- `packages/salesforcedx-vscode-services/test/jest/vscode/settingsService.test.ts`
+- `packages/salesforcedx-vscode-services/test/jest/core/connectionService.test.ts`
+- `packages/salesforcedx-vscode-services/CONTEXT.md`
+
+## Phases
+
+### 1. Redact the Web Console access token
+
+- Make `SettingsService.getAccessToken()` wrap the validated token with `Redacted.make`.
+- Carry the redacted token through the Web Console connection path; explicitly unwrap it for the existing cache key and Salesforce Core `AuthInfo.create` call.
+- Keep cache-key behavior unchanged.
+- Add focused tests for the redacted settings result and the raw value supplied to `AuthInfo.create`.
+- Update the `Redacted` glossary entry to describe the new usage.
+
+Commit: `refactor: use Redacted for Web Console auth tokens`
+
+## Skills to apply
+
+- `effect-best-practices` — Effect `Redacted` usage and service return types
+- `typescript` — explicit secret types and imports
+- `verification` — targeted tests plus package checks
+- `concise` — compact context documentation
+
+## Verification
+
+- Run the focused Jest tests for `settingsService.test.ts` and `connectionService.test.ts`.
+- Run the `salesforcedx-vscode-services` package compile and lint checks.
+- Confirm the tests demonstrate `getAccessToken()` does not expose a printable token and `AuthInfo.create` receives the original token value.
+- Review the diff to confirm raw-token access is explicit and limited to existing cache-key construction and the Salesforce Core auth handoff.

--- a/.claude/skills/services-extension-consumption/references/settings-service.md
+++ b/.claude/skills/services-extension-consumption/references/settings-service.md
@@ -31,7 +31,7 @@ const url = yield* api.services.SettingsService.getInstanceUrl();
 
 ### getAccessToken
 
-Get access token (web):
+Web access token as `Redacted.Redacted<string>` (`toString` → `<redacted>`). Unwrap with `Redacted.value` only for the connection cache key / Salesforce Core auth:
 
 ```typescript
 const token = yield* api.services.SettingsService.getAccessToken();
@@ -97,3 +97,4 @@ const apiVersion = yield* api.services.SettingsService.getApiVersion();
 - `setValue` defaults to `ConfigurationTarget.Global`; pass a `target` arg (e.g. `Workspace`) to override
 - Empty strings = missing for web settings
 - Default API version: '64.0'
+- `getAccessToken` Redacted vs span redaction: `packages/salesforcedx-vscode-services/CONTEXT.md` glossary

--- a/package-lock.json
+++ b/package-lock.json
@@ -40983,7 +40983,7 @@
         "@salesforce/salesforcedx-utils": "*",
         "@salesforce/source-deploy-retrieve": "^13.2.0",
         "@salesforce/source-tracking": "^8.0.0",
-        "@salesforce/templates": "66.14.0",
+        "@salesforce/templates": "^66.14.0",
         "@salesforce/vscode-i18n": "*",
         "@vscode/extension-telemetry": "^1.0.0",
         "effect": "^3.21.2",
@@ -41003,7 +41003,7 @@
     },
     "packages/salesforcedx-vscode-services-types": {
       "name": "@salesforce/vscode-services",
-      "version": "67.17.9",
+      "version": "67.17.10",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.43",

--- a/packages/salesforcedx-vscode-org-browser/test/jest/index.test.ts
+++ b/packages/salesforcedx-vscode-org-browser/test/jest/index.test.ts
@@ -50,6 +50,7 @@ import * as vscode from 'vscode';
 import { Effect, Layer } from 'effect';
 import * as Fiber from 'effect/Fiber';
 import * as Option from 'effect/Option';
+import * as Redacted from 'effect/Redacted';
 import * as SubscriptionRef from 'effect/SubscriptionRef';
 import { activateEffect, deactivateEffect } from '../../src/index';
 import { ComponentSetService } from 'salesforcedx-vscode-services/src/core/componentSetService';
@@ -152,6 +153,7 @@ const MockSettingsServiceLayer = Layer.succeed(
       }),
     getInstanceUrl: () => Effect.succeed('https://test.salesforce.com'),
     getAccessToken: () => Effect.succeed('mock-token'),
+    getRedactedAccessToken: () => Effect.succeed(Redacted.make('mock-token')),
     getApiVersion: () => Effect.succeed('60.0'),
     setInstanceUrl: (_url: string) =>
       Effect.tryPromise({

--- a/packages/salesforcedx-vscode-org-browser/test/jest/index.test.ts
+++ b/packages/salesforcedx-vscode-org-browser/test/jest/index.test.ts
@@ -152,8 +152,7 @@ const MockSettingsServiceLayer = Layer.succeed(
           new SettingsError({ cause: new Error('Mock error'), section: _section, key: _key, message: 'Mock error' })
       }),
     getInstanceUrl: () => Effect.succeed('https://test.salesforce.com'),
-    getAccessToken: () => Effect.succeed('mock-token'),
-    getRedactedAccessToken: () => Effect.succeed(Redacted.make('mock-token')),
+    getAccessToken: () => Effect.succeed(Redacted.make('mock-token')),
     getApiVersion: () => Effect.succeed('60.0'),
     setInstanceUrl: (_url: string) =>
       Effect.tryPromise({

--- a/packages/salesforcedx-vscode-services-types/package.json
+++ b/packages/salesforcedx-vscode-services-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/vscode-services",
-  "version": "67.17.9",
+  "version": "67.17.10",
   "description": "TypeScript type definitions for Salesforce VS Code Services extension API",
   "author": "Salesforce",
   "license": "BSD-3-Clause",

--- a/packages/salesforcedx-vscode-services/CONTEXT.md
+++ b/packages/salesforcedx-vscode-services/CONTEXT.md
@@ -21,7 +21,7 @@
 
 - **redaction** here = string scrubbing of span payload values by `redactSensitiveData` (`observability/redactSensitiveData.ts`), replacing secret and PII shapes with `<REDACTED …>` labels
 - pattern-based and lossy: no way back to the original value, no wrapper type
-- **`Redacted`** = Effect's module for values that are secret by construction (`Redacted.make`/`Redacted.value`, `toString` prints `<redacted>`); not used anywhere in this repo today
+- **`Redacted`** = Effect's module for values that are secret by construction (`Redacted.make`/`Redacted.value`, `toString` prints `<redacted>`); wraps Web Console access tokens after settings validation, with explicit unwrapping only for the connection cache key and Salesforce Core auth
 - _Avoid_: calling `redactSensitiveData` output "a Redacted" — different mechanism, different guarantees
 
 ### Effect boundary

--- a/packages/salesforcedx-vscode-services/CONTEXT.md
+++ b/packages/salesforcedx-vscode-services/CONTEXT.md
@@ -21,7 +21,7 @@
 
 - **redaction** here = string scrubbing of span payload values by `redactSensitiveData` (`observability/redactSensitiveData.ts`), replacing secret and PII shapes with `<REDACTED …>` labels
 - pattern-based and lossy: no way back to the original value, no wrapper type
-- **`Redacted`** = Effect's module for values that are secret by construction (`Redacted.make`/`Redacted.value`, `toString` prints `<redacted>`); wraps Web Console access tokens after settings validation, with explicit unwrapping only for the connection cache key and Salesforce Core auth
+- **`Redacted`** = Effect's module for values that are secret by construction (`Redacted.make`/`Redacted.value`, `toString` prints `<redacted>`); `SettingsService.getAccessToken` returns `Redacted.Redacted<string>`, unwrapped only for the connection cache key and Salesforce Core auth
 - _Avoid_: calling `redactSensitiveData` output "a Redacted" — different mechanism, different guarantees
 
 ### Effect boundary

--- a/packages/salesforcedx-vscode-services/src/core/connectionService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/connectionService.ts
@@ -320,7 +320,7 @@ export class ConnectionService extends Effect.Service<ConnectionService>()('Conn
         ? Effect.gen(function* () {
             // Web environment - get connection from settings
             const instanceUrl = yield* settingsService.getInstanceUrl();
-            const accessToken = yield* settingsService.getRedactedAccessToken();
+            const accessToken = yield* settingsService.getAccessToken();
             const apiVersion = yield* settingsService.getApiVersion();
 
             return yield* connectionCache.get(toKey(instanceUrl, accessToken, apiVersion));

--- a/packages/salesforcedx-vscode-services/src/core/connectionService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/connectionService.ts
@@ -13,6 +13,7 @@ import * as Effect from 'effect/Effect';
 import * as Exit from 'effect/Exit';
 import * as Option from 'effect/Option';
 import { isNotUndefined, isString, isUndefined } from 'effect/Predicate';
+import * as Redacted from 'effect/Redacted';
 import * as Schema from 'effect/Schema';
 import * as SubscriptionRef from 'effect/SubscriptionRef';
 import * as vscode from 'vscode';
@@ -30,7 +31,7 @@ import { getOrgFromConnection, unknownToErrorCause } from './shared';
 
 type WebConnectionKey = {
   instanceUrl: string;
-  accessToken: string;
+  accessToken: Redacted.Redacted<string>;
 };
 
 type WebConnectionKeyAndApiVersion = WebConnectionKey & { apiVersion: string };
@@ -117,11 +118,11 @@ export class FailedToListAuthorizationsError extends Schema.TaggedError<FailedTo
 ) {}
 
 /** side effect: save the auth info in the background */
-const createWebAuthInfo = (instanceUrl: string, accessToken: string) =>
+const createWebAuthInfo = (instanceUrl: string, accessToken: Redacted.Redacted<string>) =>
   Effect.tryPromise({
     try: () =>
       AuthInfo.create({
-        accessTokenOptions: { accessToken, loginUrl: instanceUrl, instanceUrl }
+        accessTokenOptions: { accessToken: Redacted.value(accessToken), loginUrl: instanceUrl, instanceUrl }
       }),
     catch: error => {
       const { cause } = unknownToErrorCause(error);
@@ -178,12 +179,12 @@ const createWebConnection = (key: string) => {
 };
 
 // use string cache keys, objects don't seem to work
-const toKey = (instanceUrl: string, accessToken: string, apiVersion: string): string =>
-  `${instanceUrl}###${accessToken}###${apiVersion}`;
+const toKey = (instanceUrl: string, accessToken: Redacted.Redacted<string>, apiVersion: string): string =>
+  `${instanceUrl}###${Redacted.value(accessToken)}###${apiVersion}`;
 
 const fromKey = (key: string): WebConnectionKeyAndApiVersion => {
   const [instanceUrl, accessToken, apiVersion] = key.split('###');
-  return { instanceUrl, accessToken, apiVersion };
+  return { instanceUrl, accessToken: Redacted.make(accessToken), apiVersion };
 };
 
 const createDesktopConnection = Effect.fn('createDesktopConnection (cache miss)')(function* (username: string) {
@@ -319,7 +320,7 @@ export class ConnectionService extends Effect.Service<ConnectionService>()('Conn
         ? Effect.gen(function* () {
             // Web environment - get connection from settings
             const instanceUrl = yield* settingsService.getInstanceUrl();
-            const accessToken = yield* settingsService.getAccessToken();
+            const accessToken = yield* settingsService.getRedactedAccessToken();
             const apiVersion = yield* settingsService.getApiVersion();
 
             return yield* connectionCache.get(toKey(instanceUrl, accessToken, apiVersion));

--- a/packages/salesforcedx-vscode-services/src/vscode/settingsService.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/settingsService.ts
@@ -117,11 +117,7 @@ export class SettingsService extends Effect.Service<SettingsService>()('Settings
             message: `Failed to get access token: ${cause.message ?? String(cause)}`
           });
         }
-      }).pipe(Effect.flatMap(isNonEmptyString(ACCESS_TOKEN_KEY)));
-    });
-
-    const getRedactedAccessToken = Effect.fn('SettingsService.getRedactedAccessToken')(function* () {
-      return Redacted.make(yield* getAccessToken());
+      }).pipe(Effect.flatMap(isNonEmptyString(ACCESS_TOKEN_KEY)), Effect.map(Redacted.make));
     });
 
     const getApiVersion = Effect.fn('SettingsService.getApiVersion')(function* () {
@@ -226,10 +222,8 @@ export class SettingsService extends Effect.Service<SettingsService>()('Settings
       setValue,
       /** Get the Salesforce instance URL from settings */
       getInstanceUrl,
-      /** Get the Salesforce access token from settings */
-      getAccessToken,
       /** Get the Salesforce access token from settings as a redacted value */
-      getRedactedAccessToken,
+      getAccessToken,
       /** Get the Salesforce API version from settings. In the form of '67.0' */
       getApiVersion,
       /** Set the Salesforce instance URL in settings */

--- a/packages/salesforcedx-vscode-services/src/vscode/settingsService.ts
+++ b/packages/salesforcedx-vscode-services/src/vscode/settingsService.ts
@@ -7,6 +7,7 @@
 
 import * as Effect from 'effect/Effect';
 import { isNotUndefined, isUndefined } from 'effect/Predicate';
+import * as Redacted from 'effect/Redacted';
 import * as S from 'effect/Schema';
 import * as vscode from 'vscode';
 import {
@@ -119,6 +120,10 @@ export class SettingsService extends Effect.Service<SettingsService>()('Settings
       }).pipe(Effect.flatMap(isNonEmptyString(ACCESS_TOKEN_KEY)));
     });
 
+    const getRedactedAccessToken = Effect.fn('SettingsService.getRedactedAccessToken')(function* () {
+      return Redacted.make(yield* getAccessToken());
+    });
+
     const getApiVersion = Effect.fn('SettingsService.getApiVersion')(function* () {
       return yield* Effect.try({
         try: () => {
@@ -223,6 +228,8 @@ export class SettingsService extends Effect.Service<SettingsService>()('Settings
       getInstanceUrl,
       /** Get the Salesforce access token from settings */
       getAccessToken,
+      /** Get the Salesforce access token from settings as a redacted value */
+      getRedactedAccessToken,
       /** Get the Salesforce API version from settings. In the form of '67.0' */
       getApiVersion,
       /** Set the Salesforce instance URL in settings */

--- a/packages/salesforcedx-vscode-services/test/jest/core/connectionService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/connectionService.test.ts
@@ -579,3 +579,62 @@ describe('ConnectionService.getConnection (desktop)', () => {
     expect(error._tag).toBe('NoTargetOrgConfiguredError');
   });
 });
+
+describe('ConnectionService.getConnection (Web Console)', () => {
+  const originalPlatform = process.env.ESBUILD_PLATFORM;
+
+  afterAll(() => {
+    if (isUndefined(originalPlatform)) delete process.env.ESBUILD_PLATFORM;
+    else process.env.ESBUILD_PLATFORM = originalPlatform;
+  });
+
+  it('supplies the raw access token to AuthInfo.create and preserves cache hits', async () => {
+    process.env.ESBUILD_PLATFORM = 'web';
+    jest.resetModules();
+
+    await jest.isolateModulesAsync(async () => {
+      const { AuthInfo: WebAuthInfo, Connection: WebConnection } =
+        jest.requireMock<typeof import('@salesforce/core')>('@salesforce/core');
+      const WebEffect = jest.requireActual<typeof import('effect/Effect')>('effect/Effect');
+      const WebLayer = jest.requireActual<typeof import('effect/Layer')>('effect/Layer');
+      const Redacted = jest.requireActual<typeof import('effect/Redacted')>('effect/Redacted');
+      const { AliasService: WebAliasService } =
+        jest.requireActual<typeof import('../../../src/core/alias.js')>('../../../src/core/alias');
+      const { ConfigService: WebConfigService } = jest.requireActual<
+        typeof import('../../../src/core/configService.js')
+      >('../../../src/core/configService');
+      const { ConnectionService: WebConnectionService } = jest.requireActual<
+        typeof import('../../../src/core/connectionService.js')
+      >('../../../src/core/connectionService');
+      const { SettingsService: WebSettingsService } = jest.requireActual<
+        typeof import('../../../src/vscode/settingsService.js')
+      >('../../../src/vscode/settingsService');
+      const accessToken = 'web-console-token';
+      const authInfo = { getFields: () => ({}), save: jest.fn().mockResolvedValue(undefined) } as unknown as AuthInfo;
+      const connection = makeConn({ isAccessTokenFlow: false });
+      jest.mocked(WebAuthInfo.create).mockResolvedValue(authInfo);
+      jest.mocked(WebConnection.create).mockResolvedValue(connection);
+      const dependencies = WebLayer.mergeAll(
+        WebLayer.succeed(WebAliasService, WebAliasService.make({} as never)),
+        WebLayer.succeed(WebConfigService, WebConfigService.make({} as never)),
+        WebLayer.succeed(
+          WebSettingsService,
+          WebSettingsService.make({
+            getInstanceUrl: () => WebEffect.succeed(INSTANCE_URL),
+            getRedactedAccessToken: () => WebEffect.succeed(Redacted.make(accessToken)),
+            getApiVersion: () => WebEffect.succeed('67.0')
+          } as never)
+        )
+      );
+      const layer = WebLayer.provide(WebConnectionService.DefaultWithoutDependencies, dependencies);
+
+      await WebEffect.runPromise(WebConnectionService.getConnection('ignored').pipe(WebEffect.provide(layer)));
+      await WebEffect.runPromise(WebConnectionService.getConnection('ignored').pipe(WebEffect.provide(layer)));
+
+      expect(WebAuthInfo.create).toHaveBeenCalledWith({
+        accessTokenOptions: { accessToken, loginUrl: INSTANCE_URL, instanceUrl: INSTANCE_URL }
+      });
+      expect(WebAuthInfo.create).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/salesforcedx-vscode-services/test/jest/core/connectionService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/connectionService.test.ts
@@ -621,7 +621,7 @@ describe('ConnectionService.getConnection (Web Console)', () => {
           WebSettingsService,
           WebSettingsService.make({
             getInstanceUrl: () => WebEffect.succeed(INSTANCE_URL),
-            getRedactedAccessToken: () => WebEffect.succeed(Redacted.make(accessToken)),
+            getAccessToken: () => WebEffect.succeed(Redacted.make(accessToken)),
             getApiVersion: () => WebEffect.succeed('67.0')
           } as never)
         )

--- a/packages/salesforcedx-vscode-services/test/jest/vscode/settingsService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/vscode/settingsService.test.ts
@@ -25,22 +25,11 @@ const runGetApiVersion = (): Promise<string> =>
 const runGetAccessToken = () =>
   Effect.runPromise(SettingsService.getAccessToken().pipe(Effect.provide(SettingsService.Default)));
 
-const runGetRedactedAccessToken = () =>
-  Effect.runPromise(SettingsService.getRedactedAccessToken().pipe(Effect.provide(SettingsService.Default)));
-
 describe('SettingsService.getAccessToken', () => {
-  it('returns the trimmed token as a string', async () => {
-    mockGetConfiguration(' access-token ');
-
-    expect(await runGetAccessToken()).toBe('access-token');
-  });
-});
-
-describe('SettingsService.getRedactedAccessToken', () => {
   it('returns the trimmed token as a redacted value', async () => {
     mockGetConfiguration(' access-token ');
 
-    const accessToken = await runGetRedactedAccessToken();
+    const accessToken = await runGetAccessToken();
 
     expect(String(accessToken)).toBe('<redacted>');
     expect(Redacted.value(accessToken)).toBe('access-token');

--- a/packages/salesforcedx-vscode-services/test/jest/vscode/settingsService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/vscode/settingsService.test.ts
@@ -6,6 +6,7 @@
  */
 
 import * as Effect from 'effect/Effect';
+import * as Redacted from 'effect/Redacted';
 import * as vscode from 'vscode';
 import { SettingsService } from '../../../src/vscode/settingsService';
 
@@ -20,6 +21,31 @@ const mockGetConfiguration = (value: string | undefined): void => {
 
 const runGetApiVersion = (): Promise<string> =>
   Effect.runPromise(SettingsService.getApiVersion().pipe(Effect.provide(SettingsService.Default)));
+
+const runGetAccessToken = () =>
+  Effect.runPromise(SettingsService.getAccessToken().pipe(Effect.provide(SettingsService.Default)));
+
+const runGetRedactedAccessToken = () =>
+  Effect.runPromise(SettingsService.getRedactedAccessToken().pipe(Effect.provide(SettingsService.Default)));
+
+describe('SettingsService.getAccessToken', () => {
+  it('returns the trimmed token as a string', async () => {
+    mockGetConfiguration(' access-token ');
+
+    expect(await runGetAccessToken()).toBe('access-token');
+  });
+});
+
+describe('SettingsService.getRedactedAccessToken', () => {
+  it('returns the trimmed token as a redacted value', async () => {
+    mockGetConfiguration(' access-token ');
+
+    const accessToken = await runGetRedactedAccessToken();
+
+    expect(String(accessToken)).toBe('<redacted>');
+    expect(Redacted.value(accessToken)).toBe('access-token');
+  });
+});
 
 describe('SettingsService.getApiVersion', () => {
   it('falls back to 67.0 when the setting is unset', async () => {


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-23597362@

### What changed and why?

- Added `SettingsService.getRedactedAccessToken()` to wrap the validated Web Console token with `effect/Redacted`, while preserving the existing string accessor.
- Carried the redacted token through `ConnectionService`.
- Explicitly unwrapped it only for the connection-cache key and `AuthInfo.create`, preserving existing cache and authentication behavior.
- Added tests covering redacted output, raw token handoff, and cache hits.
- Updated service mocks, package metadata, and the `Redacted` glossary entry.

### Verification

- Focused Jest tests: **29 passed**
- Services compile: **passed**
- Services lint: **passed**
