### PR TITLE
chore: Adopt Effect String point-free trim in three Effect pipelines - W-23573551

### DIFF
--- a/.claude/plans/W-23573551.md
+++ b/.claude/plans/W-23573551.md
@@ -1,0 +1,42 @@
+# W-23573551
+
+## Context
+
+Adopt Effect's `String.trim` as a point-free pipeline function in the 3 scoped Apex Log prompt flows. Move cancellation handling before trimming so each trim receives a `string`; preserve prompt cancellation and returned trimmed names.
+
+Files:
+
+- `packages/salesforcedx-vscode-apex-log/src/commands/createAnonymousApexScript.ts`
+- `packages/salesforcedx-vscode-apex-log/src/commands/createApexTrigger.ts`
+- `packages/salesforcedx-vscode-apex-log/src/commands/sfTemplateProjectHelpers.ts`
+- `packages/salesforcedx-vscode-apex-log/test/playwright/specs/executeAnonymous.headless.spec.ts`
+- `packages/salesforcedx-vscode-apex-log/test/playwright/specs/createApexTrigger.headless.spec.ts`
+
+## Phases
+
+1. **Use point-free trim in all 3 pipelines**
+   - Import Effect's `String` module in each file.
+   - Apply `promptService.considerUndefinedAsCancellation` before trimming.
+   - Replace optional-chaining trim callbacks with `Effect.map(String.trim)`.
+2. **Cover cancellation and trimmed results**
+   - Normalize Apex type names before validation so padded valid names reach the trim pipeline.
+   - Assert Escape cancels each of the 3 input-box pipelines without creating a file.
+   - Assert padded values produce trimmed anonymous-script and trigger files and trimmed trigger content.
+
+## Skills to apply
+
+- `typescript`: preserve repository TypeScript import, naming, and functional-style conventions.
+- `verification`: verify the changed package with repository checks; rely on the stop hook for compile, lint, Effect LS, tests, bundle, and knip.
+
+## Verification
+
+1. Run `npm install` from the repository root if dependencies are not installed in this worktree.
+2. Run the Apex Log Playwright suites from the repository root:
+   - `WIREIT_CACHE=none npm run test:web -w salesforcedx-vscode-apex-log -- --retries 0 test/playwright/specs/executeAnonymous.headless.spec.ts`
+   - `WIREIT_CACHE=none npm run test:web -w salesforcedx-vscode-apex-log -- --retries 0 test/playwright/specs/createApexTrigger.headless.spec.ts`
+   - `WIREIT_CACHE=none npm run test:desktop -w salesforcedx-vscode-apex-log -- --retries 0 test/playwright/specs/executeAnonymous.headless.spec.ts`
+   - `WIREIT_CACHE=none npm run test:desktop -w salesforcedx-vscode-apex-log -- --retries 0 test/playwright/specs/createApexTrigger.headless.spec.ts`
+   - Assert Escape cancels anonymous-script name, trigger name, and trigger sObject prompts without creating a file.
+   - Assert whitespace-padded anonymous-script name, trigger name, and trigger sObject values produce trimmed filenames and trigger content.
+3. Let the stop hook run compile, lint, Effect LS, tests, `vscode:bundle`, and knip.
+4. Inspect the diff to confirm changes remain within the 3 named pipelines, shared name validation, and 2 named specs.

--- a/packages/salesforcedx-vscode-apex-log/src/commands/createAnonymousApexScript.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/commands/createAnonymousApexScript.ts
@@ -8,6 +8,7 @@
 import { ExtensionProviderService, LetterStartNameSchema } from '@salesforce/effect-ext-utils';
 import * as Effect from 'effect/Effect';
 import * as Schema from 'effect/Schema';
+import * as String from 'effect/String';
 import * as vscode from 'vscode';
 import { Utils } from 'vscode-uri';
 import { nls } from '../messages';
@@ -26,10 +27,7 @@ const promptForScriptName = Effect.fn('promptForScriptName')(function* () {
         return undefined;
       }
     })
-  ).pipe(
-    Effect.map(raw => raw?.trim()),
-    Effect.flatMap(promptService.considerUndefinedAsCancellation)
-  );
+  ).pipe(Effect.flatMap(promptService.considerUndefinedAsCancellation), Effect.map(String.trim));
 });
 
 export const createAnonymousApexScriptCommand = Effect.fn('ApexLog.Command.createAnonymousApexScript')(function* () {

--- a/packages/salesforcedx-vscode-apex-log/src/commands/createApexTrigger.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/commands/createApexTrigger.ts
@@ -7,6 +7,7 @@
 
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
 import * as Effect from 'effect/Effect';
+import * as String from 'effect/String';
 import * as vscode from 'vscode';
 import { URI, Utils } from 'vscode-uri';
 import { nls } from '../messages';
@@ -31,10 +32,7 @@ const promptForSObject = Effect.fn('promptForTriggerSObject')(function* () {
   if (sobjects.length === 0) {
     return yield* Effect.promise(() =>
       vscode.window.showInputBox({ prompt: nls.localize('apex_trigger_sobject_prompt') })
-    ).pipe(
-      Effect.map(raw => raw?.trim()),
-      Effect.flatMap(promptService.considerUndefinedAsCancellation)
-    );
+    ).pipe(Effect.flatMap(promptService.considerUndefinedAsCancellation), Effect.map(String.trim));
   }
 
   const items: vscode.QuickPickItem[] = sobjects

--- a/packages/salesforcedx-vscode-apex-log/src/commands/sfTemplateProjectHelpers.ts
+++ b/packages/salesforcedx-vscode-apex-log/src/commands/sfTemplateProjectHelpers.ts
@@ -8,6 +8,7 @@
 import { ExtensionProviderService, LetterStartNameSchema } from '@salesforce/effect-ext-utils';
 import * as Effect from 'effect/Effect';
 import * as Schema from 'effect/Schema';
+import * as String from 'effect/String';
 import * as vscode from 'vscode';
 import { nls } from '../messages';
 
@@ -33,10 +34,11 @@ const validateApexTypeName = (
   options?: { readonly maxLength?: number }
 ): string | undefined => {
   const maxLen = options?.maxLength ?? APEX_NAME_MAX_LENGTH;
-  if (!value || value.trim().length === 0) return messages.empty;
-  if (value.toLowerCase() === 'default') return messages.reservedDefault;
-  if (!Schema.is(LetterStartNameSchema)(value)) return messages.invalidFormat;
-  return value.length > maxLen ? messages.maxLength : undefined;
+  const normalized = String.trim(value);
+  if (!normalized) return messages.empty;
+  if (normalized.toLowerCase() === 'default') return messages.reservedDefault;
+  if (!Schema.is(LetterStartNameSchema)(normalized)) return messages.invalidFormat;
+  return normalized.length > maxLen ? messages.maxLength : undefined;
 };
 
 type PromptForApexTypeNameParams = {
@@ -58,8 +60,5 @@ export const promptForApexTypeName = Effect.fn('promptForApexTypeName')(function
           maxLength: APEX_NAME_MAX_LENGTH
         })
     })
-  ).pipe(
-    Effect.map(raw => raw?.trim()),
-    Effect.flatMap(promptService.considerUndefinedAsCancellation)
-  );
+  ).pipe(Effect.flatMap(promptService.considerUndefinedAsCancellation), Effect.map(String.trim));
 });

--- a/packages/salesforcedx-vscode-apex-log/test/playwright/specs/createApexTrigger.headless.spec.ts
+++ b/packages/salesforcedx-vscode-apex-log/test/playwright/specs/createApexTrigger.headless.spec.ts
@@ -23,14 +23,14 @@ import {
 } from '@salesforce/playwright-vscode-ext';
 import { messages } from '../../../src/messages/i18n';
 import packageNls from '../../../package.nls.json';
-import { test } from '../fixtures';
+import { noOrgTest } from '../fixtures';
 
-test('Apex Generate Trigger: creates new Apex trigger via command palette', async ({ page }) => {
+noOrgTest('Apex Generate Trigger: creates new Apex trigger via command palette', async ({ page }) => {
   const consoleErrors = setupConsoleMonitoring(page);
   const networkErrors = setupNetworkMonitoring(page);
   const triggerName = `GenerateTriggerTest${Date.now()}`;
 
-  await test.step('setup with no org', async () => {
+  await noOrgTest.step('setup with no org', async () => {
     await waitForVSCodeWorkbench(page);
     await closeWelcomeTabs(page);
     await ensureSecondarySideBarHidden(page);
@@ -38,11 +38,39 @@ test('Apex Generate Trigger: creates new Apex trigger via command palette', asyn
     await saveScreenshot(page, 'setup.after-workbench.png');
   });
 
-  await test.step('command is present', async () => {
+  await noOrgTest.step('command is present', async () => {
     await verifyCommandExists(page, packageNls.apex_generate_trigger_text, 120_000);
   });
 
-  await test.step('create Apex trigger via command palette', async () => {
+  await noOrgTest.step('cancel trigger name input', async () => {
+    await executeCommandWithCommandPalette(page, packageNls.apex_generate_trigger_text);
+    const quickInput = page.locator(QUICK_INPUT_WIDGET);
+    await quickInput.waitFor({ state: 'visible', timeout: 5000 });
+    await quickInput.getByText(messages.apex_trigger_name_prompt).waitFor({ state: 'visible', timeout: 10_000 });
+    await page.keyboard.press('Escape');
+    await expect(quickInput).not.toBeVisible({ timeout: 5000 });
+    await expect(
+      page.locator('[role="tab"]').filter({ hasText: new RegExp(`${triggerName}\\.trigger$`, 'i') })
+    ).not.toBeVisible();
+  });
+
+  await noOrgTest.step('cancel trigger sObject input', async () => {
+    await executeCommandWithCommandPalette(page, packageNls.apex_generate_trigger_text);
+    const quickInput = page.locator(QUICK_INPUT_WIDGET);
+    await quickInput.waitFor({ state: 'visible', timeout: 5000 });
+    await quickInput.getByText(messages.apex_trigger_name_prompt).waitFor({ state: 'visible', timeout: 10_000 });
+    await page.keyboard.type(`  ${triggerName}  `);
+    await page.keyboard.press('Enter');
+    await quickInput.waitFor({ state: 'visible', timeout: 10_000 });
+    await quickInput.getByText(messages.apex_trigger_sobject_prompt).waitFor({ state: 'visible', timeout: 10_000 });
+    await page.keyboard.press('Escape');
+    await expect(quickInput).not.toBeVisible({ timeout: 5000 });
+    await expect(
+      page.locator('[role="tab"]').filter({ hasText: new RegExp(`${triggerName}\\.trigger$`, 'i') })
+    ).not.toBeVisible();
+  });
+
+  await noOrgTest.step('create Apex trigger via command palette', async () => {
     await executeCommandWithCommandPalette(page, packageNls.apex_generate_trigger_text);
     await saveScreenshot(page, 'step1.after-command.png');
 
@@ -51,14 +79,14 @@ test('Apex Generate Trigger: creates new Apex trigger via command palette', asyn
     await quickInput.waitFor({ state: 'visible', timeout: 5000 });
     await quickInput.getByText(messages.apex_trigger_name_prompt).waitFor({ state: 'visible', timeout: 10_000 });
     await saveScreenshot(page, 'step1.name-prompt-visible.png');
-    await page.keyboard.type(triggerName);
+    await page.keyboard.type(`  ${triggerName}  `);
     await page.keyboard.press('Enter');
     await saveScreenshot(page, 'step1.after-type-name.png');
 
     // Select sObject — QuickPick when org is connected, text input fallback otherwise
     await quickInput.waitFor({ state: 'visible', timeout: 10_000 });
     await saveScreenshot(page, 'step1.sobject-prompt-visible.png');
-    await page.keyboard.type('Case');
+    await page.keyboard.type('  Case  ');
     const hasSObjectList = await page.locator('.quick-input-list').isVisible();
     if (hasSObjectList) {
       await waitForQuickInputFirstOption(page);
@@ -98,8 +126,8 @@ test('Apex Generate Trigger: creates new Apex trigger via command palette', asyn
     await saveScreenshot(page, 'step1.editor-opened.png');
   });
 
-  await test.step('verify trigger was created correctly', async () => {
-    const editorTab = page.locator('[role="tab"]').filter({ hasText: new RegExp(`${triggerName}\\.trigger`, 'i') });
+  await noOrgTest.step('verify trigger was created correctly', async () => {
+    const editorTab = page.locator('[role="tab"]').filter({ hasText: new RegExp(`${triggerName}\\.trigger$`, 'i') });
     await expect(editorTab).toBeVisible({ timeout: 1000 });
     await saveScreenshot(page, 'step2.tab-visible.png');
 
@@ -122,5 +150,5 @@ test('Apex Generate Trigger: creates new Apex trigger via command palette', asyn
     await saveScreenshot(page, 'step2.trigger-content-verified.png');
   });
 
-  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+  await validateNoCriticalErrors(noOrgTest, consoleErrors, networkErrors);
 });

--- a/packages/salesforcedx-vscode-apex-log/test/playwright/specs/executeAnonymous.headless.spec.ts
+++ b/packages/salesforcedx-vscode-apex-log/test/playwright/specs/executeAnonymous.headless.spec.ts
@@ -47,21 +47,33 @@ test('Execute Anonymous Apex: document, selection, script creation, compile erro
     await ensureSecondarySideBarHidden(page);
   });
 
-  await test.step('create anonymous apex script via command palette', async () => {
+  await test.step('cancel anonymous Apex script creation', async () => {
     await verifyCommandExists(page, packageNls['apexLog.command.createAnonymousApexScript'], 30_000);
+    await executeCommandWithCommandPalette(page, packageNls['apexLog.command.createAnonymousApexScript']);
+    const quickInput = page.locator(QUICK_INPUT_WIDGET);
+    await quickInput.waitFor({ state: 'visible', timeout: 10_000 });
+    await quickInput.getByText(/Enter script name/i).waitFor({ state: 'visible', timeout: 5000 });
+    await page.keyboard.press('Escape');
+    await expect(quickInput).not.toBeVisible({ timeout: 5000 });
+    await expect(page.locator(TAB).filter({ hasText: new RegExp(`${scriptName}\\.apex$`) })).not.toBeVisible();
+  });
+
+  await test.step('create anonymous apex script via command palette', async () => {
     await executeCommandWithCommandPalette(page, packageNls['apexLog.command.createAnonymousApexScript']);
     const quickInput = page.locator(QUICK_INPUT_WIDGET);
     await quickInput.waitFor({ state: 'visible', timeout: 10_000 });
     await quickInput.getByText(/Enter script name/i).waitFor({ state: 'visible', timeout: 5000 });
     const quickInputText = quickInput.locator('input.input').first();
     await quickInputText.waitFor({ state: 'visible', timeout: 5000 });
-    await quickInputText.fill(scriptName);
+    await quickInputText.fill(`  ${scriptName}  `);
     await page.keyboard.press('Enter');
     await waitForQuickInputFirstOption(page);
     await page.keyboard.press('Enter');
     const editor = page.locator(EDITOR_WITH_URI).first();
     await editor.waitFor({ state: 'visible', timeout: 15_000 });
-    await expect(page.locator(TAB).filter({ hasText: /\.apex$/ })).toBeVisible({ timeout: 5000 });
+    await expect(page.locator(TAB).filter({ hasText: new RegExp(`${scriptName}\\.apex$`) })).toBeVisible({
+      timeout: 5000
+    });
     await saveScreenshot(page, 'create-script.apex-opened.png');
   });
 


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-23573551@

### What changed and why?

- Replaced callback-based trimming with Effect’s point-free `String.trim` in the three Apex Log prompt pipelines.
- Moved cancellation handling before trimming so cancelled prompts remain cancelled and trimming always receives a string.
- Normalized Apex type names before validation so padded names validate correctly.
- Added Playwright coverage for prompt cancellation, trimmed filenames, and trimmed trigger content.
- Updated trigger tests to use the no-org fixture.
