### PR TITLE
chore(skills): exclude drivable-vscode from plan/diff review - W-24156067

### DIFF
--- a/.claude/skills/drivable-vscode/SKILL.md
+++ b/.claude/skills/drivable-vscode/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: drivable-vscode
 description: Operate a real VS Code instance through drivable-vscode. Use for drivable VS Code, exploratory testing, customer bug reproduction, feature verification, screenshots, videos, or other evidence from VS Code.
-review: always
+review: never
 ---
 
 # drivable-vscode


### PR DESCRIPTION
### What does this PR do?

Set `review: never` on the drivable-vscode skill so plan/diff review (reviewDiff) skips it. Operating a VS Code instance is not a review standard.

### What issues does this PR fix or reference?
@W-24156067@