### PR TITLE
feat(codebuilder-e2e): multi-org + Dreamhouse container spec coverage - W-23898526

### DIFF
--- a/.github/workflows/codeBuilderE2E.yml
+++ b/.github/workflows/codeBuilderE2E.yml
@@ -180,7 +180,7 @@ jobs:
       # orchestrator auths it into the container via CB_EXTRA_ORG_ALIASES (below). No -d: the boot org
       # ($MINIMAL_ORG_ALIAS) stays the default; multi-org specs switch to this alias with save/restore.
       - name: Create non-tracking scratch org (multi-org specs)
-        if: matrix.package == 'salesforcedx-vscode-org'
+        if: contains(fromJSON('["salesforcedx-vscode-org", "salesforcedx-vscode-metadata", "salesforcedx-vscode-core", "salesforcedx-vscode-apex-testing"]'), matrix.package)
         uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           max_attempts: 3
@@ -194,7 +194,7 @@ jobs:
       # need extra orgs; empty elsewhere (the orchestrator no-ops).
       - name: Run Code Builder E2E (orchestrator)
         env:
-          CB_EXTRA_ORG_ALIASES: ${{ matrix.package == 'salesforcedx-vscode-org' && 'nonTrackingTestOrg' || '' }}
+          CB_EXTRA_ORG_ALIASES: ${{ contains(fromJSON('["salesforcedx-vscode-org", "salesforcedx-vscode-metadata", "salesforcedx-vscode-core", "salesforcedx-vscode-apex-testing"]'), matrix.package) && 'nonTrackingTestOrg' || '' }}
         run: npm run test:container:local -- --run-id "$RUN_ID" --image-tag "$IMAGE_TAG" --only "$PACKAGE"
 
       # This shard runs one package (--only), so only that package's report/results dir exists; the
@@ -232,6 +232,6 @@ jobs:
 
       # Same for the extra multi-org scratch org, when this shard created one.
       - name: Cleanup non-tracking scratch org
-        if: always() && matrix.package == 'salesforcedx-vscode-org'
+        if: always() && contains(fromJSON('["salesforcedx-vscode-org", "salesforcedx-vscode-metadata", "salesforcedx-vscode-core", "salesforcedx-vscode-apex-testing"]'), matrix.package)
         continue-on-error: true
         run: sf org delete scratch -o nonTrackingTestOrg --no-prompt || true

--- a/.github/workflows/codeBuilderE2E.yml
+++ b/.github/workflows/codeBuilderE2E.yml
@@ -175,10 +175,26 @@ jobs:
           retry_wait_seconds: 30
           command: bash -c 'rm -rf cb-e2e-org-project && sf project generate -n cb-e2e-org-project && cd cb-e2e-org-project && sf org create scratch -y 1 -d -f config/project-scratch-def.json -a "$MINIMAL_ORG_ALIAS" --json --wait 30'
 
+      # Multi-org specs (org picker/switch) need a SECOND org beyond the boot org. Create a non-tracking
+      # scratch org — only for the package(s) that use it (keeps scratch-org spend + time down). The
+      # orchestrator auths it into the container via CB_EXTRA_ORG_ALIASES (below). No -d: the boot org
+      # ($MINIMAL_ORG_ALIAS) stays the default; multi-org specs switch to this alias with save/restore.
+      - name: Create non-tracking scratch org (multi-org specs)
+        if: matrix.package == 'salesforcedx-vscode-org'
+        uses: salesforcecli/github-workflows/.github/actions/retry@main
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: bash -c 'rm -rf cb-e2e-nt-project && sf project generate -n cb-e2e-nt-project && cd cb-e2e-nt-project && sf org create scratch -y 1 -f config/project-scratch-def.json -a nonTrackingTestOrg --no-track-source --json --wait 30'
+
       # The orchestrator does the rest: download the VSIX for RUN_ID, pull the image, REUSE the scratch
-      # org created above (via createMinimalOrg), run + seed + swap + restart + verify gate, then run the
-      # container specs and tear the container down. Same pipeline a developer runs locally.
+      # org created above (via createMinimalOrg), auth any CB_EXTRA_ORG_ALIASES into the container, run +
+      # seed + swap + restart + verify gate, then run the container specs and tear the container down.
+      # Same pipeline a developer runs locally. CB_EXTRA_ORG_ALIASES is set only for packages whose specs
+      # need extra orgs; empty elsewhere (the orchestrator no-ops).
       - name: Run Code Builder E2E (orchestrator)
+        env:
+          CB_EXTRA_ORG_ALIASES: ${{ matrix.package == 'salesforcedx-vscode-org' && 'nonTrackingTestOrg' || '' }}
         run: npm run test:container:local -- --run-id "$RUN_ID" --image-tag "$IMAGE_TAG" --only "$PACKAGE"
 
       # This shard runs one package (--only), so only that package's report/results dir exists; the
@@ -213,3 +229,9 @@ jobs:
         if: always()
         continue-on-error: true
         run: sf org delete scratch -o "$MINIMAL_ORG_ALIAS" --no-prompt || true
+
+      # Same for the extra multi-org scratch org, when this shard created one.
+      - name: Cleanup non-tracking scratch org
+        if: always() && matrix.package == 'salesforcedx-vscode-org'
+        continue-on-error: true
+        run: sf org delete scratch -o nonTrackingTestOrg --no-prompt || true

--- a/.github/workflows/codeBuilderE2E.yml
+++ b/.github/workflows/codeBuilderE2E.yml
@@ -187,14 +187,35 @@ jobs:
           retry_wait_seconds: 30
           command: bash -c 'rm -rf cb-e2e-nt-project && sf project generate -n cb-e2e-nt-project && cd cb-e2e-nt-project && sf org create scratch -y 1 -f config/project-scratch-def.json -a nonTrackingTestOrg --no-track-source --json --wait 30'
 
+      # Some specs (org-browser custom object/tab/report; metadata sObject refresh) need an org that has
+      # real custom metadata a bare scratch org lacks. Provision a Dreamhouse org (clone + create + deploy
+      # + permset) — only for those package(s). No -d: the boot org stays default; those specs switch to
+      # this alias with save/restore. Dreamhouse deploy is slow, hence the tight package gate.
+      - name: Create Dreamhouse scratch org (custom-metadata specs)
+        if: contains(fromJSON('["salesforcedx-vscode-org-browser", "salesforcedx-vscode-metadata"]'), matrix.package)
+        uses: salesforcecli/github-workflows/.github/actions/retry@main
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: bash -c 'rm -rf cb-e2e-dh && git clone --depth=1 https://github.com/trailheadapps/dreamhouse-lwc cb-e2e-dh && cd cb-e2e-dh && sf org create scratch -y 1 -f config/project-scratch-def.json -a orgBrowserDreamhouseTestOrg --json --wait 30 && sf project deploy start -o orgBrowserDreamhouseTestOrg && sf org assign permset -n dreamhouse -o orgBrowserDreamhouseTestOrg'
+
+      # Resolve which extra orgs the orchestrator auths into the container for THIS package (comma-sep).
+      # org/core switch to a non-tracking org; org-browser browses a Dreamhouse org; metadata uses both.
+      - name: Resolve extra org aliases (per package)
+        run: |
+          case "$PACKAGE" in
+            salesforcedx-vscode-metadata) echo "CB_EXTRA_ORG_ALIASES=nonTrackingTestOrg,orgBrowserDreamhouseTestOrg" >> "$GITHUB_ENV" ;;
+            salesforcedx-vscode-org-browser) echo "CB_EXTRA_ORG_ALIASES=orgBrowserDreamhouseTestOrg" >> "$GITHUB_ENV" ;;
+            salesforcedx-vscode-org | salesforcedx-vscode-core) echo "CB_EXTRA_ORG_ALIASES=nonTrackingTestOrg" >> "$GITHUB_ENV" ;;
+            *) echo "CB_EXTRA_ORG_ALIASES=" >> "$GITHUB_ENV" ;;
+          esac
+
       # The orchestrator does the rest: download the VSIX for RUN_ID, pull the image, REUSE the scratch
       # org created above (via createMinimalOrg), auth any CB_EXTRA_ORG_ALIASES into the container, run +
       # seed + swap + restart + verify gate, then run the container specs and tear the container down.
-      # Same pipeline a developer runs locally. CB_EXTRA_ORG_ALIASES is set only for packages whose specs
-      # need extra orgs; empty elsewhere (the orchestrator no-ops).
+      # Same pipeline a developer runs locally. CB_EXTRA_ORG_ALIASES (set above) is empty for packages
+      # whose specs need no extra org (the orchestrator no-ops).
       - name: Run Code Builder E2E (orchestrator)
-        env:
-          CB_EXTRA_ORG_ALIASES: ${{ contains(fromJSON('["salesforcedx-vscode-org", "salesforcedx-vscode-metadata", "salesforcedx-vscode-core"]'), matrix.package) && 'nonTrackingTestOrg' || '' }}
         run: npm run test:container:local -- --run-id "$RUN_ID" --image-tag "$IMAGE_TAG" --only "$PACKAGE"
 
       # This shard runs one package (--only), so only that package's report/results dir exists; the
@@ -235,3 +256,9 @@ jobs:
         if: always() && contains(fromJSON('["salesforcedx-vscode-org", "salesforcedx-vscode-metadata", "salesforcedx-vscode-core"]'), matrix.package)
         continue-on-error: true
         run: sf org delete scratch -o nonTrackingTestOrg --no-prompt || true
+
+      # And the Dreamhouse org, when this shard created one.
+      - name: Cleanup Dreamhouse scratch org
+        if: always() && contains(fromJSON('["salesforcedx-vscode-org-browser", "salesforcedx-vscode-metadata"]'), matrix.package)
+        continue-on-error: true
+        run: sf org delete scratch -o orgBrowserDreamhouseTestOrg --no-prompt || true

--- a/.github/workflows/codeBuilderE2E.yml
+++ b/.github/workflows/codeBuilderE2E.yml
@@ -180,7 +180,7 @@ jobs:
       # orchestrator auths it into the container via CB_EXTRA_ORG_ALIASES (below). No -d: the boot org
       # ($MINIMAL_ORG_ALIAS) stays the default; multi-org specs switch to this alias with save/restore.
       - name: Create non-tracking scratch org (multi-org specs)
-        if: contains(fromJSON('["salesforcedx-vscode-org", "salesforcedx-vscode-metadata", "salesforcedx-vscode-core", "salesforcedx-vscode-apex-testing"]'), matrix.package)
+        if: contains(fromJSON('["salesforcedx-vscode-org", "salesforcedx-vscode-metadata", "salesforcedx-vscode-core"]'), matrix.package)
         uses: salesforcecli/github-workflows/.github/actions/retry@main
         with:
           max_attempts: 3
@@ -194,7 +194,7 @@ jobs:
       # need extra orgs; empty elsewhere (the orchestrator no-ops).
       - name: Run Code Builder E2E (orchestrator)
         env:
-          CB_EXTRA_ORG_ALIASES: ${{ contains(fromJSON('["salesforcedx-vscode-org", "salesforcedx-vscode-metadata", "salesforcedx-vscode-core", "salesforcedx-vscode-apex-testing"]'), matrix.package) && 'nonTrackingTestOrg' || '' }}
+          CB_EXTRA_ORG_ALIASES: ${{ contains(fromJSON('["salesforcedx-vscode-org", "salesforcedx-vscode-metadata", "salesforcedx-vscode-core"]'), matrix.package) && 'nonTrackingTestOrg' || '' }}
         run: npm run test:container:local -- --run-id "$RUN_ID" --image-tag "$IMAGE_TAG" --only "$PACKAGE"
 
       # This shard runs one package (--only), so only that package's report/results dir exists; the
@@ -232,6 +232,6 @@ jobs:
 
       # Same for the extra multi-org scratch org, when this shard created one.
       - name: Cleanup non-tracking scratch org
-        if: always() && contains(fromJSON('["salesforcedx-vscode-org", "salesforcedx-vscode-metadata", "salesforcedx-vscode-core", "salesforcedx-vscode-apex-testing"]'), matrix.package)
+        if: always() && contains(fromJSON('["salesforcedx-vscode-org", "salesforcedx-vscode-metadata", "salesforcedx-vscode-core"]'), matrix.package)
         continue-on-error: true
         run: sf org delete scratch -o nonTrackingTestOrg --no-prompt || true

--- a/docs/codeBuilderContainerParity.md
+++ b/docs/codeBuilderContainerParity.md
@@ -58,6 +58,51 @@ yet ported — see "Reachable but not yet ported" below.
 The orchestrator auto-discovers every package that declares a `test:container` script, so adding a
 suite to a new package wires it in with no orchestrator edit.
 
+### Origin-spec coverage tally
+
+How the container suite maps back to the original desktop/web (`.desktop`/`.headless`/`.spec`) specs
+it was ported from. **Origin** counts product specs only — the 10 `playwright-vscode-ext` specs test
+the shared test *library* itself, not a product feature, so they're excluded. **Ported** is origin
+specs that now have container coverage; the container has 5 more spec *files* than that (91 total)
+from container-only splits/additions (`seededWorkspace`, `testExplorerRun`, metadata `deploySource`,
+2 org-browser variants).
+
+| Package | Origin | Ported | Not ported |
+| --- | --: | --: | --: |
+| `salesforcedx-vscode-metadata` | 32 | 22 | 10 |
+| `salesforcedx-vscode-apex-testing` | 14 | 11 | 3 |
+| `salesforcedx-vscode-lwc` | 13 | 10 | 3 |
+| `salesforcedx-vscode-apex-log` | 12 | 8 | 4 |
+| `salesforcedx-vscode-org` | 12 | 8 | 4 |
+| `salesforcedx-vscode-apex-oas` | 9 | 3 | 6 |
+| `salesforcedx-vscode-apex-replay-debugger` | 7 | 1 | 6 |
+| `salesforcedx-vscode-org-browser` | 7 | 6 | 1 |
+| `salesforcedx-vscode-lightning` | 6 | 4 | 2 |
+| `salesforcedx-vscode-apex` | 5 | 4 | 1 |
+| `salesforcedx-vscode-services` | 4 | 1 | 3 |
+| `salesforcedx-vscode-soql` | 4 | 2 | 2 |
+| `salesforcedx-vscode-core` | 3 | 3 | 0 |
+| `salesforcedx-vscode-apex-debugger` | 2 | 1 | 1 |
+| `salesforcedx-vscode-visualforce` | 2 | 2 | 0 |
+| **Total** | **132** | **86 (65%)** | **46** |
+
+The 46 not-ported specs by blocking constraint:
+
+| Blocking constraint | Count |
+| --- | --: |
+| Different workspace shape (no-folder / empty / multi-package) | 11 |
+| Interactive debug session / DAP | 8 |
+| Rate-limited A4V/Einstein LLM (apex-oas) | 6 |
+| Destructive org lifecycle / second org user | 6 |
+| Reads span/telemetry files | 5 |
+| Webview-only surface | 2 |
+| Slow/mutating positive retrieve | 2 |
+| Needs desktop window reload / native file-watch event | 2 |
+| Dev/Test-only internal command | 1 |
+| Needs a fixture dev-dependency (`sfdx-lwc-jest`) | 1 |
+| **Reachable but not yet ported** | **2** |
+| **Total** | **46** |
+
 ## Not ported (and why)
 
 These specs cannot run in the container and stay desktop/web-only. Grouped by the blocking

--- a/docs/codeBuilderContainerParity.md
+++ b/docs/codeBuilderContainerParity.md
@@ -38,7 +38,7 @@ Count is container spec **files**: 91 active + 2 `test.fixme`.
 
 | Package | Specs | Container specs |
 | --- | --: | --- |
-| `salesforcedx-vscode-metadata` | 23 | deploy (Source/Path/Palette/Manifest/OnSave), retrieve (Source/Manifest/StaleApiVersion), deleteSource, sourceDiff(+Multiple), viewChangesCommands, generateManifest, editorWatcher, projectDeployStart, projectInfo, packageInstall, **nonTrackingOrgDeployRetrieve(Manifest/Operations), refreshSObjectDefinitions, sourceTrackingStatusBar, manifestCommandVisibility, noProjectCommandsHidden** + nonTrackingOrgTracking(Commands/UI)Hidden (`fixme`) |
+| `salesforcedx-vscode-metadata` | 25 | deploy (Source/Path/Palette/Manifest/OnSave), retrieve (Source/Manifest/StaleApiVersion), deleteSource, sourceDiff(+Multiple), viewChangesCommands, generateManifest, editorWatcher, projectDeployStart, projectInfo, packageInstall, **nonTrackingOrgDeployRetrieve(Manifest/Operations), refreshSObjectDefinitions, sourceTrackingStatusBar, manifestCommandVisibility, noProjectCommandsHidden** + nonTrackingOrgTracking(Commands/UI)Hidden (`fixme`) |
 | `salesforcedx-vscode-lwc` | 10 | generateComponent, rename, snippets, customComponentsIndex + LSP (autocomplete, goToDefinition Html/Js, hover, indexing, sfdxTypings) |
 | `salesforcedx-vscode-apex-testing` | 12 | testExplorer(+Run), runApexTests (CodeLens/CommandPalette/FailAndFix), apexTestSuite(+Delete), clearApexTestResults, codeCoverageColorizer, staleTestResultsRestoration, **orgOnlyClassRetrieve, inWorkspaceFilter** |
 | `salesforcedx-vscode-org-browser` | 8 | orgBrowser (types), orgBrowser.describe, orgBrowser.filterToggle, orgBrowser.textFilter, **orgBrowserCustomObject, orgBrowserCustomTab, orgBrowserFolderedReport, orgBrowserTextFilterDreamhouse** |
@@ -63,13 +63,13 @@ suite to a new package wires it in with no orchestrator edit.
 How the container suite maps back to the original desktop/web (`.desktop`/`.headless`/`.spec`) specs
 it was ported from. **Origin** counts product specs only — the 10 `playwright-vscode-ext` specs test
 the shared test *library* itself, not a product feature, so they're excluded. **Ported** is origin
-specs that now have container coverage; the container has 5 more spec *files* than that (91 total)
+specs that now have container coverage; the container has 5 more spec *files* than that (93 total)
 from container-only splits/additions (`seededWorkspace`, `testExplorerRun`, metadata `deploySource`,
 2 org-browser variants).
 
 | Package | Origin | Ported | Not ported |
 | --- | --: | --: | --: |
-| `salesforcedx-vscode-metadata` | 32 | 22 | 10 |
+| `salesforcedx-vscode-metadata` | 32 | 24 | 8 |
 | `salesforcedx-vscode-apex-testing` | 14 | 11 | 3 |
 | `salesforcedx-vscode-lwc` | 13 | 10 | 3 |
 | `salesforcedx-vscode-apex-log` | 12 | 8 | 4 |
@@ -84,9 +84,9 @@ from container-only splits/additions (`seededWorkspace`, `testExplorerRun`, meta
 | `salesforcedx-vscode-core` | 3 | 3 | 0 |
 | `salesforcedx-vscode-apex-debugger` | 2 | 1 | 1 |
 | `salesforcedx-vscode-visualforce` | 2 | 2 | 0 |
-| **Total** | **132** | **86 (65%)** | **46** |
+| **Total** | **132** | **88 (67%)** | **44** |
 
-The 46 not-ported specs by blocking constraint:
+The 44 not-ported specs by blocking constraint:
 
 | Blocking constraint | Count |
 | --- | --: |

--- a/docs/codeBuilderContainerParity.md
+++ b/docs/codeBuilderContainerParity.md
@@ -86,12 +86,14 @@ from container-only splits/additions (`seededWorkspace`, `testExplorerRun`, meta
 | `salesforcedx-vscode-visualforce` | 2 | 2 | 0 |
 | **Total** | **132** | **88 (67%)** | **44** |
 
-The 44 not-ported specs by blocking constraint:
+The 44 not-ported specs by blocking constraint (6 of them are actively being ported — see the
+DAP row and the "Debug / DAP portability assessment" below):
 
 | Blocking constraint | Count |
 | --- | --: |
 | Different workspace shape (no-folder / empty / multi-package) | 9 |
-| Interactive debug session / DAP | 8 |
+| Interactive debug session / DAP — in active porting (6 apex-replay; DAP-in-code-server proven, pending green verification) | 6 |
+| Interactive debug session / DAP — hard-blocked (`isvDebugBootstrap` live org session, `lwcDebugTests` jest dep + debug) | 2 |
 | Rate-limited A4V/Einstein LLM (apex-oas) | 6 |
 | Destructive org lifecycle / second org user | 6 |
 | Reads span/telemetry files | 5 |
@@ -102,6 +104,11 @@ The 44 not-ported specs by blocking constraint:
 | Needs a fixture dev-dependency (`sfdx-lwc-jest`) | 1 |
 | **Reachable but not yet ported** | **2** |
 | **Total** | **44** |
+
+Once the 6 apex-replay debug specs verify green, the tally becomes **94 ported (71%) / 38 not-ported**;
+of the remaining 38, only ~28 are hard-blocked (the rest are reachable-with-work: the 2 metadata
+"reachable" specs, the 4 phase-2-ready workspace-shape visibility specs, and multi-package/no-org-boot
+variants).
 
 ## Not ported (and why)
 
@@ -208,8 +215,11 @@ Neither is in the current stack; they're the next low-risk coverage additions if
 ## Debug / DAP portability assessment
 
 The 8 interactive-debug specs are the largest not-ported bucket. A feasibility review found **7 are
-realistically reachable and 1 is permanently blocked** — but the whole group is gated on one unproven
-assumption, so it is scoped here rather than attempted blind.
+realistically reachable and 1 is permanently blocked**, and the gating unknown has since been **retired
+by a spike**: a live apex-replay DAP session launches and renders the debug view through code-server in
+the container (green at 17.3s). The 6 apex-replay specs are now in **active porting** on the
+`jh/W-23898526-cb-e2e-debug` branch (verification in progress); they stay counted as not-ported until
+they pass green. `isvDebugBootstrap` remains hard-blocked; `lwcDebugTests` needs the jest dep baked in.
 
 **Why it isn't already done:** the two shipped container debug twins
 (`apex-replay-debugger/.../container/errorPaths` and `apex-debugger/.../container/debuggerStop`) were

--- a/docs/codeBuilderContainerParity.md
+++ b/docs/codeBuilderContainerParity.md
@@ -250,6 +250,33 @@ helpers** in `playwright-vscode-ext`; specs hand-roll it plus a local `continueD
    org setup for the boot org (as `errorPaths.container` already does).
 7. **BLOCKED:** `isvDebugBootstrap` real bootstrap — org-side `ApexDebuggerSession` unavailable in CI.
 
+## Workspace-shape portability assessment
+
+The 11 "different workspace shape" specs are the largest not-ported bucket. A feasibility review found
+**8 of 11 reachable, 3 effectively blocked** — but every reachable path must change the shape at
+**boot** (via what `coder.json` opens / whether an org is authed), never at **runtime**. Closing the
+workspace or removing the boot org mid-session rides the same cross-extension-host event / window-reload
+limitation already `test.fixme`'d for the tracking specs, and corrupts the one shared serial workbench
+for every subsequent spec.
+
+| Spec(s) | Shape needed | Verdict |
+| --- | --- | --- |
+| metadata `manifestCommandVisibility` | standard project + org (= the current fixture) | **EASY** — not a shape problem; just write `*Package.xml`/`.xml` into the mounted fixture + clean up, drop `createMinimalOrg` (org is ambient) |
+| apex-log/apex-testing `noProjectVisibility`, metadata `noProjectCommandsHidden`, metadata `emptyWorkspaceSfdxCommands` | folder open, no `sfdx-project.json` / no folder open | **MEDIUM** — org-agnostic palette-visibility checks; add an orchestrator phase that re-seeds `coder.json` to a non-project / no folder + existing `restart()`. Touches only orchestrator/config, not the shared fixture |
+| apex-log `apexGenerateClassMultiPackageDirs` | multi-`packageDirectories` project | **MEDIUM** — needs a **second** multi-package mount. Do NOT convert the shared fixture to multi-package: it would make every class/trigger-create command start prompting a dir picker → regresses existing apex specs |
+| apex-log/apex-testing `noOrgVisibility` | DX project open, **no org** | **MEDIUM–HARD** — needs a dedicated **no-org container boot** (make `bootEnv`/org optional in `lifecycle.ts` + orchestrator); can't be a mid-run phase since `restart()` re-auths the org |
+| metadata `createProject`, `createProjectEmptyWindow`, `createProjectWithManifest` | scaffold a new project on disk | **HARD / blocked** — assert files via host `node:fs` (container FS is invisible unless under the bind mount), target dir `/home/codebuilder` isn't mounted, and Create Project ends with `vscode.openFolder` → reloads the shared workbench (the unreliable path). Low value-to-cost |
+
+**Cheapest path (highest reachable-count-per-effort):** ship `manifestCommandVisibility` first (no shape
+change). Then cover the four visibility specs with **one** added orchestrator capability — re-seed
+`coder.json` (non-project folder, and no-folder) + a second trivial non-project mount, sequenced with
+the existing `restart()` — which touches only orchestrator/config and leaves the 86 ported specs
+untouched. Multi-package and no-org boot are each a further self-contained mount/boot variant.
+
+**Spike first:** whether a re-seed + `restart()` reliably reopens a *different* `coder.json` shape
+(folder / no-folder) cleanly on the CB image. That boot-time re-seed behavior isn't exercised anywhere
+today and gates the whole phased design.
+
 ## Adding a container suite to a package
 
 1. `test/playwright/playwright.config.container.ts` → `createContainerConfig({ testDir: './specs/container' })`.

--- a/docs/codeBuilderContainerParity.md
+++ b/docs/codeBuilderContainerParity.md
@@ -27,20 +27,24 @@ VS Code Web (the Apex/Aura/LWC language servers, `child_process`, and the `sf` C
 so many specs that are `isDesktop()`-gated in the web suite run here — those gates are dropped in the
 container ports.
 
-## Coverage summary — 75 specs across 15 packages
+## Coverage summary — 90 specs across 15 packages
+
+Includes the multi-org / Dreamhouse ports (see "Multi-org container support" below): 13 previously
+org-blocked specs now run by authing extra orgs into the container and switching the default with
+save/restore; 2 more are ported but `test.fixme` for a documented code-server limitation.
 
 | Package | Specs | Container specs |
 | --- | --: | --- |
-| `salesforcedx-vscode-metadata` | 17 | deploy (Source/Path/Palette/Manifest/OnSave), retrieve (Source/Manifest/StaleApiVersion), deleteSource, sourceDiff(+Multiple), viewChangesCommands, generateManifest, editorWatcher, projectDeployStart, projectInfo, packageInstall |
+| `salesforcedx-vscode-metadata` | 23 | deploy (Source/Path/Palette/Manifest/OnSave), retrieve (Source/Manifest/StaleApiVersion), deleteSource, sourceDiff(+Multiple), viewChangesCommands, generateManifest, editorWatcher, projectDeployStart, projectInfo, packageInstall, **nonTrackingOrgDeployRetrieve(Manifest/Operations), refreshSObjectDefinitions, sourceTrackingStatusBar** + nonTrackingOrgTracking(Commands/UI)Hidden (`fixme`) |
 | `salesforcedx-vscode-lwc` | 10 | generateComponent, rename, snippets, customComponentsIndex + LSP (autocomplete, goToDefinition Html/Js, hover, indexing, sfdxTypings) |
-| `salesforcedx-vscode-apex-testing` | 9 | testExplorer, runApexTests (CodeLens/CommandPalette/FailAndFix), apexTestSuite(+Delete), clearApexTestResults, codeCoverageColorizer, staleTestResultsRestoration |
+| `salesforcedx-vscode-apex-testing` | 11 | testExplorer, runApexTests (CodeLens/CommandPalette/FailAndFix), apexTestSuite(+Delete), clearApexTestResults, codeCoverageColorizer, staleTestResultsRestoration, **orgOnlyClassRetrieve, inWorkspaceFilter** |
+| `salesforcedx-vscode-org-browser` | 8 | orgBrowser (types), orgBrowser.describe, orgBrowser.filterToggle, orgBrowser.textFilter, **orgBrowserCustomObject, orgBrowserCustomTab, orgBrowserFolderedReport, orgBrowserTextFilterDreamhouse** |
 | `salesforcedx-vscode-apex-log` | 8 | executeAnonymous, logRetrieval, apexGenerateClass, apexTestClassCreate, createApexTrigger, autoCollection, traceFlagsCrud, traceFlagExpiry |
-| `salesforcedx-vscode-org` | 6 | orgDisplay, aliasList, orgOpen, orgCommands, orgDeleteCommandVisibility, orgLoginAccessToken |
+| `salesforcedx-vscode-org` | 8 | orgDisplay, aliasList, orgOpen, orgCommands, orgDeleteCommandVisibility, orgLoginAccessToken, **orgPicker, orgPickers** |
 | `salesforcedx-vscode-apex` | 4 | apexLsp (go-to-def/autocomplete), apexLspHover, apexLspRestart, apexSnippets |
 | `salesforcedx-vscode-lightning` | 4 | auraLspAutocompletion, auraLspGoToDefinition, auraRename, auraTemplates |
-| `salesforcedx-vscode-org-browser` | 4 | orgBrowser (types), orgBrowser.describe, orgBrowser.filterToggle, orgBrowser.textFilter |
+| `salesforcedx-vscode-core` | 4 | configList, seededWorkspace, coreOutputChannel, **workspaceContextOrgSwitch** |
 | `salesforcedx-vscode-apex-oas` | 3 | ineligibleClass, mixedFrameworksClass, restResourceNoHttpMethod (all pre-LLM eligibility guards) |
-| `salesforcedx-vscode-core` | 3 | configList, seededWorkspace, coreOutputChannel |
 | `salesforcedx-vscode-soql` | 2 | soqlRunQuery, soqlQueryPlan |
 | `salesforcedx-vscode-visualforce` | 2 | visualforceLsp, visualforceTemplates |
 | `salesforcedx-vscode-services` | 1 | retrieveOnLoad (activation + no-op branch) |
@@ -64,21 +68,18 @@ constraint:
 `composedManualMerge`, `composedOverwrite`, `decomposedSimpleAccount`, `contextMenuEditor`,
 `contextMenuExplorer`.
 
-**Requires a different org (non-tracking / second org / dev hub / web login / delete / logout)** —
-metadata: `nonTrackingOrgDeployRetrieveManifest`, `nonTrackingOrgDeployRetrieveOperations`,
-`nonTrackingOrgTrackingCommandsHidden`, `nonTrackingOrgTrackingUIHidden`, `deleteBundleSource`;
-apex-testing: `clearOnLogout`, `orgOnlyClassRetrieve`, `inWorkspaceFilter`; apex-log:
-`traceFlagsForOtherUser`; org: `orgLoginWeb`, `orgDeleteUsername`, `orgListClean`, `orgPicker`,
-`orgPickers`; core: `workspaceContextOrgSwitch`.
+**Destructive org lifecycle (web login / delete / logout / list-clean) or a second org USER** —
+metadata: `deleteBundleSource`; apex-testing: `clearOnLogout`; apex-log: `traceFlagsForOtherUser`
+(needs a second user in the org); org: `orgLoginWeb`, `orgDeleteUsername`, `orgListClean`. These
+mutate or destroy org auth on the ONE shared serial session (or need a second user), which the
+multi-org capability below deliberately does not provide. (Non-tracking, org-picker, org-switch, and
+Dreamhouse-metadata specs that only READ or SWITCH between pre-provisioned orgs ARE now ported — see
+"Multi-org container support".)
 
 **Requires a different workspace shape (no-folder / empty / multi-package)** — metadata:
 `createProject`, `createProjectEmptyWindow`, `createProjectWithManifest`, `emptyWorkspaceSfdxCommands`,
 `manifestCommandVisibility`, `noProjectCommandsHidden`; apex-log: `apexGenerateClassMultiPackageDirs`,
 `noOrgVisibility`, `noProjectVisibility`; apex-testing: `noOrgVisibility`, `noProjectVisibility`.
-
-**Requires custom/Dreamhouse org metadata a bare scratch org lacks** — org-browser:
-`orgBrowser.customObject`, `orgBrowser.customTab`, `orgBrowser.folderedReport` (+ the `Broker__c`
-subtests of `textFilter`); metadata: `refreshSObjectDefinitions`, `sourceTrackingStatusBar`.
 
 **Reads local span/telemetry files or needs the spans:server** — apex: `apexTelemetrySpans`;
 metadata: `cliEnvSpans`; lightning: `telemetryOutput`, `spanRedaction`; org: `telemetryIdentitySeeding`.
@@ -93,6 +94,35 @@ webviews).
 `orgBrowser.filterToggle.desktop`.
 
 **Needs a fixture dev-dependency not in the workspace** — lwc: `lwcRunTests` (`@salesforce/sfdx-lwc-jest`).
+
+## Multi-org container support
+
+The container boots ONE org (token injection). To cover specs that need a NON-tracking org, a second
+org to pick/switch between, or Dreamhouse custom metadata, the harness now authenticates ADDITIONAL
+pre-created orgs into the running container:
+
+- The CI workflow (`codeBuilderE2E.yml`) provisions the extra org(s) per package — a `--no-track-source`
+  scratch org (`nonTrackingTestOrg`) and/or a Dreamhouse org (`orgBrowserDreamhouseTestOrg`, cloned +
+  deployed + permset) — and passes their aliases via `CB_EXTRA_ORG_ALIASES`.
+- The orchestrator (`scripts/codeBuilderLocalE2E.ts`, `authExtraOrgsIntoContainer`) resolves each org's
+  access token + instance URL on the host (un-redacted, via `resolveOrgBootEnv`) and runs
+  `sf org login access-token` INSIDE the container **as the `codebuilder` user** (the workbench user,
+  so `~/.sf` matches) **after the restart** (the boot re-auth would otherwise wipe it). The org
+  extension reads the org list fresh on each picker open, so no window reload is needed.
+- Specs switch the default org via the shared `switchDefaultOrgViaPicker` helper (a re-driving poll)
+  and RESTORE the boot org in a `finally`, so the shared serial session isn't contaminated.
+
+Ported this way: org `orgPicker`/`orgPickers`, core `workspaceContextOrgSwitch`, apex-testing
+`orgOnlyClassRetrieve`/`inWorkspaceFilter` (boot org — org-only is presence, not tracking), metadata
+`nonTrackingOrgDeployRetrieve(Manifest/Operations)`/`refreshSObjectDefinitions`/`sourceTrackingStatusBar`,
+and org-browser `customObject`/`customTab`/`folderedReport`/`textFilterDreamhouse`.
+
+**Documented `test.fixme` (code-server limitation):** metadata `nonTrackingOrgTrackingCommandsHidden`
+and `nonTrackingOrgTrackingUIHidden`. The metadata source-tracking status bar re-evaluates only on a
+`~/.sf/config.json` file event, which code-server does not deliver cross-extension-host for a RUNTIME
+org switch — so the tracking UI doesn't hide after switching to a non-tracking org without a window
+reload the web container can't perform. (`sourceTrackingStatusBar` avoids this by testing the boot
+org, which is tracking + default from activation.)
 
 ## Adding a container suite to a package
 

--- a/docs/codeBuilderContainerParity.md
+++ b/docs/codeBuilderContainerParity.md
@@ -97,7 +97,7 @@ The 46 not-ported specs by blocking constraint:
 | Reads span/telemetry files | 5 |
 | Webview-only surface | 2 |
 | Slow/mutating positive retrieve | 2 |
-| Needs desktop window reload / native file-watch event | 2 |
+| Reload-flakiness in web / native file-watch event not delivered | 2 |
 | Dev/Test-only internal command | 1 |
 | Needs a fixture dev-dependency (`sfdx-lwc-jest`) | 1 |
 | **Reachable but not yet ported** | **2** |
@@ -139,11 +139,15 @@ webviews).
 **Slow/mutating positive retrieve (writes metadata into the shared fixture)** — services:
 `retrieveOnLoadMetadata`, `retrieveOnLoadRetry` (the no-op branch is covered by `retrieveOnLoad`).
 
-**Needs a desktop window reload or native file-watch event the web container can't deliver** —
-org-browser: `orgBrowser.filterToggle.desktop`; lwc: `lwcLspSfdxProjectWatcher` (mutates
-`sfdx-project.json` and asserts the debounced FS-watcher restarts the LWC LSP — code-server doesn't
-deliver the cross-extension-host config/FS event at runtime, the same limitation behind the
-`test.fixme`'d tracking specs).
+**Reload-flakiness in web, or a native file-watch event the container can't deliver** — org-browser:
+`orgBrowser.filterToggle.desktop`; lwc: `lwcLspSfdxProjectWatcher`. `reloadWindow` (`Developer: Reload
+Window`) *does* work in code-server — the block is narrower: `filterToggle` verifies state persistence
+*across a reload*, and in the web/dev harness a reload is a full page reload that re-fetches extension
+bundles from the dev web server (a flakiness source unrelated to the assertion), so the desktop twin
+covers it more reliably. `lwcLspSfdxProjectWatcher` mutates `sfdx-project.json` and asserts the
+debounced FS-watcher restarts the LWC LSP — that relies on a cross-extension-host config/FS **event**
+code-server doesn't deliver at runtime (the real limitation behind the `test.fixme`'d tracking specs),
+which a reload would mask rather than test.
 
 **Dev/Test-only internal command absent in the container** — services: `redactingConsoleLogger`. It
 drives `sf.internal.testRedactingConsoleLogger`, which core registers only when
@@ -177,9 +181,11 @@ and org-browser `customObject`/`customTab`/`folderedReport`/`textFilterDreamhous
 **Documented `test.fixme` (code-server limitation):** metadata `nonTrackingOrgTrackingCommandsHidden`
 and `nonTrackingOrgTrackingUIHidden`. The metadata source-tracking status bar re-evaluates only on a
 `~/.sf/config.json` file event, which code-server does not deliver cross-extension-host for a RUNTIME
-org switch — so the tracking UI doesn't hide after switching to a non-tracking org without a window
-reload the web container can't perform. (`sourceTrackingStatusBar` avoids this by testing the boot
-org, which is tracking + default from activation.)
+org switch — so the tracking UI doesn't hide after switching to a non-tracking org. A window reload
+*would* refresh it (reload works in code-server), but that would mask the real gap — the metadata
+extension is a separate host and should observe the switch without a reload — so these are `fixme`'d
+pending a product fix rather than papered over. (`sourceTrackingStatusBar` avoids this by testing the
+boot org, which is tracking + default from activation.)
 
 ## Reachable but not yet ported
 
@@ -253,11 +259,12 @@ helpers** in `playwright-vscode-ext`; specs hand-roll it plus a local `continueD
 ## Workspace-shape portability assessment
 
 The 11 "different workspace shape" specs are the largest not-ported bucket. A feasibility review found
-**8 of 11 reachable, 3 effectively blocked** — but every reachable path must change the shape at
-**boot** (via what `coder.json` opens / whether an org is authed), never at **runtime**. Closing the
-workspace or removing the boot org mid-session rides the same cross-extension-host event / window-reload
-limitation already `test.fixme`'d for the tracking specs, and corrupts the one shared serial workbench
-for every subsequent spec.
+**8 of 11 reachable, 3 effectively blocked** — but every reachable path must change the shape at a
+**phase boundary** (re-seed `coder.json` + `restart()`, which the orchestrator already does), never by
+mutating the shape *mid-suite*. Closing the workspace or removing the boot org in the middle of the one
+shared serial session corrupts the workbench every subsequent spec depends on. (This is a shared-session-
+integrity cost, not a code-server limitation — a reload/`restart()` at a phase boundary is fully
+supported; `reloadWindow` works in code-server.)
 
 | Spec(s) | Shape needed | Verdict |
 | --- | --- | --- |
@@ -265,7 +272,7 @@ for every subsequent spec.
 | apex-log/apex-testing `noProjectVisibility`, metadata `noProjectCommandsHidden`, metadata `emptyWorkspaceSfdxCommands` | folder open, no `sfdx-project.json` / no folder open | **MEDIUM** — org-agnostic palette-visibility checks; add an orchestrator phase that re-seeds `coder.json` to a non-project / no folder + existing `restart()`. Touches only orchestrator/config, not the shared fixture |
 | apex-log `apexGenerateClassMultiPackageDirs` | multi-`packageDirectories` project | **MEDIUM** — needs a **second** multi-package mount. Do NOT convert the shared fixture to multi-package: it would make every class/trigger-create command start prompting a dir picker → regresses existing apex specs |
 | apex-log/apex-testing `noOrgVisibility` | DX project open, **no org** | **MEDIUM–HARD** — needs a dedicated **no-org container boot** (make `bootEnv`/org optional in `lifecycle.ts` + orchestrator); can't be a mid-run phase since `restart()` re-auths the org |
-| metadata `createProject`, `createProjectEmptyWindow`, `createProjectWithManifest` | scaffold a new project on disk | **HARD / blocked** — assert files via host `node:fs` (container FS is invisible unless under the bind mount), target dir `/home/codebuilder` isn't mounted, and Create Project ends with `vscode.openFolder` → reloads the shared workbench (the unreliable path). Low value-to-cost |
+| metadata `createProject`, `createProjectEmptyWindow`, `createProjectWithManifest` | scaffold a new project on disk | **HARD / blocked** — assert files via host `node:fs` (container FS is invisible unless under the bind mount), target dir `/home/codebuilder` isn't mounted, and Create Project ends with `vscode.openFolder` (changing the opened folder — a harder operation than a plain reload, and it re-navigates the shared workbench). Low value-to-cost |
 
 **Cheapest path (highest reachable-count-per-effort):** ship `manifestCommandVisibility` first (no shape
 change). Then cover the four visibility specs with **one** added orchestrator capability — re-seed

--- a/docs/codeBuilderContainerParity.md
+++ b/docs/codeBuilderContainerParity.md
@@ -27,18 +27,18 @@ VS Code Web (the Apex/Aura/LWC language servers, `child_process`, and the `sf` C
 so many specs that are `isDesktop()`-gated in the web suite run here — those gates are dropped in the
 container ports.
 
-## Coverage summary — 91 specs across 15 packages
+## Coverage summary — 93 specs across 15 packages
 
-Includes the multi-org / Dreamhouse ports (see "Multi-org container support" below): 13 previously
-org-blocked specs now run by authing extra orgs into the container and switching the default with
-save/restore; 2 more are ported but `test.fixme` for a documented code-server limitation.
+Includes multi-org / Dreamhouse ports (see "Multi-org container support" below): 13 previously
+org-blocked specs now run by authing extra orgs + switching default with save/restore; 2 ported but
+`test.fixme` for code-server limits. Includes phase-2 no-project shape ports: 2 specs now run after
+orchestrator re-seeds to non-project workspace.
 
-Count is container spec **files**: 89 active + 2 `test.fixme`. Two origin specs are reachable but not
-yet ported — see "Reachable but not yet ported" below.
+Count is container spec **files**: 91 active + 2 `test.fixme`.
 
 | Package | Specs | Container specs |
 | --- | --: | --- |
-| `salesforcedx-vscode-metadata` | 23 | deploy (Source/Path/Palette/Manifest/OnSave), retrieve (Source/Manifest/StaleApiVersion), deleteSource, sourceDiff(+Multiple), viewChangesCommands, generateManifest, editorWatcher, projectDeployStart, projectInfo, packageInstall, **nonTrackingOrgDeployRetrieve(Manifest/Operations), refreshSObjectDefinitions, sourceTrackingStatusBar** + nonTrackingOrgTracking(Commands/UI)Hidden (`fixme`) |
+| `salesforcedx-vscode-metadata` | 23 | deploy (Source/Path/Palette/Manifest/OnSave), retrieve (Source/Manifest/StaleApiVersion), deleteSource, sourceDiff(+Multiple), viewChangesCommands, generateManifest, editorWatcher, projectDeployStart, projectInfo, packageInstall, **nonTrackingOrgDeployRetrieve(Manifest/Operations), refreshSObjectDefinitions, sourceTrackingStatusBar, manifestCommandVisibility, noProjectCommandsHidden** + nonTrackingOrgTracking(Commands/UI)Hidden (`fixme`) |
 | `salesforcedx-vscode-lwc` | 10 | generateComponent, rename, snippets, customComponentsIndex + LSP (autocomplete, goToDefinition Html/Js, hover, indexing, sfdxTypings) |
 | `salesforcedx-vscode-apex-testing` | 12 | testExplorer(+Run), runApexTests (CodeLens/CommandPalette/FailAndFix), apexTestSuite(+Delete), clearApexTestResults, codeCoverageColorizer, staleTestResultsRestoration, **orgOnlyClassRetrieve, inWorkspaceFilter** |
 | `salesforcedx-vscode-org-browser` | 8 | orgBrowser (types), orgBrowser.describe, orgBrowser.filterToggle, orgBrowser.textFilter, **orgBrowserCustomObject, orgBrowserCustomTab, orgBrowserFolderedReport, orgBrowserTextFilterDreamhouse** |
@@ -90,7 +90,7 @@ The 46 not-ported specs by blocking constraint:
 
 | Blocking constraint | Count |
 | --- | --: |
-| Different workspace shape (no-folder / empty / multi-package) | 11 |
+| Different workspace shape (no-folder / empty / multi-package) | 9 |
 | Interactive debug session / DAP | 8 |
 | Rate-limited A4V/Einstein LLM (apex-oas) | 6 |
 | Destructive org lifecycle / second org user | 6 |
@@ -101,7 +101,7 @@ The 46 not-ported specs by blocking constraint:
 | Dev/Test-only internal command | 1 |
 | Needs a fixture dev-dependency (`sfdx-lwc-jest`) | 1 |
 | **Reachable but not yet ported** | **2** |
-| **Total** | **46** |
+| **Total** | **44** |
 
 ## Not ported (and why)
 
@@ -126,9 +126,10 @@ Dreamhouse-metadata specs that only READ or SWITCH between pre-provisioned orgs 
 "Multi-org container support".)
 
 **Requires a different workspace shape (no-folder / empty / multi-package)** — metadata:
-`createProject`, `createProjectEmptyWindow`, `createProjectWithManifest`, `emptyWorkspaceSfdxCommands`,
-`manifestCommandVisibility`, `noProjectCommandsHidden`; apex-log: `apexGenerateClassMultiPackageDirs`,
-`noOrgVisibility`, `noProjectVisibility`; apex-testing: `noOrgVisibility`, `noProjectVisibility`.
+`createProject`, `createProjectEmptyWindow`, `createProjectWithManifest`, `emptyWorkspaceSfdxCommands`;
+apex-log: `apexGenerateClassMultiPackageDirs`, `noOrgVisibility`, `noProjectVisibility`; apex-testing:
+`noOrgVisibility`, `noProjectVisibility`. (metadata `manifestCommandVisibility` and `noProjectCommandsHidden`
+now ported — see "Workspace-shape portability assessment" below.)
 
 **Reads local span/telemetry files or needs the spans:server** — apex: `apexTelemetrySpans`;
 metadata: `cliEnvSpans`; lightning: `telemetryOutput`, `spanRedaction`; org: `telemetryIdentitySeeding`.
@@ -258,38 +259,46 @@ helpers** in `playwright-vscode-ext`; specs hand-roll it plus a local `continueD
 
 ## Workspace-shape portability assessment
 
-The 11 "different workspace shape" specs are the largest not-ported bucket. A feasibility review found
-**8 of 11 reachable, 3 effectively blocked** — but every reachable path must change the shape at a
-**phase boundary** (re-seed `coder.json` + `restart()`, which the orchestrator already does), never by
-mutating the shape *mid-suite*. Closing the workspace or removing the boot org in the middle of the one
-shared serial session corrupts the workbench every subsequent spec depends on. (This is a shared-session-
-integrity cost, not a code-server limitation — a reload/`restart()` at a phase boundary is fully
-supported; `reloadWindow` works in code-server.)
+The 9 remaining "different workspace shape" specs are blocked by harness constraints. Every shape change
+must occur at a **phase boundary** (re-seed `coder.json` + `restart()` at suite transitions), never
+mid-suite—mutating the shared serial session corrupts the workbench for downstream specs. This is a
+shared-session integrity cost, not a code-server limit; `restart()` at phase boundaries works fully.
 
 | Spec(s) | Shape needed | Verdict |
 | --- | --- | --- |
-| metadata `manifestCommandVisibility` | standard project + org (= the current fixture) | **EASY** — not a shape problem; just write `*Package.xml`/`.xml` into the mounted fixture + clean up, drop `createMinimalOrg` (org is ambient) |
-| apex-log/apex-testing `noProjectVisibility`, metadata `noProjectCommandsHidden`, metadata `emptyWorkspaceSfdxCommands` | folder open, no `sfdx-project.json` / no folder open | **MEDIUM** — org-agnostic palette-visibility checks; add an orchestrator phase that re-seeds `coder.json` to a non-project / no folder + existing `restart()`. Touches only orchestrator/config, not the shared fixture |
-| apex-log `apexGenerateClassMultiPackageDirs` | multi-`packageDirectories` project | **MEDIUM** — needs a **second** multi-package mount. Do NOT convert the shared fixture to multi-package: it would make every class/trigger-create command start prompting a dir picker → regresses existing apex specs |
-| apex-log/apex-testing `noOrgVisibility` | DX project open, **no org** | **MEDIUM–HARD** — needs a dedicated **no-org container boot** (make `bootEnv`/org optional in `lifecycle.ts` + orchestrator); can't be a mid-run phase since `restart()` re-auths the org |
-| metadata `createProject`, `createProjectEmptyWindow`, `createProjectWithManifest` | scaffold a new project on disk | **HARD / blocked** — assert files via host `node:fs` (container FS is invisible unless under the bind mount), target dir `/home/codebuilder` isn't mounted, and Create Project ends with `vscode.openFolder` (changing the opened folder — a harder operation than a plain reload, and it re-navigates the shared workbench). Low value-to-cost |
+| metadata `manifestCommandVisibility` | standard project + org (= current fixture) | **DONE** — ported; writes `*Package.xml`/`.xml` into bind-mounted fixture via `CB_FIXTURE_HOST_DIR` env; runs against ambient boot org in phase 1 |
+| metadata `noProjectCommandsHidden` | folder, no `sfdx-project.json` | **DONE** — ported; orchestrator re-seeds `coder.json` to non-project mount + `restart()`s in phase 2, re-runs verify gate, then runs `test:container:noproject`. Re-seed spike: **PASS** ✓ |
+| apex-log/apex-testing `noProjectVisibility`, metadata `emptyWorkspaceSfdxCommands` | folder open, no `sfdx-project.json` / no folder open | **READY** — reachable; palette-visibility checks are org-agnostic; reuse phase 2 machinery (re-seed to non-project / no-folder mount + `restart()`), autodiscover via `test:container:noproject` script |
+| apex-log `apexGenerateClassMultiPackageDirs` | multi-`packageDirectories` project | **READY** — needs 2nd multi-package mount; don't convert shared fixture to multi-package (regresses picker-on-create for existing apex specs) |
+| apex-log/apex-testing `noOrgVisibility` | DX project, **no org** | **BLOCKED** — needs dedicated no-org boot (make `bootEnv` optional in lifecycle); can't be mid-run phase since `restart()` re-auths org |
+| metadata `createProject`, `createProjectEmptyWindow`, `createProjectWithManifest` | scaffold new project on disk | **BLOCKED** — container FS invisible outside bind mounts; `vscode.openFolder` (harder than reload, re-navigates workbench); low value-to-cost |
 
-**Cheapest path (highest reachable-count-per-effort):** ship `manifestCommandVisibility` first (no shape
-change). Then cover the four visibility specs with **one** added orchestrator capability — re-seed
-`coder.json` (non-project folder, and no-folder) + a second trivial non-project mount, sequenced with
-the existing `restart()` — which touches only orchestrator/config and leaves the 86 ported specs
-untouched. Multi-package and no-org boot are each a further self-contained mount/boot variant.
-
-**Spike first:** whether a re-seed + `restart()` reliably reopens a *different* `coder.json` shape
-(folder / no-folder) cleanly on the CB image. That boot-time re-seed behavior isn't exercised anywhere
-today and gates the whole phased design.
+**Phase 2 infrastructure:** Orchestrator now runs a second phase after standard suites (phase 1).
+Re-seeds `coder.json` to a 2nd non-project mount (`container-noproject` fixture), `restart()`s, re-runs
+verify gate, then runs any package's `test:container:noproject` suite (auto-discovered). New env vars:
+`CB_FIXTURE_HOST_DIR` (host path of DX fixture bind mount, for specs writing files), `CB_GREP` (grep
+passed via env, not CLI arg, to preserve shell quoting through wireit/npm). New plumbing:
+`discoverPackagesWithScript()` generalized for any script name, second bind mount in container config.
 
 ## Adding a container suite to a package
+
+**Phase 1 (standard DX-project fixture):**
 
 1. `test/playwright/playwright.config.container.ts` → `createContainerConfig({ testDir: './specs/container' })`.
 2. `test/playwright/fixtures/containerFixtures.ts` → `export const containerTest = createContainerTest()`.
 3. `test/playwright/specs/container/<name>.container.spec.ts` importing `containerTest` and only
-   plain-`Page` helpers from `@salesforce/playwright-vscode-ext`. Drive the boot org, harden for the
-   shared workbench (unique names, `beforeEach` cleanup), and drop `isDesktop()` gates.
-4. Add a `test:container` script + wireit block mirroring the other packages.
-5. The orchestrator discovers the suite automatically. Update the tables above.
+   plain-`Page` helpers from `@salesforce/playwright-vscode-ext`. Drive the boot org, harden for shared
+   workbench (unique names, `beforeEach` cleanup), drop `isDesktop()` gates.
+4. Add `test:container` script + wireit block (mirrors other packages; accept `CODE_BUILDER_URL` env,
+   forward `CB_GREP` to Playwright).
+5. Orchestrator auto-discovers. Update coverage tables.
+
+**Phase 2 (no-project workspace shape):**
+
+For specs requiring a no-project folder (project-gated commands must be hidden):
+
+1. `test/playwright/playwright.config.container.noproject.ts` → `createContainerConfig({ testDir: './specs/container-noproject' })`.
+2. `test/playwright/specs/container-noproject/<name>.container.spec.ts` — same patterns as phase 1.
+3. Add `test:container:noproject` script + wireit block (same env vars as `test:container`).
+4. Orchestrator auto-discovers `test:container:noproject` scripts; runs phase 2 after phase 1. Specs
+   run against the mounted non-project folder after re-seed + `restart()`.

--- a/docs/codeBuilderContainerParity.md
+++ b/docs/codeBuilderContainerParity.md
@@ -27,17 +27,20 @@ VS Code Web (the Apex/Aura/LWC language servers, `child_process`, and the `sf` C
 so many specs that are `isDesktop()`-gated in the web suite run here — those gates are dropped in the
 container ports.
 
-## Coverage summary — 90 specs across 15 packages
+## Coverage summary — 91 specs across 15 packages
 
 Includes the multi-org / Dreamhouse ports (see "Multi-org container support" below): 13 previously
 org-blocked specs now run by authing extra orgs into the container and switching the default with
 save/restore; 2 more are ported but `test.fixme` for a documented code-server limitation.
 
+Count is container spec **files**: 89 active + 2 `test.fixme`. Two origin specs are reachable but not
+yet ported — see "Reachable but not yet ported" below.
+
 | Package | Specs | Container specs |
 | --- | --: | --- |
 | `salesforcedx-vscode-metadata` | 23 | deploy (Source/Path/Palette/Manifest/OnSave), retrieve (Source/Manifest/StaleApiVersion), deleteSource, sourceDiff(+Multiple), viewChangesCommands, generateManifest, editorWatcher, projectDeployStart, projectInfo, packageInstall, **nonTrackingOrgDeployRetrieve(Manifest/Operations), refreshSObjectDefinitions, sourceTrackingStatusBar** + nonTrackingOrgTracking(Commands/UI)Hidden (`fixme`) |
 | `salesforcedx-vscode-lwc` | 10 | generateComponent, rename, snippets, customComponentsIndex + LSP (autocomplete, goToDefinition Html/Js, hover, indexing, sfdxTypings) |
-| `salesforcedx-vscode-apex-testing` | 11 | testExplorer, runApexTests (CodeLens/CommandPalette/FailAndFix), apexTestSuite(+Delete), clearApexTestResults, codeCoverageColorizer, staleTestResultsRestoration, **orgOnlyClassRetrieve, inWorkspaceFilter** |
+| `salesforcedx-vscode-apex-testing` | 12 | testExplorer(+Run), runApexTests (CodeLens/CommandPalette/FailAndFix), apexTestSuite(+Delete), clearApexTestResults, codeCoverageColorizer, staleTestResultsRestoration, **orgOnlyClassRetrieve, inWorkspaceFilter** |
 | `salesforcedx-vscode-org-browser` | 8 | orgBrowser (types), orgBrowser.describe, orgBrowser.filterToggle, orgBrowser.textFilter, **orgBrowserCustomObject, orgBrowserCustomTab, orgBrowserFolderedReport, orgBrowserTextFilterDreamhouse** |
 | `salesforcedx-vscode-apex-log` | 8 | executeAnonymous, logRetrieval, apexGenerateClass, apexTestClassCreate, createApexTrigger, autoCollection, traceFlagsCrud, traceFlagExpiry |
 | `salesforcedx-vscode-org` | 8 | orgDisplay, aliasList, orgOpen, orgCommands, orgDeleteCommandVisibility, orgLoginAccessToken, **orgPicker, orgPickers** |
@@ -62,7 +65,8 @@ constraint:
 
 **Interactive debug session (DAP launch/attach/breakpoints/replay)** — apex-replay-debugger:
 `apexReplayDebugger`, `apexReplayDebuggerVariables`, `checkpoints`, `debugAnonymousApex`,
-`debugApexTests`; apex-debugger: `isvDebugBootstrap`; lwc: `lwcDebugTests`.
+`debugApexTests`, `promptForLogFile` (F5-launches a debug config to reach the log-file quick input);
+apex-debugger: `isvDebugBootstrap`; lwc: `lwcDebugTests`.
 
 **Rate-limited A4V/Einstein LLM (OpenAPI generation)** — apex-oas: `composedCaseManager`,
 `composedManualMerge`, `composedOverwrite`, `decomposedSimpleAccount`, `contextMenuEditor`,
@@ -90,8 +94,16 @@ webviews).
 **Slow/mutating positive retrieve (writes metadata into the shared fixture)** — services:
 `retrieveOnLoadMetadata`, `retrieveOnLoadRetry` (the no-op branch is covered by `retrieveOnLoad`).
 
-**Needs a desktop window reload the web container can't do** — org-browser:
-`orgBrowser.filterToggle.desktop`.
+**Needs a desktop window reload or native file-watch event the web container can't deliver** —
+org-browser: `orgBrowser.filterToggle.desktop`; lwc: `lwcLspSfdxProjectWatcher` (mutates
+`sfdx-project.json` and asserts the debounced FS-watcher restarts the LWC LSP — code-server doesn't
+deliver the cross-extension-host config/FS event at runtime, the same limitation behind the
+`test.fixme`'d tracking specs).
+
+**Dev/Test-only internal command absent in the container** — services: `redactingConsoleLogger`. It
+drives `sf.internal.testRedactingConsoleLogger`, which core registers only when
+`extensionMode === Development || Test`. The container runs swapped-in **packaged** extensions in
+Normal mode, so the command doesn't exist.
 
 **Needs a fixture dev-dependency not in the workspace** — lwc: `lwcRunTests` (`@salesforce/sfdx-lwc-jest`).
 
@@ -123,6 +135,23 @@ and `nonTrackingOrgTrackingUIHidden`. The metadata source-tracking status bar re
 org switch — so the tracking UI doesn't hide after switching to a non-tracking org without a window
 reload the web container can't perform. (`sourceTrackingStatusBar` avoids this by testing the boot
 org, which is tracking + default from activation.)
+
+## Reachable but not yet ported
+
+Two origin specs land in none of the blocking constraints above — they *can* run in the container and
+are simply not ported yet (both added to develop after the initial parity sweep):
+
+- **metadata `analyticsTemplates`** — creates an Analytics/wave sample template via palette + explorer
+  context menu and checks the 7 scaffold files appear. Fully local `TemplateService.create` scaffold:
+  no org, no CLI plugin, no webview. A straight port on the same pattern as `generateManifest` /
+  lightning `auraTemplates` (unique `Date.now()` names to stay clean on the shared fixture).
+- **metadata `taggedErrorChannelOutput`** — runs deploy-in-manifest with no manifest and asserts the
+  channel output carries the tagged `[ManifestSelectionRequiredError]`. The error fires on the
+  manifest-selection guard before any org round-trip; the only desktop-ism is a `createMinimalOrg`
+  call to make the command available, which is exactly the boot-org rewire used by the other ported
+  org specs.
+
+Neither is in the current stack; they're the next low-risk coverage additions if we want them.
 
 ## Adding a container suite to a package
 

--- a/docs/codeBuilderContainerParity.md
+++ b/docs/codeBuilderContainerParity.md
@@ -198,6 +198,58 @@ are simply not ported yet (both added to develop after the initial parity sweep)
 
 Neither is in the current stack; they're the next low-risk coverage additions if we want them.
 
+## Debug / DAP portability assessment
+
+The 8 interactive-debug specs are the largest not-ported bucket. A feasibility review found **7 are
+realistically reachable and 1 is permanently blocked** — but the whole group is gated on one unproven
+assumption, so it is scoped here rather than attempted blind.
+
+**Why it isn't already done:** the two shipped container debug twins
+(`apex-replay-debugger/.../container/errorPaths` and `apex-debugger/.../container/debuggerStop`) were
+*deliberately* scoped to the command/notification paths that launch **no** debug session — because the
+container fixture exposes only a `page` (no host-filesystem handle to the workspace) and the shared
+serial workbench makes a running debug session hazardous. Nobody has yet driven a **live DAP session**
+through code-server over the browser.
+
+**Adapters:** apex-replay is a bundled **local Node** adapter (`type:"apex-replay"`, replays a log
+file, no org streaming) — it runs in the container's server-side Node extension host exactly as on
+desktop, nothing web-guards it. lwc debug uses VS Code's built-in **js-debug** node adapter. The
+interactive/ISV apex debugger (`type:"apex"`) needs a **live org-side `ApexDebuggerSession`** behind an
+ISV/Debug-Only license — not creatable against a CI scratch org.
+
+**Debug UI driving:** all existing debug driving is client-agnostic Monaco DOM (`.debug-toolbar`,
+`.debug-variables`, `.debug-call-stack`, `.repl`, gutter glyphs) + F5/F9 + palette — none of it is
+Electron-specific, so it *should* work against code-server. There are currently **no shared debug-view
+helpers** in `playwright-vscode-ext`; specs hand-roll it plus a local `continueDebugSession`.
+
+| Spec | Adapter / flow | Verdict |
+| --- | --- | --- |
+| `apexReplayDebugger` | local Node replay; launch + continue | reachable (gated on spike) |
+| `apexReplayDebuggerVariables` | local Node replay; breakpoint + VARIABLES tree — full debug UI | reachable (highest value) |
+| `checkpoints` | local Node replay + org checkpoint upload | reachable |
+| `debugAnonymousApex` | local Node replay; debug codelens/selection | reachable |
+| `debugApexTests` | local Node replay; Test Explorer "Debug Test" | reachable |
+| `promptForLogFile` | F5 to reach log-file quick input | reachable (needs seeded `launch.json`) |
+| `lwcDebugTests` | js-debug + jest `--inspect-brk` | reachable (needs `sfdx-lwc-jest` baked into fixture + result-verify rework) |
+| `isvDebugBootstrap` | live ISV org-side debug session | **blocked** (only its command-availability/cancel slice ports) |
+
+**What it would take (ranked):**
+
+1. **Spike (HARD, do first):** launch the apex-replay Node adapter in the running container and confirm
+   `.debug-toolbar` + `.debug-variables` render and F5-continue works over the browser. The port's
+   viability hinges on this — there is zero precedent of a live DAP session in code-server.
+2. **(MEDIUM)** Add reusable debug-view helpers to `playwright-vscode-ext` (continue/step/toggle-
+   breakpoint/read-variables/end-session) with a hazard-safe `afterEach` session-teardown guard.
+3. **(MEDIUM)** Seed an inert `launch.json` into the fixture (for `promptForLogFile`) and add
+   `beforeEach` breakpoint/checkpoint reset + running-session guard for the shared workbench.
+4. **(MEDIUM)** Give container specs a host-readable handle to the mounted fixture, or convert
+   fs-polling assertions (`promptForLogFile`, `lwcDebugTests`) to UI-state assertions.
+5. **(MEDIUM–HARD)** Bake `@salesforce/sfdx-lwc-jest` + an LWC-with-test into the container fixture/image
+   for `lwcDebugTests`.
+6. **(MEDIUM, gated on 1)** Port the 6 replay/LWC specs — swap fixture to `containerTest`, drop per-test
+   org setup for the boot org (as `errorPaths.container` already does).
+7. **BLOCKED:** `isvDebugBootstrap` real bootstrap — org-side `ApexDebuggerSession` unavailable in CI.
+
 ## Adding a container suite to a package
 
 1. `test/playwright/playwright.config.container.ts` → `createContainerConfig({ testDir: './specs/container' })`.

--- a/docs/codeBuilderContainerParity.md
+++ b/docs/codeBuilderContainerParity.md
@@ -27,14 +27,20 @@ VS Code Web (the Apex/Aura/LWC language servers, `child_process`, and the `sf` C
 so many specs that are `isDesktop()`-gated in the web suite run here — those gates are dropped in the
 container ports.
 
-## Coverage summary — 91 specs across 15 packages
+## Coverage summary — 97 specs across 15 packages
 
 Includes the multi-org / Dreamhouse ports (see "Multi-org container support" below): 13 previously
 org-blocked specs now run by authing extra orgs into the container and switching the default with
-save/restore; 2 more are ported but `test.fixme` for a documented code-server limitation.
+save/restore; 2 more are ported but `test.fixme` for a documented code-server limitation. Also
+includes the 6 apex-replay **interactive-debug** specs — a live DAP replay session driven through
+code-server, verified green in isolation and in the full serial suite.
 
-Count is container spec **files**: 89 active + 2 `test.fixme`. Two origin specs are reachable but not
+Count is container spec **files**: 95 active + 2 `test.fixme`. Two origin specs are reachable but not
 yet ported — see "Reachable but not yet ported" below.
+
+(This `jh/W-23898526-cb-e2e-debug` branch does not include the 2 workspace-shape ports on the sibling
+`jh/W-23898526-cb-e2e-workspace-shape` branch; the combined post-merge tally is 99 specs / 94 origin
+ported. See "Branch fragmentation" note at the bottom.)
 
 | Package | Specs | Container specs |
 | --- | --: | --- |
@@ -52,7 +58,7 @@ yet ported — see "Reachable but not yet ported" below.
 | `salesforcedx-vscode-visualforce` | 2 | visualforceLsp, visualforceTemplates |
 | `salesforcedx-vscode-services` | 1 | retrieveOnLoad (activation + no-op branch) |
 | `salesforcedx-vscode-apex-debugger` | 1 | debuggerStop (stop-session command; no DAP) |
-| `salesforcedx-vscode-apex-replay-debugger` | 1 | errorPaths (command error-paths; no debug session) |
+| `salesforcedx-vscode-apex-replay-debugger` | 7 | errorPaths + **apexReplayDebugger, apexReplayDebuggerVariables, checkpoints, debugAnonymousApex, debugApexTests, promptForLogFile** (live DAP replay session in code-server) |
 | `playwright-vscode-ext` | 0 | test library itself — validated by jest + its own `.headless` specs |
 
 The orchestrator auto-discovers every package that declares a `test:container` script, so adding a
@@ -63,7 +69,7 @@ suite to a new package wires it in with no orchestrator edit.
 How the container suite maps back to the original desktop/web (`.desktop`/`.headless`/`.spec`) specs
 it was ported from. **Origin** counts product specs only — the 10 `playwright-vscode-ext` specs test
 the shared test *library* itself, not a product feature, so they're excluded. **Ported** is origin
-specs that now have container coverage; the container has 5 more spec *files* than that (91 total)
+specs that now have container coverage; the container has 5 more spec *files* than that (97 total)
 from container-only splits/additions (`seededWorkspace`, `testExplorerRun`, metadata `deploySource`,
 2 org-browser variants).
 
@@ -75,7 +81,7 @@ from container-only splits/additions (`seededWorkspace`, `testExplorerRun`, meta
 | `salesforcedx-vscode-apex-log` | 12 | 8 | 4 |
 | `salesforcedx-vscode-org` | 12 | 8 | 4 |
 | `salesforcedx-vscode-apex-oas` | 9 | 3 | 6 |
-| `salesforcedx-vscode-apex-replay-debugger` | 7 | 1 | 6 |
+| `salesforcedx-vscode-apex-replay-debugger` | 7 | 7 | 0 |
 | `salesforcedx-vscode-org-browser` | 7 | 6 | 1 |
 | `salesforcedx-vscode-lightning` | 6 | 4 | 2 |
 | `salesforcedx-vscode-apex` | 5 | 4 | 1 |
@@ -84,14 +90,14 @@ from container-only splits/additions (`seededWorkspace`, `testExplorerRun`, meta
 | `salesforcedx-vscode-core` | 3 | 3 | 0 |
 | `salesforcedx-vscode-apex-debugger` | 2 | 1 | 1 |
 | `salesforcedx-vscode-visualforce` | 2 | 2 | 0 |
-| **Total** | **132** | **86 (65%)** | **46** |
+| **Total** | **132** | **92 (70%)** | **40** |
 
-The 46 not-ported specs by blocking constraint:
+The 40 not-ported specs by blocking constraint:
 
 | Blocking constraint | Count |
 | --- | --: |
 | Different workspace shape (no-folder / empty / multi-package) | 11 |
-| Interactive debug session / DAP | 8 |
+| Interactive debug session / DAP (hard-blocked: `isvDebugBootstrap` live org session, `lwcDebugTests` jest dep) | 2 |
 | Rate-limited A4V/Einstein LLM (apex-oas) | 6 |
 | Destructive org lifecycle / second org user | 6 |
 | Reads span/telemetry files | 5 |
@@ -101,17 +107,19 @@ The 46 not-ported specs by blocking constraint:
 | Dev/Test-only internal command | 1 |
 | Needs a fixture dev-dependency (`sfdx-lwc-jest`) | 1 |
 | **Reachable but not yet ported** | **2** |
-| **Total** | **46** |
+| **Total** | **40** |
 
 ## Not ported (and why)
 
 These specs cannot run in the container and stay desktop/web-only. Grouped by the blocking
 constraint:
 
-**Interactive debug session (DAP launch/attach/breakpoints/replay)** — apex-replay-debugger:
-`apexReplayDebugger`, `apexReplayDebuggerVariables`, `checkpoints`, `debugAnonymousApex`,
-`debugApexTests`, `promptForLogFile` (F5-launches a debug config to reach the log-file quick input);
-apex-debugger: `isvDebugBootstrap`; lwc: `lwcDebugTests`.
+**Interactive debug session — hard-blocked** — apex-debugger: `isvDebugBootstrap` (needs a live
+org-side `ApexDebuggerSession` behind an ISV/Debug-Only license, uncreatable in CI); lwc:
+`lwcDebugTests` (js-debug + jest, needs `@salesforce/sfdx-lwc-jest` baked into the fixture). The 6
+apex-replay debug specs (`apexReplayDebugger`, `apexReplayDebuggerVariables`, `checkpoints`,
+`debugAnonymousApex`, `debugApexTests`, `promptForLogFile`) are now **ported and green** — see the
+apex-replay-debugger row above and "Debug / DAP portability assessment".
 
 **Rate-limited A4V/Einstein LLM (OpenAPI generation)** — apex-oas: `composedCaseManager`,
 `composedManualMerge`, `composedOverwrite`, `decomposedSimpleAccount`, `contextMenuEditor`,
@@ -206,9 +214,17 @@ Neither is in the current stack; they're the next low-risk coverage additions if
 
 ## Debug / DAP portability assessment
 
-The 8 interactive-debug specs are the largest not-ported bucket. A feasibility review found **7 are
-realistically reachable and 1 is permanently blocked** — but the whole group is gated on one unproven
-assumption, so it is scoped here rather than attempted blind.
+**Status: DONE for the 6 apex-replay specs — verified green.** A feasibility review found 7 of the 8
+reachable and 1 permanently blocked; the gating unknown (can a live DAP session render through
+code-server?) was retired by a spike, and the 6 apex-replay specs are now ported and pass green both
+in isolation on a cold Apex LS and in the full serial suite. `isvDebugBootstrap` stays hard-blocked
+(live org-side session); `lwcDebugTests` needs the jest dep baked in. Notable fixes to reach green:
+replaced a context-sensitive "Indexing complete" gate with the test-class Run/Debug CodeLens gate,
+inlined `@IsTest` annotations (a completion-accept was swallowing the newline and merging the
+annotation into the class decl), a robust `activateEditorTab` helper (Quick Open intermittently
+returned an unclickable grouped row — the dominant flake), an LS-readiness retry on Update Checkpoints,
+and an `expandAllVariableScopes` rewrite (the empty Global scope never expands). The per-spec table and
+work-items below are retained for history.
 
 **Why it isn't already done:** the two shipped container debug twins
 (`apex-replay-debugger/.../container/errorPaths` and `apex-debugger/.../container/debuggerStop`) were
@@ -283,6 +299,21 @@ untouched. Multi-package and no-org boot are each a further self-contained mount
 **Spike first:** whether a re-seed + `restart()` reliably reopens a *different* `coder.json` shape
 (folder / no-folder) cleanly on the CB image. That boot-time re-seed behavior isn't exercised anywhere
 today and gates the whole phased design.
+
+## Branch fragmentation (temporary — reconcile at merge)
+
+The container-parity follow-on work is split across three sibling branches off `jh/W-23898517`/#8165,
+so this ledger's tally differs per branch until they merge:
+
+| Branch | Adds | Tally on that branch |
+| --- | --- | --: |
+| `jh/W-23898526-cb-e2e-multiorg` (#8165) | multi-org + Dreamhouse | 86 ported / 46 not-ported |
+| `jh/W-23898526-cb-e2e-workspace-shape` | +2 workspace-shape specs + re-seed phase | 88 / 44 |
+| `jh/W-23898526-cb-e2e-debug` (this branch) | +6 apex-replay debug specs | 92 / 40 |
+
+Combined post-merge: **99 container spec files, 94 origin specs ported (71%), 38 not-ported** (of which
+only ~28 are hard-blocked). Whichever branch merges last should fold in the others' rows and land the
+single combined tally.
 
 ## Adding a container suite to a package
 

--- a/packages/playwright-vscode-ext/src/codeBuilder/auth.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/auth.ts
@@ -21,7 +21,24 @@
  */
 
 import * as Schema from 'effect/Schema';
-import { defaultRunner, type CommandRunner } from './runner';
+import { execFileSync } from 'node:child_process';
+import { runnerTimeoutMs, withTimeoutRetry, type CommandRunner } from './runner';
+
+/*
+ * Default runner for the boot-env resolver. Mirrors `defaultRunner` (arg-array exec, timeout + retry)
+ * but forces NO_COLOR=1 / FORCE_COLOR=0 in the child env, exactly as `orgs/shared.ts` does for its own
+ * `sf` invocations. Without this a color-enabled terminal can make `sf --json` emit ANSI escapes,
+ * which then break the `JSON.parse` in `runSfJson` below. Kept local to auth.ts (not folded into
+ * `defaultRunner`) so only the JSON-consuming boot-env path changes.
+ */
+const noColorRunner: CommandRunner = (file, args) =>
+  withTimeoutRetry(() =>
+    execFileSync(file, args as string[], {
+      encoding: 'utf-8',
+      timeout: runnerTimeoutMs(),
+      env: { ...process.env, NO_COLOR: '1', FORCE_COLOR: '0' }
+    })
+  );
 
 /*
  * Schemas for the `sf --json` shapes we consume, validated at the boundary (TS standards / precedent
@@ -57,7 +74,7 @@ export type ResolveOrgBootEnvOptions = {
  * `org auth show-access-token`.
  */
 export const resolveOrgBootEnv = (orgAlias: string, options: ResolveOrgBootEnvOptions = {}): BootEnv => {
-  const runner = options.runner ?? defaultRunner;
+  const runner = options.runner ?? noColorRunner;
 
   /*
    * Parse `sf --json` stdout, but attach context on failure: if `sf` ever prints an update notice /

--- a/packages/playwright-vscode-ext/src/config/createContainerConfig.ts
+++ b/packages/playwright-vscode-ext/src/config/createContainerConfig.ts
@@ -31,6 +31,11 @@ type ContainerConfigOptions = {
 export const createContainerConfig = (options: ContainerConfigOptions) =>
   defineConfig({
     testDir: options.testDir,
+    // CB_GREP filters specs by title regex. Passed as an env var (not a `--grep` CLI arg) because the
+    // orchestrator forwards it through `npm run … -w <pkg>` → wireit, which does NOT shell-quote
+    // forwarded args — a value with spaces or a `|` alternation (e.g. two spec titles) would be split
+    // and mis-parsed. An env var travels intact through spawnSync's `env`, so any title regex works.
+    grep: process.env.CB_GREP ? new RegExp(process.env.CB_GREP) : undefined,
     fullyParallel: options.fullyParallel ?? false,
     forbidOnly: !!process.env.CI,
     workers: options.workers ?? 1,

--- a/packages/playwright-vscode-ext/src/index.ts
+++ b/packages/playwright-vscode-ext/src/index.ts
@@ -162,7 +162,8 @@ export {
   expectOrgPickerStatusBar,
   expectOrgPickerActionItems,
   expectOrgPickerListsOrg,
-  selectOrgInPicker
+  selectOrgInPicker,
+  switchDefaultOrgViaPicker
 } from './pages/statusBar';
 
 export { webviewActiveFrame, hasTitle, hasContent } from './pages/webview';

--- a/packages/playwright-vscode-ext/src/index.ts
+++ b/packages/playwright-vscode-ext/src/index.ts
@@ -169,7 +169,8 @@ export {
   getVariableRow,
   expandNestedVariable,
   continueDebugSession,
-  stopDebugSession
+  stopDebugSession,
+  activateEditorTab
 } from './pages/debug';
 
 export {

--- a/packages/playwright-vscode-ext/src/index.ts
+++ b/packages/playwright-vscode-ext/src/index.ts
@@ -158,6 +158,21 @@ export {
 export { clickCodeLens } from './pages/codeLens';
 
 export {
+  DEBUG_TOOLBAR,
+  DEBUG_CALL_STACK,
+  DEBUG_VARIABLES,
+  assertDebugToolbarVisible,
+  showRunAndDebugView,
+  getCallStackRows,
+  openVariablesView,
+  expandAllVariableScopes,
+  getVariableRow,
+  expandNestedVariable,
+  continueDebugSession,
+  stopDebugSession
+} from './pages/debug';
+
+export {
   clickOrgPickerStatusBar,
   expectOrgPickerStatusBar,
   expectOrgPickerActionItems,

--- a/packages/playwright-vscode-ext/src/orgs/shared.ts
+++ b/packages/playwright-vscode-ext/src/orgs/shared.ts
@@ -38,12 +38,43 @@ export const runScratchOrgCreate = async (command: string, cwd: string): Promise
   }
 };
 
-/** Try to use existing org, return auth fields if found */
+/*
+ * Is the org described by `sf org display --json` actually alive and reusable? A cached scratch org
+ * can be Deleted/expired while `sf org auth show-access-token` still hands back a STALE cached token —
+ * reuse it and the CB container boot fails to log in ("Unable to automatically login to org during
+ * start"), surfacing downstream as a confusing `NoTargetOrgConfiguredError`. So we reuse an alias only
+ * when `org display` shows no positive evidence of death: a live connection, a non-Deleted status, and
+ * (for scratch orgs) an expiration still in the future. Missing fields are treated as "no evidence of
+ * death" so a non-scratch/older-CLI happy path isn't broken by an over-eager check.
+ */
+const isOrgAlive = (result: OrgDisplayResult['result']): boolean => {
+  if (result.status !== undefined && result.status === 'Deleted') {
+    return false;
+  }
+  if (result.connectedStatus !== undefined && result.connectedStatus !== 'Connected') {
+    return false;
+  }
+  if (result.expirationDate !== undefined) {
+    const expiresAt = Date.parse(result.expirationDate);
+    if (Number.isFinite(expiresAt) && expiresAt <= Date.now()) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/** Try to use existing org, return auth fields if found AND the org is actually alive (not dead/expired) */
 export const tryUseExistingOrg = async (orgAlias: string): Promise<OrgAuthResult | undefined> => {
   try {
     const displayResponse = JSON.parse(
       (await execAsync(`sf org display -o ${orgAlias} --json`, { env })).stdout
     ) as OrgDisplayResult;
+
+    // Liveness gate BEFORE reading the token: `show-access-token` returns a stale cached token even
+    // for a Deleted/expired org, so trusting it would hand back a dead org. Fall through to create.
+    if (!isOrgAlive(displayResponse.result)) {
+      return undefined;
+    }
 
     const tokenResponse = JSON.parse(
       (await execAsync(`sf org auth show-access-token -o ${orgAlias} --json`, { env })).stdout

--- a/packages/playwright-vscode-ext/src/orgs/types.ts
+++ b/packages/playwright-vscode-ext/src/orgs/types.ts
@@ -9,5 +9,15 @@ import type { AuthFields } from '@salesforce/core';
 
 export type OrgAuthResult = Required<Pick<AuthFields, 'instanceUrl' | 'accessToken' | 'instanceApiVersion'>>;
 
-type OrgDisplayFields = { instanceUrl: string; accessToken: string; apiVersion: string };
+type OrgDisplayFields = {
+  instanceUrl: string;
+  accessToken: string;
+  apiVersion: string;
+  // Liveness signals from `sf org display --json`. Optional because non-scratch orgs / older CLIs may
+  // omit them; a dead scratch org (Deleted/expired) still returns a stale cached token, so these are
+  // what let `tryUseExistingOrg` tell a reusable org from a dead one.
+  status?: string;
+  connectedStatus?: string;
+  expirationDate?: string;
+};
 export type OrgDisplayResult = { result: OrgDisplayFields };

--- a/packages/playwright-vscode-ext/src/pages/debug.ts
+++ b/packages/playwright-vscode-ext/src/pages/debug.ts
@@ -6,8 +6,29 @@
  */
 
 import { expect, type Locator, type Page } from '@playwright/test';
-import { WORKBENCH } from '../utils/locators';
+import { escapeRegExp } from '../utils/helpers';
+import { EDITOR_WITH_URI, WORKBENCH } from '../utils/locators';
 import { executeCommandWithCommandPalette } from './commands';
+
+/**
+ * Activate an already-open editor tab by file name and wait for its editor to render.
+ *
+ * Prefer this over Quick Open (`openFileByName`) for a file created earlier in the same test: on the
+ * browser-served (code-server) workbench Quick Open intermittently returns the match grouped under a
+ * "recently opened" / "other commands" header, and the reconstructed row resolves but is not
+ * clickable — a flaky `locator.click: Element is not visible`. Clicking the stable editor tab is
+ * reliable. The debug specs create their `.cls`/`.apex` files (which leaves them open in a tab)
+ * before driving a launch, so the tab is always present.
+ */
+export const activateEditorTab = async (page: Page, fileName: string, timeout = 15_000): Promise<void> => {
+  const tab = page.getByRole('tab', { name: new RegExp(escapeRegExp(fileName)) }).first();
+  await tab.waitFor({ state: 'visible', timeout });
+  await tab.click({ force: true });
+  await page
+    .locator(`${EDITOR_WITH_URI}[data-uri$="${fileName}"]`)
+    .first()
+    .waitFor({ state: 'visible', timeout: 10_000 });
+};
 
 /** The floating debug toolbar (Continue / Step / Stop). Present whenever a DAP session is live. */
 export const DEBUG_TOOLBAR = '.debug-toolbar';
@@ -44,19 +65,37 @@ export const openVariablesView = async (page: Page, timeout = 30_000): Promise<L
 };
 
 /**
- * Expand every collapsed scope row (Local/Static) in the VARIABLES tree so locals render.
- * Always clicks the FIRST remaining collapsed row: clicking a twistie mutates the live NodeList, so
- * an index-based loop would target shifted rows and could re-collapse a scope. Driving the
- * first-collapsed row to zero is stable.
+ * Expand every collapsed scope row (Local/Static/Global) in the VARIABLES tree so locals render.
+ * Clicks each top-level (aria-level="1") scope's twistie once, tracked by aria-label. An empty scope
+ * (e.g. Global with no variables) never leaves the collapsed state, so we must NOT drive the
+ * collapsed set to zero (that would spin until timeout on the empty scope) — instead attempt each
+ * scope exactly once. Clicking a twistie mutates the live list, so re-query after each click.
  */
 export const expandAllVariableScopes = async (variablesView: Locator, timeout = 30_000): Promise<void> => {
-  const firstCollapsed = variablesView.locator('.monaco-list-row[aria-expanded="false"]').first();
-  await expect(async () => {
-    if (await firstCollapsed.isVisible()) {
-      await firstCollapsed.locator('.monaco-tl-twistie').click({ force: true });
+  const deadline = Date.now() + timeout;
+  const attempted = new Set<string>();
+  while (Date.now() < deadline) {
+    const collapsed = variablesView.locator('.monaco-list-row[aria-level="1"][aria-expanded="false"]');
+    const count = await collapsed.count();
+    let clickedOne = false;
+    for (let i = 0; i < count; i++) {
+      const row = collapsed.nth(i);
+      const label = (await row.getAttribute('aria-label').catch(() => null)) ?? `row-${i}`;
+      if (attempted.has(label)) {
+        continue;
+      }
+      attempted.add(label);
+      await row
+        .locator('.monaco-tl-twistie')
+        .click({ force: true })
+        .catch(() => {});
+      clickedOne = true;
+      break; // list mutated by the expand; re-query from the top
     }
-    await expect(firstCollapsed).toBeHidden();
-  }).toPass({ timeout });
+    if (!clickedOne) {
+      break; // every collapsed scope has been attempted once
+    }
+  }
 };
 
 /**

--- a/packages/playwright-vscode-ext/src/pages/debug.ts
+++ b/packages/playwright-vscode-ext/src/pages/debug.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { expect, type Locator, type Page } from '@playwright/test';
+import { WORKBENCH } from '../utils/locators';
+import { executeCommandWithCommandPalette } from './commands';
+
+/** The floating debug toolbar (Continue / Step / Stop). Present whenever a DAP session is live. */
+export const DEBUG_TOOLBAR = '.debug-toolbar';
+
+/** The Run and Debug CALL STACK tree. */
+export const DEBUG_CALL_STACK = `${WORKBENCH} .debug-call-stack`;
+
+/** The Run and Debug VARIABLES tree. */
+export const DEBUG_VARIABLES = `${WORKBENCH} .debug-variables`;
+
+/** Assert the debug toolbar is visible (i.e. a debug session is live). */
+export const assertDebugToolbarVisible = async (page: Page, timeout = 60_000): Promise<void> => {
+  await expect(page.locator(DEBUG_TOOLBAR)).toBeVisible({ timeout });
+};
+
+/** Show the Run and Debug viewlet. Launching replay does not open it automatically. */
+export const showRunAndDebugView = async (page: Page): Promise<void> => {
+  await executeCommandWithCommandPalette(page, 'View: Show Run and Debug');
+};
+
+/** All rows of the CALL STACK tree. Show the Run and Debug view first via {@link showRunAndDebugView}. */
+export const getCallStackRows = (page: Page): Locator => page.locator(`${DEBUG_CALL_STACK} .monaco-list-row`);
+
+/**
+ * Show the Run and Debug view, focus the VARIABLES view, and return its locator once visible.
+ * Launching a replay session does not open the viewlet, so show it before focusing VARIABLES.
+ */
+export const openVariablesView = async (page: Page, timeout = 30_000): Promise<Locator> => {
+  await showRunAndDebugView(page);
+  await executeCommandWithCommandPalette(page, 'Run and Debug: Focus on Variables View');
+  const variablesView = page.locator(DEBUG_VARIABLES);
+  await variablesView.waitFor({ state: 'visible', timeout });
+  return variablesView;
+};
+
+/**
+ * Expand every collapsed scope row (Local/Static) in the VARIABLES tree so locals render.
+ * Always clicks the FIRST remaining collapsed row: clicking a twistie mutates the live NodeList, so
+ * an index-based loop would target shifted rows and could re-collapse a scope. Driving the
+ * first-collapsed row to zero is stable.
+ */
+export const expandAllVariableScopes = async (variablesView: Locator, timeout = 30_000): Promise<void> => {
+  const firstCollapsed = variablesView.locator('.monaco-list-row[aria-expanded="false"]').first();
+  await expect(async () => {
+    if (await firstCollapsed.isVisible()) {
+      await firstCollapsed.locator('.monaco-tl-twistie').click({ force: true });
+    }
+    await expect(firstCollapsed).toBeHidden();
+  }).toPass({ timeout });
+};
+
+/**
+ * Locate a VARIABLES row by its variable-name cell (exact match on the highlighted-label text).
+ * Expand its parent scopes first via {@link expandAllVariableScopes}.
+ */
+export const getVariableRow = (variablesView: Locator, page: Page, name: string): Locator =>
+  variablesView
+    .locator('.monaco-list-row')
+    .filter({ has: page.locator('.monaco-highlighted-label', { hasText: new RegExp(`^${name}$`) }) })
+    .first();
+
+/**
+ * Expand a nested variable's twistie and wait for one of its child property rows to render.
+ * Selects the row then presses ArrowRight: on a Monaco tree Right expands a collapsed row (never
+ * collapses an expanded one), so it's idempotent under CI timing where the row may already be
+ * expanded. Re-drives until a matching child appears.
+ */
+export const expandNestedVariable = async (
+  page: Page,
+  variablesView: Locator,
+  parentRow: Locator,
+  childMatcher: RegExp,
+  timeout = 30_000
+): Promise<Locator> => {
+  const childRow = variablesView.locator('.monaco-list-row').filter({ hasText: childMatcher }).first();
+  await expect(async () => {
+    await parentRow.click({ force: true });
+    await page.keyboard.press('ArrowRight');
+    await expect(childRow).toBeVisible({ timeout: 5000 });
+  }).toPass({ timeout });
+  return childRow;
+};
+
+/** Continue debug session (dismiss hover, Escape, then F5). Repeats until session ends. */
+export const continueDebugSession = async (page: Page, maxContinues = 2): Promise<void> => {
+  const toolbar = page.locator(DEBUG_TOOLBAR);
+  for (let i = 0; i < maxContinues; i++) {
+    await toolbar.waitFor({ state: 'visible', timeout: 15_000 });
+    // Click editor area to dismiss search-bar hover that can cover debug toolbar and block F5
+    await page.locator(`${WORKBENCH} .editor-instance .view-lines`).first().click({ force: true });
+    await page.keyboard.press('Escape');
+    await page.keyboard.press('F5');
+    // Catch intentionally swallows rejection to detect debug session end (pre-existing pattern)
+    const sessionEnded = await expect(toolbar)
+      .not.toBeVisible({ timeout: 30_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (sessionEnded) break;
+  }
+  await expect(toolbar).not.toBeVisible({ timeout: 45_000 });
+};
+
+/**
+ * Guaranteed debug-session teardown for a shared, persistent workbench: a session left running
+ * would poison the next test. If the toolbar is still up (a mid-test failure never reached the
+ * clean stop), stop the session and wait for it to disappear. Best-effort — never throws, so it's
+ * safe to call unconditionally from `afterEach`.
+ */
+export const stopDebugSession = async (page: Page, timeout = 30_000): Promise<void> => {
+  const toolbar = page.locator(DEBUG_TOOLBAR);
+  if (await toolbar.isVisible().catch(() => false)) {
+    await executeCommandWithCommandPalette(page, 'Debug: Stop').catch(() => {});
+    await expect(toolbar)
+      .not.toBeVisible({ timeout })
+      .catch(() => {});
+  }
+};

--- a/packages/playwright-vscode-ext/src/pages/statusBar.ts
+++ b/packages/playwright-vscode-ext/src/pages/statusBar.ts
@@ -114,3 +114,53 @@ export const expectOrgPickerListsOrg = async (
     `Org picker should list org "${alias}"`
   ).toBeVisible({ timeout: opts?.timeout ?? 10_000 });
 };
+
+/**
+ * Switch the default org through the status-bar picker AND confirm it took, re-driving the whole
+ * interaction if the status bar hasn't settled to `expectLabel`.
+ *
+ * Why this exists (container flake): `clickOrgPickerStatusBar` → `selectOrgInPicker` →
+ * `expectOrgPickerStatusBar` composed inline is racy in the loaded Code Builder container. When a
+ * picker row click doesn't register (or the `TargetOrgRef` config write / status-bar watcher lags),
+ * the default never changes, so a plain `expectOrgPickerStatusBar` just waits for a label that will
+ * never appear and times out. A longer timeout alone can't fix that — the switch must be re-driven.
+ *
+ * Each `toPass` attempt: if the bar already shows `expectLabel`, done; otherwise dismiss any stray
+ * picker, re-open it via the label the bar currently shows (`fromLabel`), optionally assert the
+ * target org is listed (`assertListsOrg`, the pre-switch staleness guard), select the target
+ * (`filterText`, an alias or username), then confirm the bar settled. `toPass` retries the whole
+ * block, so a dropped click or a slow watcher refresh no longer fails the switch.
+ */
+export const switchDefaultOrgViaPicker = async (
+  page: Page,
+  opts: {
+    /** Label the status bar shows BEFORE the switch (used to locate + click the picker on each retry). */
+    fromLabel: string | RegExp;
+    /** Text typed into the picker to filter to the target org row (its alias, or username if unaliased). */
+    filterText: string;
+    /** Label the status bar must show AFTER the switch settles (the target org's alias or username). */
+    expectLabel: string | RegExp;
+    /** Optional pre-select staleness guard: assert the picker lists this org before selecting. */
+    assertListsOrg?: string;
+    /** Overall budget for the switch to take + the status bar to reflect it (default 60s). */
+    timeout?: number;
+  }
+): Promise<void> => {
+  const confirmItem = orgPickerStatusBarItem(page, opts.expectLabel);
+  await expect(async () => {
+    // Already settled on the target org — the switch took (possibly on a prior attempt).
+    if (await confirmItem.isVisible().catch(() => false)) {
+      return;
+    }
+    // Close any picker left open by a dropped click on the previous attempt, then re-drive.
+    await page.keyboard.press('Escape').catch(() => {});
+    await clickOrgPickerStatusBar(page, opts.fromLabel);
+    if (opts.assertListsOrg !== undefined) {
+      await expectOrgPickerListsOrg(page, opts.assertListsOrg);
+    }
+    await selectOrgInPicker(page, opts.filterText);
+    await expect(confirmItem, `Org picker status bar should show ${String(opts.expectLabel)}`).toBeVisible({
+      timeout: 20_000
+    });
+  }).toPass({ timeout: opts.timeout ?? 60_000 });
+};

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/helpers/debugHelpers.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/helpers/debugHelpers.ts
@@ -4,24 +4,8 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { expect, type Page } from '@playwright/test';
-import { WORKBENCH } from '@salesforce/playwright-vscode-ext';
 
-/** Continue debug session (dismiss hover, Escape, then F5). Repeats until session ends. */
-export const continueDebugSession = async (page: Page, maxContinues = 2): Promise<void> => {
-  const toolbar = page.locator('.debug-toolbar');
-  for (let i = 0; i < maxContinues; i++) {
-    await toolbar.waitFor({ state: 'visible', timeout: 15_000 });
-    // Click editor area to dismiss search-bar hover that can cover debug toolbar and block F5
-    await page.locator(`${WORKBENCH} .editor-instance .view-lines`).first().click({ force: true });
-    await page.keyboard.press('Escape');
-    await page.keyboard.press('F5');
-    // Catch intentionally swallows rejection to detect debug session end (pre-existing pattern)
-    const sessionEnded = await expect(toolbar)
-      .not.toBeVisible({ timeout: 30_000 })
-      .then(() => true)
-      .catch(() => false);
-    if (sessionEnded) break;
-  }
-  await expect(toolbar).not.toBeVisible({ timeout: 45_000 });
-};
+// Re-export the shared debug-view helpers so existing desktop specs keep importing from
+// `../helpers/debugHelpers`. The implementations now live in the shared package
+// (`@salesforce/playwright-vscode-ext` -> src/pages/debug.ts) so container specs can use them too.
+export { continueDebugSession } from '@salesforce/playwright-vscode-ext';

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/apexReplayDebugger.container.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/apexReplayDebugger.container.spec.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Spike (ADR 0022, W-23898526): the FIRST live apex-replay DAP session driven through code-server.
+ * The gating unknown for porting the interactive-debug specs is whether a real replay session — a
+ * local Node adapter (`type: apex-replay`) replaying a debug log — launches and renders the debug UI
+ * (`.debug-toolbar`, `.debug-call-stack`, `.debug-variables`) in the container's browser-served
+ * workbench, then continues/stops cleanly. This ports the SIMPLEST launch path from
+ * debugAnonymousApex.desktop (Launch Apex Replay Debugger with Selected File on a `.apex` script),
+ * adapted to the boot (default target) org — no per-test org creation, no trace flag (the anonymous
+ * debug delegate produces the log inline). Hardened for the shared, persistent workbench: a unique
+ * per-run script name, beforeEach reset, and a guaranteed debug-session teardown in afterEach so a
+ * leaked session can't poison the next test.
+ */
+
+import { expect } from '@playwright/test';
+import {
+  clearAllNotifications,
+  closeAllEditors,
+  closeWelcomeTabs,
+  createAndOpenApexScript,
+  ensureSecondarySideBarHidden,
+  executeCommandWithCommandPalette,
+  openFileByName,
+  saveScreenshot,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  validateNoCriticalErrors,
+  WORKBENCH
+} from '@salesforce/playwright-vscode-ext';
+
+import packageNls from '../../../../package.nls.json';
+import { containerTest as test } from '../../fixtures/containerFixtures';
+import { continueDebugSession } from '../../helpers/debugHelpers';
+
+const DEBUG_TOOLBAR = '.debug-toolbar';
+
+// Shared, persistent workbench: reset editors and notifications before each test rather than
+// assuming a clean slate. No org setup — every test uses the container's boot (default) org.
+test.beforeEach(async ({ page }) => {
+  await closeWelcomeTabs(page);
+  await ensureSecondarySideBarHidden(page);
+  await closeAllEditors(page);
+  await clearAllNotifications(page);
+});
+
+// Guaranteed debug-session teardown: a session left running would poison the next test in the shared
+// workbench. If the toolbar is still up (a mid-test failure never reached the clean stop), stop the
+// session and wait for it to disappear. Best-effort — never fail teardown itself.
+test.afterEach(async ({ page }) => {
+  const toolbar = page.locator(DEBUG_TOOLBAR);
+  if (await toolbar.isVisible().catch(() => false)) {
+    await executeCommandWithCommandPalette(page, 'Debug: Stop').catch(() => {});
+    await expect(toolbar)
+      .not.toBeVisible({ timeout: 30_000 })
+      .catch(() => {});
+  }
+});
+
+test('Apex Replay Debugger (Code Builder): launches a replay session and renders the debug view', async ({ page }) => {
+  test.setTimeout(600_000);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  // Unique per-run name so the shared, persistent workbench never collides with a script left by a
+  // prior run.
+  const scriptName = `ReplaySpike_${Date.now().toString(36)}`;
+
+  await test.step('create and open an anonymous apex script in the boot-org workspace', async () => {
+    await ensureSecondarySideBarHidden(page);
+    await createAndOpenApexScript(page, { name: scriptName, content: "System.debug('replay spike');" });
+    await saveScreenshot(page, 'setup.anon-script-open.png');
+  });
+
+  await test.step('launch the replay debugger with the selected file — toolbar must appear', async () => {
+    await openFileByName(page, `${scriptName}.apex`);
+    await executeCommandWithCommandPalette(page, packageNls.launch_apex_replay_debugger_with_selected_file as string);
+    // Replay pauses on entry: the debug toolbar appearing is the gating unknown — a live DAP session
+    // driven through code-server. Long timeout covers executing the anon apex against the boot org
+    // and the adapter spawning server-side.
+    await expect(page.locator(DEBUG_TOOLBAR)).toBeVisible({ timeout: 60_000 });
+    await saveScreenshot(page, 'step.replay-launched.png');
+  });
+
+  await test.step('the Run and Debug view renders a call stack and a variables element', async () => {
+    // Launching replay does not open the Run and Debug viewlet — show it, then confirm the debug DOM
+    // (client-agnostic Monaco) actually renders in the browser-served workbench.
+    await executeCommandWithCommandPalette(page, 'View: Show Run and Debug');
+    const callStackRow = page.locator(`${WORKBENCH} .debug-call-stack .monaco-list-row`);
+    await expect(callStackRow.first()).toBeVisible({ timeout: 30_000 });
+
+    await executeCommandWithCommandPalette(page, 'Run and Debug: Focus on Variables View');
+    const variablesView = page.locator(`${WORKBENCH} .debug-variables`);
+    await expect(variablesView).toBeVisible({ timeout: 30_000 });
+    await saveScreenshot(page, 'step.debug-view-rendered.png');
+  });
+
+  await test.step('continue and end the debug session cleanly', async () => {
+    await continueDebugSession(page);
+    await saveScreenshot(page, 'step.session-ended.png');
+  });
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/apexReplayDebugger.container.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/apexReplayDebugger.container.spec.ts
@@ -6,42 +6,48 @@
  */
 
 /*
- * Spike (ADR 0022, W-23898526): the FIRST live apex-replay DAP session driven through code-server.
- * The gating unknown for porting the interactive-debug specs is whether a real replay session — a
- * local Node adapter (`type: apex-replay`) replaying a debug log — launches and renders the debug UI
- * (`.debug-toolbar`, `.debug-call-stack`, `.debug-variables`) in the container's browser-served
- * workbench, then continues/stops cleanly. This ports the SIMPLEST launch path from
- * debugAnonymousApex.desktop (Launch Apex Replay Debugger with Selected File on a `.apex` script),
- * adapted to the boot (default target) org — no per-test org creation, no trace flag (the anonymous
- * debug delegate produces the log inline). Hardened for the shared, persistent workbench: a unique
- * per-run script name, beforeEach reset, and a guaranteed debug-session teardown in afterEach so a
- * leaked session can't poison the next test.
+ * Container twin of apexReplayDebugger.desktop (ADR 0022, W-23898526). Covers the MULTI-LAUNCH flow
+ * distinct from debugAnonymousApex.container: create a trace flag, exec anon to produce a standalone
+ * `.log`, then launch a replay session from three different entry points —
+ *   - "Launch with Selected File" on the `.log` file
+ *   - "Launch with Last Log File"
+ *   - "Launch with Selected File" on a test `.cls`
+ * — continuing each to completion, then delete the trace flag. Runs against the container's boot
+ * (default target) org; per-test org creation is dropped. Hardened for the shared, persistent
+ * workbench: unique per-run class/script names, a beforeEach reset, and an afterEach that stops any
+ * leaked session.
  */
 
 import { expect } from '@playwright/test';
 import {
+  APEX_TRACE_FLAG_STATUS_BAR,
   clearAllNotifications,
+  clearOutputChannel,
   closeAllEditors,
   closeWelcomeTabs,
+  continueDebugSession,
+  createApexClass,
   createAndOpenApexScript,
+  ensureOutputPanelOpen,
   ensureSecondarySideBarHidden,
   executeCommandWithCommandPalette,
+  NOTIFICATION_LIST_ITEM,
   openFileByName,
+  removeAllDebugLevels,
   saveScreenshot,
+  selectOutputChannel,
   setupConsoleMonitoring,
   setupNetworkMonitoring,
+  stopDebugSession,
   validateNoCriticalErrors,
-  WORKBENCH
+  waitForOutputChannelText
 } from '@salesforce/playwright-vscode-ext';
 
+import apexLogNls from 'salesforcedx-vscode-apex-log/package.nls.json';
+import metadataNls from 'salesforcedx-vscode-metadata/package.nls.json';
 import packageNls from '../../../../package.nls.json';
 import { containerTest as test } from '../../fixtures/containerFixtures';
-import { continueDebugSession } from '../../helpers/debugHelpers';
 
-const DEBUG_TOOLBAR = '.debug-toolbar';
-
-// Shared, persistent workbench: reset editors and notifications before each test rather than
-// assuming a clean slate. No org setup — every test uses the container's boot (default) org.
 test.beforeEach(async ({ page }) => {
   await closeWelcomeTabs(page);
   await ensureSecondarySideBarHidden(page);
@@ -49,60 +55,126 @@ test.beforeEach(async ({ page }) => {
   await clearAllNotifications(page);
 });
 
-// Guaranteed debug-session teardown: a session left running would poison the next test in the shared
-// workbench. If the toolbar is still up (a mid-test failure never reached the clean stop), stop the
-// session and wait for it to disappear. Best-effort — never fail teardown itself.
 test.afterEach(async ({ page }) => {
-  const toolbar = page.locator(DEBUG_TOOLBAR);
-  if (await toolbar.isVisible().catch(() => false)) {
-    await executeCommandWithCommandPalette(page, 'Debug: Stop').catch(() => {});
-    await expect(toolbar)
-      .not.toBeVisible({ timeout: 30_000 })
-      .catch(() => {});
-  }
+  await stopDebugSession(page);
 });
 
-test('Apex Replay Debugger (Code Builder): launches a replay session and renders the debug view', async ({ page }) => {
+test('Apex Replay Debugger (Code Builder): trace flag, exec anon, replay from log file, last log, and test class', async ({
+  page
+}) => {
   test.setTimeout(600_000);
   const consoleErrors = setupConsoleMonitoring(page);
   const networkErrors = setupNetworkMonitoring(page);
 
-  // Unique per-run name so the shared, persistent workbench never collides with a script left by a
-  // prior run.
-  const scriptName = `ReplaySpike_${Date.now().toString(36)}`;
+  const uid = Date.now().toString(36);
+  const exampleClass = `ExampleApexClass_${uid}`;
+  const exampleTestClass = `ExampleApexClass_${uid}Test`;
+  const runScript = `RunExample_${uid}`;
 
-  await test.step('create and open an anonymous apex script in the boot-org workspace', async () => {
+  const exampleClassContent = [
+    `public with sharing class ${exampleClass} {`,
+    '  public static void SayHello(string name){',
+    "    System.debug('Hello, ' + name + '!');",
+    '  }',
+    '}'
+  ].join('\n');
+
+  const exampleTestContent = [
+    '@IsTest',
+    `public class ${exampleTestClass} {`,
+    '  @IsTest',
+    '  static void validateSayHello() {',
+    "    System.debug('Starting validate');",
+    `    ${exampleClass}.SayHello('Cody');`,
+    "    System.assertEquals(1, 1, 'all good');",
+    '  }',
+    '}'
+  ].join('\n');
+
+  await test.step('deploy an Apex class and its test to the boot org', async () => {
     await ensureSecondarySideBarHidden(page);
-    await createAndOpenApexScript(page, { name: scriptName, content: "System.debug('replay spike');" });
-    await saveScreenshot(page, 'setup.anon-script-open.png');
+    await createApexClass(page, exampleClass, exampleClassContent);
+    await createApexClass(page, exampleTestClass, exampleTestContent);
+    await ensureOutputPanelOpen(page);
+    await selectOutputChannel(page, 'Salesforce Metadata');
+    await executeCommandWithCommandPalette(
+      page,
+      metadataNls.project_deploy_start_ignore_conflicts_default_org_text as string
+    );
+    await waitForOutputChannelText(page, { expectedText: 'Starting metadata deployment', timeout: 90_000 });
+    await waitForOutputChannelText(page, { expectedText: 'Deployed Source', timeout: 120_000 });
+    await saveScreenshot(page, 'setup.classes-deployed.png');
   });
 
-  await test.step('launch the replay debugger with the selected file — toolbar must appear', async () => {
-    await openFileByName(page, `${scriptName}.apex`);
+  await test.step('wait for Apex LS indexing to complete', async () => {
+    // Apex LS must finish indexing before the test-class launch resolves the class name; CI is slower.
+    const indexingComplete = page.getByRole('button', { name: /Indexing complete/ });
+    await expect(indexingComplete).toBeVisible({ timeout: 120_000 });
+  });
+
+  await test.step('remove all debug levels so ReplayDebuggerLevels is auto-created', async () => {
+    await removeAllDebugLevels(page);
+  });
+
+  await test.step('create trace flag for current user', async () => {
+    await executeCommandWithCommandPalette(
+      page,
+      apexLogNls['apexLog.command.traceFlagsCreateForCurrentUser'] as string
+    );
+    const statusBar = page.locator(APEX_TRACE_FLAG_STATUS_BAR).filter({ hasText: /Tracing until/ });
+    await expect(statusBar).toBeVisible({ timeout: 60_000 });
+  });
+
+  await test.step('exec anon that calls the class so the org captures a debug log', async () => {
+    await ensureOutputPanelOpen(page);
+    await selectOutputChannel(page, 'Salesforce Apex Log');
+    await clearOutputChannel(page);
+
+    await createAndOpenApexScript(page, { name: runScript, content: `${exampleClass}.SayHello('Cody');` });
+    await executeCommandWithCommandPalette(page, apexLogNls['apexLog.command.executeDocument'] as string);
+
+    const successNotification = page
+      .locator(NOTIFICATION_LIST_ITEM)
+      .filter({ hasText: /executed successfully/i })
+      .first();
+    await expect(successNotification).toBeVisible({ timeout: 30_000 });
+    await successNotification.getByRole('button', { name: /Open Log/i }).click();
+    const logTab = page.locator('.tab').filter({ hasText: /\.log$/ });
+    await expect(logTab).toBeVisible({ timeout: 10_000 });
+    await saveScreenshot(page, 'step.exec-anon-done.png');
+  });
+
+  await test.step('launch replay with the selected .log file', async () => {
+    // Click the .log tab directly so it is the active editor: launchApexReplayDebuggerWithCurrentFile
+    // reads activeTextEditor and only sets LAST_OPENED_LOG_KEY when the active file is a .log — the
+    // key the next "launch from last log file" step relies on.
+    const logTab = page.locator('.tab').filter({ hasText: /\.log$/ });
+    await logTab.click({ force: true });
     await executeCommandWithCommandPalette(page, packageNls.launch_apex_replay_debugger_with_selected_file as string);
-    // Replay pauses on entry: the debug toolbar appearing is the gating unknown — a live DAP session
-    // driven through code-server. Long timeout covers executing the anon apex against the boot org
-    // and the adapter spawning server-side.
-    await expect(page.locator(DEBUG_TOOLBAR)).toBeVisible({ timeout: 60_000 });
-    await saveScreenshot(page, 'step.replay-launched.png');
-  });
-
-  await test.step('the Run and Debug view renders a call stack and a variables element', async () => {
-    // Launching replay does not open the Run and Debug viewlet — show it, then confirm the debug DOM
-    // (client-agnostic Monaco) actually renders in the browser-served workbench.
-    await executeCommandWithCommandPalette(page, 'View: Show Run and Debug');
-    const callStackRow = page.locator(`${WORKBENCH} .debug-call-stack .monaco-list-row`);
-    await expect(callStackRow.first()).toBeVisible({ timeout: 30_000 });
-
-    await executeCommandWithCommandPalette(page, 'Run and Debug: Focus on Variables View');
-    const variablesView = page.locator(`${WORKBENCH} .debug-variables`);
-    await expect(variablesView).toBeVisible({ timeout: 30_000 });
-    await saveScreenshot(page, 'step.debug-view-rendered.png');
-  });
-
-  await test.step('continue and end the debug session cleanly', async () => {
     await continueDebugSession(page);
-    await saveScreenshot(page, 'step.session-ended.png');
+    await saveScreenshot(page, 'step.replay-from-log.png');
+  });
+
+  await test.step('launch replay with the last log file', async () => {
+    await executeCommandWithCommandPalette(page, packageNls.launch_from_last_log_file as string);
+    await continueDebugSession(page);
+    await saveScreenshot(page, 'step.replay-from-last-log.png');
+  });
+
+  await test.step('launch replay with the test class', async () => {
+    await openFileByName(page, `${exampleTestClass}.cls`);
+    await executeCommandWithCommandPalette(page, packageNls.launch_apex_replay_debugger_with_selected_file as string);
+    await continueDebugSession(page);
+    await saveScreenshot(page, 'step.replay-from-test-class.png');
+  });
+
+  await test.step('turn off trace flag', async () => {
+    await executeCommandWithCommandPalette(
+      page,
+      apexLogNls['apexLog.command.traceFlagsDeleteForCurrentUser'] as string
+    );
+    const statusBar = page.locator(APEX_TRACE_FLAG_STATUS_BAR).filter({ hasText: /No Tracing/ });
+    await expect(statusBar).toBeVisible({ timeout: 30_000 });
   });
 
   await validateNoCriticalErrors(test, consoleErrors, networkErrors);

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/apexReplayDebugger.container.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/apexReplayDebugger.container.spec.ts
@@ -20,6 +20,7 @@
 
 import { expect } from '@playwright/test';
 import {
+  activateEditorTab,
   APEX_TRACE_FLAG_STATUS_BAR,
   clearAllNotifications,
   clearOutputChannel,
@@ -32,7 +33,6 @@ import {
   ensureSecondarySideBarHidden,
   executeCommandWithCommandPalette,
   NOTIFICATION_LIST_ITEM,
-  openFileByName,
   removeAllDebugLevels,
   saveScreenshot,
   selectOutputChannel,
@@ -79,11 +79,12 @@ test('Apex Replay Debugger (Code Builder): trace flag, exec anon, replay from lo
     '}'
   ].join('\n');
 
+  // Annotations kept INLINE with their declarations: once the Apex LS is warm, a bare `@IsTest` line
+  // typed into the code-server editor can have its trailing newline swallowed by a completion-accept,
+  // merging it into the next line and producing invalid Apex. Inlining avoids that.
   const exampleTestContent = [
-    '@IsTest',
-    `public class ${exampleTestClass} {`,
-    '  @IsTest',
-    '  static void validateSayHello() {',
+    `@IsTest public class ${exampleTestClass} {`,
+    '  @IsTest static void validateSayHello() {',
     "    System.debug('Starting validate');",
     `    ${exampleClass}.SayHello('Cody');`,
     "    System.assertEquals(1, 1, 'all good');",
@@ -108,8 +109,12 @@ test('Apex Replay Debugger (Code Builder): trace flag, exec anon, replay from lo
 
   await test.step('wait for Apex LS indexing to complete', async () => {
     // Apex LS must finish indexing before the test-class launch resolves the class name; CI is slower.
-    const indexingComplete = page.getByRole('button', { name: /Indexing complete/ });
-    await expect(indexingComplete).toBeVisible({ timeout: 120_000 });
+    // The desktop "Indexing complete" status-bar button never renders in the code-server image, so
+    // gate on the real indexing signal instead: the test class' CodeLens (Run/Debug Test) only
+    // appears once the LS has indexed it.
+    await activateEditorTab(page, `${exampleTestClass}.cls`);
+    const codelens = page.locator('.codelens-decoration a').filter({ hasText: /Run Test|Debug Test/ });
+    await expect(codelens.first()).toBeVisible({ timeout: 120_000 });
   });
 
   await test.step('remove all debug levels so ReplayDebuggerLevels is auto-created', async () => {
@@ -162,7 +167,7 @@ test('Apex Replay Debugger (Code Builder): trace flag, exec anon, replay from lo
   });
 
   await test.step('launch replay with the test class', async () => {
-    await openFileByName(page, `${exampleTestClass}.cls`);
+    await activateEditorTab(page, `${exampleTestClass}.cls`);
     await executeCommandWithCommandPalette(page, packageNls.launch_apex_replay_debugger_with_selected_file as string);
     await continueDebugSession(page);
     await saveScreenshot(page, 'step.replay-from-test-class.png');

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/apexReplayDebuggerVariables.container.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/apexReplayDebuggerVariables.container.spec.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Container twin of apexReplayDebuggerVariables.desktop (ADR 0022, W-23898526) — the highest-value
+ * interactive replay case: a breakpoint (F9) in a deployed class, replay pauses there, and a nested
+ * related-object local (`Contact c` carrying `Account`) expands in the VARIABLES tree with no
+ * "[object Object]". Runs against the container's boot (default target) org.
+ *
+ * Rather than a manual trace flag + separate exec-anon (the desktop path), it drives the anonymous
+ * debug delegate: "Launch Apex Replay Debugger with Selected File" on a `.apex` script that calls
+ * the deployed class. The delegate execs the anon apex at Apex_code=Finest (full VARIABLE_ASSIGNMENT
+ * detail), writes the log, and launches replay in one command — so no trace-flag setup is needed.
+ * Hardened for the shared, persistent workbench: unique per-run names, a beforeEach reset, and an
+ * afterEach that stops the session AND removes all breakpoints so they can't poison the next test.
+ */
+
+import { expect } from '@playwright/test';
+import {
+  clearAllNotifications,
+  closeAllEditors,
+  closeWelcomeTabs,
+  createApexClass,
+  createAndOpenApexScript,
+  EDITOR_WITH_URI,
+  ensureOutputPanelOpen,
+  ensureSecondarySideBarHidden,
+  executeCommandWithCommandPalette,
+  expandAllVariableScopes,
+  expandNestedVariable,
+  getCallStackRows,
+  getVariableRow,
+  openFileByName,
+  openVariablesView,
+  saveScreenshot,
+  selectOutputChannel,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  showRunAndDebugView,
+  stopDebugSession,
+  validateNoCriticalErrors,
+  waitForOutputChannelText,
+  WORKBENCH
+} from '@salesforce/playwright-vscode-ext';
+
+import metadataNls from 'salesforcedx-vscode-metadata/package.nls.json';
+import packageNls from '../../../../package.nls.json';
+import { containerTest as test } from '../../fixtures/containerFixtures';
+
+// Class that builds nested SObject relationships in memory so they serialize as a
+// nested-object VARIABLE_ASSIGNMENT (`{"Account":{"Name":"Acme"}}`) in the debug log.
+// System.debug on the line below is the breakpoint target.
+const nestedClassContent = [
+  'public with sharing class NestedRelExample {',
+  '  public static void build() {',
+  "    Account a = new Account(Name = 'Acme');",
+  "    Contact c = new Contact(LastName = 'Bond', Account = a);",
+  '    System.debug(c);',
+  '  }',
+  '}'
+].join('\n');
+
+test.beforeEach(async ({ page }) => {
+  await closeWelcomeTabs(page);
+  await ensureSecondarySideBarHidden(page);
+  await closeAllEditors(page);
+  await clearAllNotifications(page);
+});
+
+// Stop the session AND remove all breakpoints — a leaked breakpoint would pause an unrelated later
+// spec's replay on the same shared workbench. Best-effort.
+test.afterEach(async ({ page }) => {
+  await stopDebugSession(page);
+  await executeCommandWithCommandPalette(page, 'Debug: Remove All Breakpoints').catch(() => {});
+});
+
+test('Apex Replay Debugger Variables (Code Builder): nested related-object VARIABLES expand (no [object Object])', async ({
+  page
+}) => {
+  test.setTimeout(600_000);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  const className = `NestedRelExample_${Date.now().toString(36)}`;
+  const scriptName = `RunNested_${Date.now().toString(36)}`;
+
+  await test.step('deploy NestedRelExample to the boot org', async () => {
+    await createApexClass(page, className, nestedClassContent.replaceAll('NestedRelExample', className));
+    await ensureOutputPanelOpen(page);
+    await selectOutputChannel(page, 'Salesforce Metadata');
+    await executeCommandWithCommandPalette(
+      page,
+      metadataNls.project_deploy_start_ignore_conflicts_default_org_text as string
+    );
+    await waitForOutputChannelText(page, { expectedText: 'Starting metadata deployment', timeout: 90_000 });
+    await waitForOutputChannelText(page, { expectedText: 'Deployed Source', timeout: 120_000 });
+    await saveScreenshot(page, 'setup.class-deployed.png');
+  });
+
+  await test.step('create an anon script that invokes the class .build()', async () => {
+    await createAndOpenApexScript(page, { name: scriptName, content: `${className}.build();` });
+    await saveScreenshot(page, 'setup.run-script-open.png');
+  });
+
+  await test.step('set breakpoint on the System.debug line in the class', async () => {
+    await openFileByName(page, `${className}.cls`);
+    const editor = page.locator(`${EDITOR_WITH_URI}[data-uri$="${className}.cls"]`);
+    await editor.waitFor({ state: 'visible', timeout: 15_000 });
+    const debugLine = editor.locator('.view-line').filter({ hasText: 'System.debug(c);' }).first();
+    await expect(debugLine).toBeVisible({ timeout: 15_000 });
+    await debugLine.click();
+    // F9 toggles a breakpoint at the current caret line
+    await page.keyboard.press('F9');
+    const breakpointGlyph = page.locator('div.codicon-debug-breakpoint');
+    await expect(breakpointGlyph.first()).toBeVisible({ timeout: 15_000 });
+  });
+
+  await test.step('launch replay via the anon script and pause at the breakpoint', async () => {
+    await openFileByName(page, `${scriptName}.apex`);
+    await executeCommandWithCommandPalette(page, packageNls.launch_apex_replay_debugger_with_selected_file as string);
+    // Replay pauses on entry first (debug toolbar appears)
+    await expect(page.locator('.debug-toolbar')).toBeVisible({ timeout: 60_000 });
+    // Continue (F5) to run to the breakpoint on the System.debug line where `c` is assigned
+    await page.keyboard.press('F5');
+    // Confirm we paused in the class (not entry) via the call stack frame
+    await showRunAndDebugView(page);
+    const stackFrame = getCallStackRows(page).filter({ hasText: new RegExp(className) });
+    await expect(stackFrame.first()).toBeVisible({ timeout: 30_000 });
+    await saveScreenshot(page, 'step.replay-paused.png');
+  });
+
+  await test.step('assert nested local expands and renders no [object Object]', async () => {
+    const variablesView = await openVariablesView(page);
+    await expandAllVariableScopes(variablesView);
+
+    // The Contact local `c` carries the nested Account relationship.
+    const nestedRow = getVariableRow(variablesView, page, 'c');
+    await expect(nestedRow).toBeVisible({ timeout: 30_000 });
+    // Symptom assertion: nested value must not render as [object Object]
+    await expect(nestedRow).not.toContainText('[object Object]');
+
+    // Expand twistie present (collapsible affordance)
+    const twistie = nestedRow.locator('.monaco-tl-twistie');
+    await expect(twistie).toBeVisible({ timeout: 10_000 });
+
+    // Expand `c` and confirm a child property row (LastName/Account) becomes visible.
+    await expandNestedVariable(page, variablesView, nestedRow, /LastName|Account/);
+
+    // No row anywhere renders [object Object]
+    await expect(variablesView.locator('.monaco-list-row', { hasText: '[object Object]' })).toHaveCount(0);
+    await saveScreenshot(page, 'step.nested-variables-expanded.png');
+  });
+
+  await test.step('continue and end debug session', async () => {
+    // Click editor area to dismiss search-bar hover that can cover debug toolbar and block F5
+    await page.locator(`${WORKBENCH} .editor-instance .view-lines`).first().click({ force: true });
+    await page.keyboard.press('Escape');
+    await page.keyboard.press('F5');
+    await expect(page.locator('.debug-toolbar')).not.toBeVisible({ timeout: 45_000 });
+  });
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/apexReplayDebuggerVariables.container.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/apexReplayDebuggerVariables.container.spec.ts
@@ -21,6 +21,7 @@
 
 import { expect } from '@playwright/test';
 import {
+  activateEditorTab,
   clearAllNotifications,
   closeAllEditors,
   closeWelcomeTabs,
@@ -34,7 +35,6 @@ import {
   expandNestedVariable,
   getCallStackRows,
   getVariableRow,
-  openFileByName,
   openVariablesView,
   saveScreenshot,
   selectOutputChannel,
@@ -107,7 +107,7 @@ test('Apex Replay Debugger Variables (Code Builder): nested related-object VARIA
   });
 
   await test.step('set breakpoint on the System.debug line in the class', async () => {
-    await openFileByName(page, `${className}.cls`);
+    await activateEditorTab(page, `${className}.cls`);
     const editor = page.locator(`${EDITOR_WITH_URI}[data-uri$="${className}.cls"]`);
     await editor.waitFor({ state: 'visible', timeout: 15_000 });
     const debugLine = editor.locator('.view-line').filter({ hasText: 'System.debug(c);' }).first();
@@ -120,7 +120,7 @@ test('Apex Replay Debugger Variables (Code Builder): nested related-object VARIA
   });
 
   await test.step('launch replay via the anon script and pause at the breakpoint', async () => {
-    await openFileByName(page, `${scriptName}.apex`);
+    await activateEditorTab(page, `${scriptName}.apex`);
     await executeCommandWithCommandPalette(page, packageNls.launch_apex_replay_debugger_with_selected_file as string);
     // Replay pauses on entry first (debug toolbar appears)
     await expect(page.locator('.debug-toolbar')).toBeVisible({ timeout: 60_000 });

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/apexReplayDebuggerVariables.container.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/apexReplayDebuggerVariables.container.spec.ts
@@ -110,6 +110,11 @@ test('Apex Replay Debugger Variables (Code Builder): nested related-object VARIA
     await activateEditorTab(page, `${className}.cls`);
     const editor = page.locator(`${EDITOR_WITH_URI}[data-uri$="${className}.cls"]`);
     await editor.waitFor({ state: 'visible', timeout: 15_000 });
+    // The breakpoint only BINDS (and replay pauses on it) once the Apex LS has indexed the class and
+    // can supply its line-breakpoint typeRefs. On a cold code-server the LS is still indexing, so gate
+    // on the Apex language-status "Indexing complete" button — it renders only while an Apex editor is
+    // active (the .cls above is), which is why it must be waited on here, not after a deploy.
+    await expect(page.getByRole('button', { name: /Indexing complete/ })).toBeVisible({ timeout: 120_000 });
     const debugLine = editor.locator('.view-line').filter({ hasText: 'System.debug(c);' }).first();
     await expect(debugLine).toBeVisible({ timeout: 15_000 });
     await debugLine.click();

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/checkpoints.container.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/checkpoints.container.spec.ts
@@ -21,6 +21,7 @@
 
 import { expect } from '@playwright/test';
 import {
+  activateEditorTab,
   APEX_TRACE_FLAG_STATUS_BAR,
   clearAllNotifications,
   clearOutputChannel,
@@ -35,7 +36,6 @@ import {
   ensureSecondarySideBarHidden,
   executeCommandWithCommandPalette,
   NOTIFICATION_LIST_ITEM,
-  openFileByName,
   removeAllDebugLevels,
   saveScreenshot,
   selectOutputChannel,
@@ -108,7 +108,7 @@ test('Checkpoints (Code Builder): Toggle Checkpoint, Update Checkpoints in Org, 
   });
 
   await test.step('toggle a checkpoint at the `return newAcct;` line', async () => {
-    await openFileByName(page, `${className}.cls`);
+    await activateEditorTab(page, `${className}.cls`);
     // Click directly on the `return newAcct;` line — sfToggleCheckpoint reads
     // activeTextEditor.selection.start.line, so the caret must sit on a valid statement.
     const editor = page.locator(`${EDITOR_WITH_URI}[data-uri$="${className}.cls"]`);
@@ -133,14 +133,21 @@ test('Checkpoints (Code Builder): Toggle Checkpoint, Update Checkpoints in Org, 
     // Dedupe guard (W-23465461): exactly one 'Apex Replay Debugger' output channel.
     const channelCount = await countOutputChannelOptions(page, 'Apex Replay Debugger');
     expect(channelCount, "expected exactly one 'Apex Replay Debugger' output channel").toBe(1);
-    await clearOutputChannel(page);
 
-    await executeCommandWithCommandPalette(page, packageNls.sf_update_checkpoints_in_org as string);
+    // Step 2 ("Retrieving source and line information") calls the Apex LS, whose readiness gate waits
+    // only ~3s. On a cold code-server the LS indexing can still be running, so the command aborts
+    // before step 6. There is no CodeLens on this plain (non-test) class to gate LS readiness on, so
+    // retry the command — clearing the channel each attempt — until it reaches step 6, riding out the
+    // LS cold-start. When the LS is already warm (shared workbench) the first attempt succeeds.
+    await expect(async () => {
+      await clearOutputChannel(page);
+      await executeCommandWithCommandPalette(page, packageNls.sf_update_checkpoints_in_org as string);
+      await waitForOutputChannelText(page, {
+        expectedText: 'SFDX: Update Checkpoints in Org, Step 6 of 6: Confirming successful checkpoint creation',
+        timeout: 45_000
+      });
+    }).toPass({ timeout: 240_000 });
 
-    await waitForOutputChannelText(page, {
-      expectedText: 'SFDX: Update Checkpoints in Org, Step 6 of 6: Confirming successful checkpoint creation',
-      timeout: 120_000
-    });
     await waitForOutputChannelText(page, {
       expectedText: 'Ended SFDX: Update Checkpoints in Org',
       timeout: 60_000

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/checkpoints.container.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/checkpoints.container.spec.ts
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Container twin of checkpoints.desktop (ADR 0022, W-23898526). Exercises the full checkpoint flow
+ * against the container's boot (default target) org:
+ *   - Toggle Checkpoint at a statement line (conditional-breakpoint glyph appears)
+ *   - Update Checkpoints in Org succeeds (Step 6 of 6 + "Ended ..." in the output), with the
+ *     single-output-channel dedupe guard (W-23465461)
+ *   - trace flag + exec anon that hits the checkpoint line (org captures a heap dump), then replay
+ *     from the resulting `.log` and assert the Debug Console shows NO heap_dump_error wrap-up text —
+ *     the host↔adapter heapDumpResults + multi-dump-fetch regression guard (W-23355895).
+ * errorPaths.container already covers the Update-Checkpoints warning/limit error paths, so this
+ * covers the SUCCESS path + replay. Hardened for the shared workbench: unique per-run names, a
+ * beforeEach reset, and an afterEach that stops the session and removes checkpoints/breakpoints.
+ */
+
+import { expect } from '@playwright/test';
+import {
+  APEX_TRACE_FLAG_STATUS_BAR,
+  clearAllNotifications,
+  clearOutputChannel,
+  closeAllEditors,
+  closeWelcomeTabs,
+  continueDebugSession,
+  countOutputChannelOptions,
+  createApexClass,
+  createAndOpenApexScript,
+  EDITOR_WITH_URI,
+  ensureOutputPanelOpen,
+  ensureSecondarySideBarHidden,
+  executeCommandWithCommandPalette,
+  NOTIFICATION_LIST_ITEM,
+  openFileByName,
+  removeAllDebugLevels,
+  saveScreenshot,
+  selectOutputChannel,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  stopDebugSession,
+  validateNoCriticalErrors,
+  waitForOutputChannelText,
+  WORKBENCH
+} from '@salesforce/playwright-vscode-ext';
+
+import apexLogNls from 'salesforcedx-vscode-apex-log/package.nls.json';
+import metadataNls from 'salesforcedx-vscode-metadata/package.nls.json';
+import packageNls from '../../../../package.nls.json';
+import { containerTest as test } from '../../fixtures/containerFixtures';
+
+// Localized fragment of the base adapter's `heap_dump_error_wrap_up_text` — emitted to the Debug
+// Console only when host↔adapter heapDumpResults wiring fails.
+const HEAP_DUMP_ERROR_TEXT = /Problems were encountered while retrieving heap dump information/;
+
+test.beforeEach(async ({ page }) => {
+  await closeWelcomeTabs(page);
+  await ensureSecondarySideBarHidden(page);
+  await closeAllEditors(page);
+  await clearAllNotifications(page);
+});
+
+// Stop the session AND remove checkpoints/breakpoints — a leaked checkpoint would pause an unrelated
+// later spec's replay on the same shared workbench. Best-effort.
+test.afterEach(async ({ page }) => {
+  await stopDebugSession(page);
+  await executeCommandWithCommandPalette(page, 'Debug: Remove All Breakpoints').catch(() => {});
+});
+
+test('Checkpoints (Code Builder): Toggle Checkpoint, Update Checkpoints in Org, and heap-dump replay', async ({
+  page
+}) => {
+  test.setTimeout(600_000);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  const uid = Date.now().toString(36);
+  const className = `AccountService_${uid}`;
+  const runScript = `RunCheckpoint_${uid}`;
+
+  const accountServiceContent = [
+    `public with sharing class ${className} {`,
+    '  public Account createAccount(String accountName, String accountNumber, String tickerSymbol) {',
+    '    Account newAcct = new Account(',
+    '      Name = accountName,',
+    '      AccountNumber = accountNumber,',
+    '      TickerSymbol = accountNumber',
+    '    );',
+    '    return newAcct;',
+    '  }',
+    '}'
+  ].join('\n');
+
+  await test.step('deploy the class to the boot org', async () => {
+    await ensureSecondarySideBarHidden(page);
+    await createApexClass(page, className, accountServiceContent);
+    await ensureOutputPanelOpen(page);
+    await selectOutputChannel(page, 'Salesforce Metadata');
+    await executeCommandWithCommandPalette(
+      page,
+      metadataNls.project_deploy_start_ignore_conflicts_default_org_text as string
+    );
+    await waitForOutputChannelText(page, { expectedText: 'Starting metadata deployment', timeout: 90_000 });
+    await waitForOutputChannelText(page, { expectedText: 'Deployed Source', timeout: 120_000 });
+  });
+
+  await test.step('toggle a checkpoint at the `return newAcct;` line', async () => {
+    await openFileByName(page, `${className}.cls`);
+    // Click directly on the `return newAcct;` line — sfToggleCheckpoint reads
+    // activeTextEditor.selection.start.line, so the caret must sit on a valid statement.
+    const editor = page.locator(`${EDITOR_WITH_URI}[data-uri$="${className}.cls"]`);
+    await editor.waitFor({ state: 'visible', timeout: 15_000 });
+    const returnLine = editor.locator('.view-line').filter({ hasText: 'return newAcct;' }).first();
+    await expect(returnLine).toBeVisible({ timeout: 15_000 });
+    await returnLine.click();
+
+    // preserveSelection so the palette opener doesn't click the workbench root and reset the caret.
+    await executeCommandWithCommandPalette(page, packageNls.sf_toggle_checkpoint as string, undefined, {
+      preserveSelection: true
+    });
+
+    const checkpointGlyph = page.locator('div.codicon-debug-breakpoint-conditional');
+    await expect(checkpointGlyph.first()).toBeVisible({ timeout: 15_000 });
+    await saveScreenshot(page, 'step.checkpoint-toggled.png');
+  });
+
+  await test.step('update checkpoints in org', async () => {
+    await ensureOutputPanelOpen(page);
+    await selectOutputChannel(page, 'Apex Replay Debugger');
+    // Dedupe guard (W-23465461): exactly one 'Apex Replay Debugger' output channel.
+    const channelCount = await countOutputChannelOptions(page, 'Apex Replay Debugger');
+    expect(channelCount, "expected exactly one 'Apex Replay Debugger' output channel").toBe(1);
+    await clearOutputChannel(page);
+
+    await executeCommandWithCommandPalette(page, packageNls.sf_update_checkpoints_in_org as string);
+
+    await waitForOutputChannelText(page, {
+      expectedText: 'SFDX: Update Checkpoints in Org, Step 6 of 6: Confirming successful checkpoint creation',
+      timeout: 120_000
+    });
+    await waitForOutputChannelText(page, {
+      expectedText: 'Ended SFDX: Update Checkpoints in Org',
+      timeout: 60_000
+    });
+    await saveScreenshot(page, 'step.checkpoints-updated.png');
+  });
+
+  await test.step('remove all debug levels so ReplayDebuggerLevels is auto-created', async () => {
+    await removeAllDebugLevels(page);
+  });
+
+  await test.step('create trace flag for current user', async () => {
+    await executeCommandWithCommandPalette(
+      page,
+      apexLogNls['apexLog.command.traceFlagsCreateForCurrentUser'] as string
+    );
+    const statusBar = page.locator(APEX_TRACE_FLAG_STATUS_BAR).filter({ hasText: /Tracing until/ });
+    await expect(statusBar).toBeVisible({ timeout: 60_000 });
+  });
+
+  await test.step('exec anon that hits the checkpoint line so the org captures a heap dump', async () => {
+    await ensureOutputPanelOpen(page);
+    await selectOutputChannel(page, 'Salesforce Apex Log');
+    await clearOutputChannel(page);
+
+    await createAndOpenApexScript(page, {
+      name: runScript,
+      content: `new ${className}().createAccount('Acme', '123', 'ACME');`
+    });
+
+    await executeCommandWithCommandPalette(page, apexLogNls['apexLog.command.executeDocument'] as string);
+
+    const successNotification = page
+      .locator(NOTIFICATION_LIST_ITEM)
+      .filter({ hasText: /executed successfully/i })
+      .first();
+    await expect(successNotification).toBeVisible({ timeout: 30_000 });
+    await successNotification.getByRole('button', { name: /Open Log/i }).click();
+    const logTab = page.locator('.tab').filter({ hasText: /\.log$/ });
+    await expect(logTab).toBeVisible({ timeout: 10_000 });
+    await saveScreenshot(page, 'step.checkpoint-exec-anon-done.png');
+  });
+
+  await test.step('launch replay against the heap-dump log and assert no heap_dump_error', async () => {
+    await ensureOutputPanelOpen(page);
+    await selectOutputChannel(page, 'Apex Replay Debugger');
+    await clearOutputChannel(page);
+
+    const logTab = page.locator('.tab').filter({ hasText: /\.log$/ });
+    await logTab.click({ force: true });
+    await executeCommandWithCommandPalette(page, packageNls.launch_apex_replay_debugger_with_selected_file as string);
+    // Replay pauses on entry first (debug toolbar appears), then continue through the heap-dump line.
+    await expect(page.locator('.debug-toolbar')).toBeVisible({ timeout: 60_000 });
+    await continueDebugSession(page, 3);
+
+    // Regression guard: the Debug Console must NOT contain the heap-dump error wrap-up text.
+    await expect(
+      page.locator(`${WORKBENCH} .repl .monaco-list-row`).filter({ hasText: HEAP_DUMP_ERROR_TEXT })
+    ).toHaveCount(0);
+    await saveScreenshot(page, 'step.checkpoint-replay-done.png');
+  });
+
+  await test.step('turn off trace flag', async () => {
+    await executeCommandWithCommandPalette(
+      page,
+      apexLogNls['apexLog.command.traceFlagsDeleteForCurrentUser'] as string
+    );
+    const statusBar = page.locator(APEX_TRACE_FLAG_STATUS_BAR).filter({ hasText: /No Tracing/ });
+    await expect(statusBar).toBeVisible({ timeout: 30_000 });
+  });
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/debugAnonymousApex.container.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/debugAnonymousApex.container.spec.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Container twin of debugAnonymousApex.desktop (ADR 0022, W-23898526). This grew out of the spike
+ * that first proved a live apex-replay DAP session runs through code-server, so it keeps that
+ * spike's debug-view render assertions (`.debug-toolbar`, call stack, VARIABLES) in the
+ * "Launch with Selected File" case. Covers the three anonymous-apex entry points that produce a
+ * replay log INLINE (the anon debug delegate runs exec-anon at Apex_code=Finest), so no trace flag
+ * or per-test org setup is needed — every case uses the container's boot (default target) org:
+ *   - the "Debug" code lens on a `.apex` script
+ *   - "Launch Apex Replay Debugger with Selected File" on a `.apex` script (+ debug-view render)
+ *   - "Debug Anonymous Apex with Editor's Selected Text"
+ * Hardened for the shared, persistent workbench: a unique per-run script name, a beforeEach reset,
+ * and a guaranteed debug-session teardown in afterEach so a leaked session can't poison the next test.
+ */
+
+import { expect } from '@playwright/test';
+import {
+  assertDebugToolbarVisible,
+  clearAllNotifications,
+  clickCodeLens,
+  closeAllEditors,
+  closeWelcomeTabs,
+  continueDebugSession,
+  createAndOpenApexScript,
+  ensureSecondarySideBarHidden,
+  executeCommandWithCommandPalette,
+  getCallStackRows,
+  openFileByName,
+  openVariablesView,
+  saveScreenshot,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  stopDebugSession,
+  validateNoCriticalErrors
+} from '@salesforce/playwright-vscode-ext';
+
+import packageNls from '../../../../package.nls.json';
+import { containerTest as test } from '../../fixtures/containerFixtures';
+
+const ANON_APEX_CONTENT = "System.debug('hello from anonymous apex');";
+
+// Shared, persistent workbench: reset editors and notifications before each test rather than
+// assuming a clean slate. No org setup — every test uses the container's boot (default) org.
+test.beforeEach(async ({ page }) => {
+  await closeWelcomeTabs(page);
+  await ensureSecondarySideBarHidden(page);
+  await closeAllEditors(page);
+  await clearAllNotifications(page);
+});
+
+// Guaranteed debug-session teardown: a session left running would poison the next test in the shared
+// workbench. Best-effort — never fails teardown itself.
+test.afterEach(async ({ page }) => {
+  await stopDebugSession(page);
+});
+
+test('Debug Anonymous Apex (Code Builder): Debug code lens, Launch with Selected File, and Debug with Selected Text', async ({
+  page
+}) => {
+  test.setTimeout(600_000);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  // Unique per-run name so the shared, persistent workbench never collides with a script left by a
+  // prior run.
+  const scriptName = `DebugAnon_${Date.now().toString(36)}`;
+
+  await test.step('create and open an anonymous apex script in the boot-org workspace', async () => {
+    await ensureSecondarySideBarHidden(page);
+    await createAndOpenApexScript(page, { name: scriptName, content: ANON_APEX_CONTENT });
+    await saveScreenshot(page, 'setup.anon-script-open.png');
+  });
+
+  // ── Case 1: "Debug" code lens ──────────────────────────────────────────────
+  await test.step('click "Debug" code lens — debugger must launch and complete', async () => {
+    await openFileByName(page, `${scriptName}.apex`);
+    // The Apex LS renders "Execute | Debug" above .apex files; click the "Debug" link.
+    // Long timeout covers Apex LS cold-start indexing before code lenses appear.
+    await clickCodeLens(page, 'Debug', { timeout: 120_000 });
+    await continueDebugSession(page);
+    await saveScreenshot(page, 'step.debug-codelens.session-ended.png');
+  });
+
+  // ── Case 2: "Launch Apex Replay Debugger with Selected File" on .apex (+ render view) ─────
+  await test.step('launch the replay debugger with the selected file — toolbar must appear', async () => {
+    await openFileByName(page, `${scriptName}.apex`);
+    await executeCommandWithCommandPalette(page, packageNls.launch_apex_replay_debugger_with_selected_file as string);
+    // Replay pauses on entry: the debug toolbar appearing is the gating unknown — a live DAP session
+    // driven through code-server. Long timeout covers executing the anon apex against the boot org
+    // and the adapter spawning server-side.
+    await assertDebugToolbarVisible(page);
+    await saveScreenshot(page, 'step.replay-launched.png');
+  });
+
+  await test.step('the Run and Debug view renders a call stack and a variables element', async () => {
+    const callStackRow = getCallStackRows(page);
+    // Launching replay does not open the Run and Debug viewlet — openVariablesView shows it.
+    const variablesView = await openVariablesView(page);
+    await expect(callStackRow.first()).toBeVisible({ timeout: 30_000 });
+    await expect(variablesView).toBeVisible({ timeout: 30_000 });
+    await saveScreenshot(page, 'step.debug-view-rendered.png');
+  });
+
+  await test.step('continue and end the debug session cleanly', async () => {
+    await continueDebugSession(page);
+    await saveScreenshot(page, 'step.launch-selected.session-ended.png');
+  });
+
+  // ── Case 3: "Debug Anonymous Apex with Editor's Selected Text" ─────────────
+  await test.step('select all text and run "Debug Anonymous Apex with Editor\'s Selected Text"', async () => {
+    await openFileByName(page, `${scriptName}.apex`);
+
+    // Select the entire file contents — keep editor focus so editorHasSelection is true.
+    const editorArea = page.locator('.editor-instance .view-lines').first();
+    await editorArea.click({ force: true });
+    await page.keyboard.press('Control+a');
+
+    await executeCommandWithCommandPalette(page, packageNls.apex_debug_document_text as string, undefined, {
+      preserveSelection: true
+    });
+
+    await continueDebugSession(page);
+    await saveScreenshot(page, 'step.debug-selection.session-ended.png');
+  });
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/debugAnonymousApex.container.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/debugAnonymousApex.container.spec.ts
@@ -21,6 +21,7 @@
 
 import { expect } from '@playwright/test';
 import {
+  activateEditorTab,
   assertDebugToolbarVisible,
   clearAllNotifications,
   clickCodeLens,
@@ -31,7 +32,6 @@ import {
   ensureSecondarySideBarHidden,
   executeCommandWithCommandPalette,
   getCallStackRows,
-  openFileByName,
   openVariablesView,
   saveScreenshot,
   setupConsoleMonitoring,
@@ -79,7 +79,7 @@ test('Debug Anonymous Apex (Code Builder): Debug code lens, Launch with Selected
 
   // ── Case 1: "Debug" code lens ──────────────────────────────────────────────
   await test.step('click "Debug" code lens — debugger must launch and complete', async () => {
-    await openFileByName(page, `${scriptName}.apex`);
+    await activateEditorTab(page, `${scriptName}.apex`);
     // The Apex LS renders "Execute | Debug" above .apex files; click the "Debug" link.
     // Long timeout covers Apex LS cold-start indexing before code lenses appear.
     await clickCodeLens(page, 'Debug', { timeout: 120_000 });
@@ -89,7 +89,7 @@ test('Debug Anonymous Apex (Code Builder): Debug code lens, Launch with Selected
 
   // ── Case 2: "Launch Apex Replay Debugger with Selected File" on .apex (+ render view) ─────
   await test.step('launch the replay debugger with the selected file — toolbar must appear', async () => {
-    await openFileByName(page, `${scriptName}.apex`);
+    await activateEditorTab(page, `${scriptName}.apex`);
     await executeCommandWithCommandPalette(page, packageNls.launch_apex_replay_debugger_with_selected_file as string);
     // Replay pauses on entry: the debug toolbar appearing is the gating unknown — a live DAP session
     // driven through code-server. Long timeout covers executing the anon apex against the boot org
@@ -114,7 +114,8 @@ test('Debug Anonymous Apex (Code Builder): Debug code lens, Launch with Selected
 
   // ── Case 3: "Debug Anonymous Apex with Editor's Selected Text" ─────────────
   await test.step('select all text and run "Debug Anonymous Apex with Editor\'s Selected Text"', async () => {
-    await openFileByName(page, `${scriptName}.apex`);
+    // The .apex is already open from the earlier cases; activate its tab directly.
+    await activateEditorTab(page, `${scriptName}.apex`);
 
     // Select the entire file contents — keep editor focus so editorHasSelection is true.
     const editorArea = page.locator('.editor-instance .view-lines').first();

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/debugApexTests.container.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/debugApexTests.container.spec.ts
@@ -18,6 +18,7 @@
 
 import { expect, type Page } from '@playwright/test';
 import {
+  activateEditorTab,
   clearAllNotifications,
   clickCodeLens,
   closeAllEditors,
@@ -28,7 +29,6 @@ import {
   ensureSecondarySideBarHidden,
   executeCommandWithCommandPalette,
   NOTIFICATION_LIST_ITEM,
-  openFileByName,
   saveScreenshot,
   selectOutputChannel,
   setupConsoleMonitoring,
@@ -146,11 +146,14 @@ test('Debug Apex Tests (Code Builder): CodeLens and Test Explorer entry points',
     '}'
   ].join('\n');
 
+  // Annotations are kept INLINE with their declarations (not on their own line). Once the Apex LS is
+  // warm, a bare `@IsTest` line typed into the code-server editor triggers a completion popup whose
+  // Enter (the next newline) gets swallowed as an accept, merging the annotation into the following
+  // declaration and producing invalid Apex ("must be declared as IsTest" / "must have public
+  // visibility"). Inlining removes the bare-annotation-then-Enter that causes the merge.
   const class1TestContent = [
-    '@IsTest',
-    `public class ${class1Test} {`,
-    '  @IsTest',
-    '  static void validateSayHello() {',
+    `@IsTest public class ${class1Test} {`,
+    '  @IsTest static void validateSayHello() {',
     "    System.debug('Starting validate');",
     `    ${class1}.SayHello('Cody');`,
     "    System.assertEquals(1, 1, 'all good');",
@@ -166,12 +169,11 @@ test('Debug Apex Tests (Code Builder): CodeLens and Test Explorer entry points',
     '}'
   ].join('\n');
 
-  // Distinct method name from class1Test so the Test Explorer treeitem label is unique.
+  // Distinct method name from class1Test so the Test Explorer treeitem label is unique. Annotations
+  // kept inline (see class1TestContent) to avoid the warm-LS suggestion-accept newline merge.
   const class2TestContent = [
-    '@IsTest',
-    `public class ${class2Test} {`,
-    '  @IsTest',
-    '  static void validateSayHelloTwo() {',
+    `@IsTest public class ${class2Test} {`,
+    '  @IsTest static void validateSayHelloTwo() {',
     "    System.debug('Starting validate');",
     `    ${class2}.SayHello('Cody');`,
     "    System.assertEquals(1, 1, 'all good');",
@@ -197,16 +199,17 @@ test('Debug Apex Tests (Code Builder): CodeLens and Test Explorer entry points',
   });
 
   await test.step('wait for CodeLens in the test class', async () => {
-    const indexingComplete = page.getByRole('button', { name: /Indexing complete/ });
-    await expect(indexingComplete).toBeVisible({ timeout: 120_000 });
-    await openFileByName(page, `${class1Test}.cls`);
+    // The desktop "Indexing complete" status-bar button never renders in the code-server image, so
+    // gate on the real indexing signal: the test class' CodeLens (Run/Debug Test) only appears once
+    // the Apex LS has indexed it.
+    await activateEditorTab(page, `${class1Test}.cls`);
     const codelens = page.locator('.codelens-decoration a').filter({ hasText: /Run Test|Debug Test/ });
-    await expect(codelens.first()).toBeVisible({ timeout: 90_000 });
+    await expect(codelens.first()).toBeVisible({ timeout: 120_000 });
     await saveScreenshot(page, 'step.codelens-visible.png');
   });
 
   await test.step('Debug All Tests via class-level CodeLens', async () => {
-    await openFileByName(page, `${class1Test}.cls`);
+    await activateEditorTab(page, `${class1Test}.cls`);
     await clickCodeLens(page, 'Debug All Tests', { timeout: 180_000 });
     await waitForSuccessNotification(page);
     await continueDebugSession(page);
@@ -214,7 +217,7 @@ test('Debug Apex Tests (Code Builder): CodeLens and Test Explorer entry points',
   });
 
   await test.step('Debug Test via method-level CodeLens', async () => {
-    await openFileByName(page, `${class2Test}.cls`);
+    await activateEditorTab(page, `${class2Test}.cls`);
     await clickCodeLens(page, 'Debug Test', { timeout: 180_000 });
     await waitForSuccessNotification(page);
     await continueDebugSession(page);

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/debugApexTests.container.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/debugApexTests.container.spec.ts
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Container twin of debugApexTests.desktop (ADR 0022, W-23898526). Debugs Apex tests through both
+ * entry points against the container's boot (default target) org — the quickLaunch debugTest path
+ * manages its own trace flag, so no manual trace-flag setup is needed:
+ *   - "Debug All Tests" / "Debug Test" CodeLens
+ *   - "Debug Test" from the Test Explorer tree (class + method rows)
+ * Waits for Apex LS indexing/CodeLens like the apexReplayDebugger precedent. Hardened for the shared,
+ * persistent workbench: unique per-run class names, a beforeEach reset, and an afterEach that stops
+ * any leaked session.
+ */
+
+import { expect, type Page } from '@playwright/test';
+import {
+  clearAllNotifications,
+  clickCodeLens,
+  closeAllEditors,
+  closeWelcomeTabs,
+  continueDebugSession,
+  createApexClass,
+  ensureOutputPanelOpen,
+  ensureSecondarySideBarHidden,
+  executeCommandWithCommandPalette,
+  NOTIFICATION_LIST_ITEM,
+  openFileByName,
+  saveScreenshot,
+  selectOutputChannel,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  stopDebugSession,
+  validateNoCriticalErrors,
+  waitForOutputChannelText
+} from '@salesforce/playwright-vscode-ext';
+
+import apexTestingNls from 'salesforcedx-vscode-apex-testing/package.nls.json';
+import metadataNls from 'salesforcedx-vscode-metadata/package.nls.json';
+import { containerTest as test } from '../../fixtures/containerFixtures';
+
+/**
+ * Clicks a Test Explorer tree row's "Debug Test" action button using the retry/force-click pattern.
+ * Clicking a tree row re-renders the tree (selection highlight + action buttons), invalidating element
+ * refs — retry/force-click to tolerate the stale refs.
+ */
+const debugTestFromTreeItem = async (page: Page, name: RegExp): Promise<void> => {
+  const item = page.getByRole('treeitem', { name });
+  await item.waitFor({ state: 'visible', timeout: 30_000 });
+  await expect(async () => {
+    await item.click({ force: true });
+    await item.hover({ force: true });
+    const debugButton = item.getByRole('button', { name: /^Debug Test/ });
+    await debugButton.waitFor({ state: 'visible', timeout: 3000 });
+    await debugButton.click({ force: true });
+  }).toPass({ timeout: 30_000 });
+};
+
+// Test Explorer builds a Namespace → Package → Class → Method hierarchy; unpackaged local classes
+// nest under these two labels. Collapsed parents virtualize their children, so class/method rows are
+// not in the DOM until both parents are expanded.
+const LOCAL_NAMESPACE_LABEL = '(Local Namespace)';
+const UNPACKAGED_METADATA_LABEL = '(Unpackaged Metadata)';
+
+/** Expand a Test Explorer tree row via its twistie if collapsed; 400ms settle matches apex-testing helper. */
+const expandTreeRow = async (page: Page, rowLabel: string): Promise<void> => {
+  const row = page.locator('[role="treeitem"]').filter({ hasText: rowLabel }).first();
+  await row.waitFor({ state: 'visible', timeout: 15_000 });
+  const twistie = row.locator('.monaco-tl-twistie');
+  const collapsed = await twistie.evaluate(el => el.classList.contains('collapsed')).catch(() => false);
+  if (!collapsed) return;
+  await twistie.click({ force: true });
+  await page.waitForTimeout(400);
+};
+
+/** Expand the (Local Namespace) → (Unpackaged Metadata) parents so class/method rows render. */
+const expandNamespaceAndPackage = async (page: Page): Promise<void> => {
+  await expandTreeRow(page, LOCAL_NAMESPACE_LABEL);
+  await page
+    .locator('[role="treeitem"]')
+    .filter({ hasText: UNPACKAGED_METADATA_LABEL })
+    .first()
+    .waitFor({ state: 'visible', timeout: 10_000 });
+  await expandTreeRow(page, UNPACKAGED_METADATA_LABEL);
+};
+
+/**
+ * Runs `Test: Refresh Tests` and waits for the async tree rebuild. Discovery clears then rebuilds the
+ * tree after the command returns (mirrors apex-testing refreshTestsAndWaitForRebuild).
+ */
+const refreshTestsAndWaitForRebuild = async (page: Page): Promise<void> => {
+  await executeCommandWithCommandPalette(page, 'Test: Refresh Tests');
+  await page
+    .getByText(LOCAL_NAMESPACE_LABEL)
+    .first()
+    .waitFor({ state: 'hidden', timeout: 2000 })
+    .catch(() => {});
+  await expect(page.getByText(LOCAL_NAMESPACE_LABEL).first()).toBeVisible({ timeout: 60_000 });
+};
+
+/**
+ * Success notification suffix from the apex-testing NLS template `%s successfully ran`.
+ * `%s` = `Debug Test(s)` (replay-debugger i18n `debug_test_exec_name`, not in any package.nls.json),
+ * so match on the static `successfully ran` suffix rather than the interpolated full string.
+ */
+const SUCCESS_NOTIFICATION_SUFFIX = apexTestingNls.apex_test_successful_execution_message.replace('%s ', '');
+
+const waitForSuccessNotification = async (page: Page): Promise<void> => {
+  const successNotification = page
+    .locator(NOTIFICATION_LIST_ITEM)
+    .filter({ hasText: SUCCESS_NOTIFICATION_SUFFIX })
+    .first();
+  await expect(successNotification).toBeVisible({ timeout: 60_000 });
+};
+
+test.beforeEach(async ({ page }) => {
+  await closeWelcomeTabs(page);
+  await ensureSecondarySideBarHidden(page);
+  await closeAllEditors(page);
+  await clearAllNotifications(page);
+});
+
+test.afterEach(async ({ page }) => {
+  await stopDebugSession(page);
+});
+
+test('Debug Apex Tests (Code Builder): CodeLens and Test Explorer entry points', async ({ page }) => {
+  test.setTimeout(600_000);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  const uid = Date.now().toString(36);
+  const class1 = `ExampleApexClass1_${uid}`;
+  const class1Test = `ExampleApexClass1_${uid}Test`;
+  const class2 = `ExampleApexClass2_${uid}`;
+  const class2Test = `ExampleApexClass2_${uid}Test`;
+
+  const class1Content = [
+    `public with sharing class ${class1} {`,
+    '  public static void SayHello(string name){',
+    "    System.debug('Hello, ' + name + '!');",
+    '  }',
+    '}'
+  ].join('\n');
+
+  const class1TestContent = [
+    '@IsTest',
+    `public class ${class1Test} {`,
+    '  @IsTest',
+    '  static void validateSayHello() {',
+    "    System.debug('Starting validate');",
+    `    ${class1}.SayHello('Cody');`,
+    "    System.assertEquals(1, 1, 'all good');",
+    '  }',
+    '}'
+  ].join('\n');
+
+  const class2Content = [
+    `public with sharing class ${class2} {`,
+    '  public static void SayHello(string name){',
+    "    System.debug('Hello, ' + name + '!');",
+    '  }',
+    '}'
+  ].join('\n');
+
+  // Distinct method name from class1Test so the Test Explorer treeitem label is unique.
+  const class2TestContent = [
+    '@IsTest',
+    `public class ${class2Test} {`,
+    '  @IsTest',
+    '  static void validateSayHelloTwo() {',
+    "    System.debug('Starting validate');",
+    `    ${class2}.SayHello('Cody');`,
+    "    System.assertEquals(1, 1, 'all good');",
+    '  }',
+    '}'
+  ].join('\n');
+
+  await test.step('deploy two Apex classes and their tests to the boot org', async () => {
+    await ensureSecondarySideBarHidden(page);
+    await createApexClass(page, class1, class1Content);
+    await createApexClass(page, class1Test, class1TestContent);
+    await createApexClass(page, class2, class2Content);
+    await createApexClass(page, class2Test, class2TestContent);
+    await ensureOutputPanelOpen(page);
+    await selectOutputChannel(page, 'Salesforce Metadata');
+    await executeCommandWithCommandPalette(
+      page,
+      metadataNls.project_deploy_start_ignore_conflicts_default_org_text as string
+    );
+    await waitForOutputChannelText(page, { expectedText: 'Starting metadata deployment', timeout: 90_000 });
+    await waitForOutputChannelText(page, { expectedText: 'Deployed Source', timeout: 120_000 });
+    await saveScreenshot(page, 'setup.classes-deployed.png');
+  });
+
+  await test.step('wait for CodeLens in the test class', async () => {
+    const indexingComplete = page.getByRole('button', { name: /Indexing complete/ });
+    await expect(indexingComplete).toBeVisible({ timeout: 120_000 });
+    await openFileByName(page, `${class1Test}.cls`);
+    const codelens = page.locator('.codelens-decoration a').filter({ hasText: /Run Test|Debug Test/ });
+    await expect(codelens.first()).toBeVisible({ timeout: 90_000 });
+    await saveScreenshot(page, 'step.codelens-visible.png');
+  });
+
+  await test.step('Debug All Tests via class-level CodeLens', async () => {
+    await openFileByName(page, `${class1Test}.cls`);
+    await clickCodeLens(page, 'Debug All Tests', { timeout: 180_000 });
+    await waitForSuccessNotification(page);
+    await continueDebugSession(page);
+    await saveScreenshot(page, 'step.debug-all-tests.png');
+  });
+
+  await test.step('Debug Test via method-level CodeLens', async () => {
+    await openFileByName(page, `${class2Test}.cls`);
+    await clickCodeLens(page, 'Debug Test', { timeout: 180_000 });
+    await waitForSuccessNotification(page);
+    await continueDebugSession(page);
+    await saveScreenshot(page, 'step.debug-single-test.png');
+  });
+
+  await test.step('Debug class via Test Explorer', async () => {
+    await executeCommandWithCommandPalette(page, 'Testing: Focus on Test Explorer View');
+    await refreshTestsAndWaitForRebuild(page);
+    await expandNamespaceAndPackage(page);
+    await debugTestFromTreeItem(page, new RegExp(class1Test, 'i'));
+    await waitForSuccessNotification(page);
+    await continueDebugSession(page);
+    await saveScreenshot(page, 'step.debug-test-explorer-class.png');
+  });
+
+  await test.step('Debug method via Test Explorer', async () => {
+    await executeCommandWithCommandPalette(page, 'Testing: Focus on Test Explorer View');
+    await expandNamespaceAndPackage(page);
+    await expandTreeRow(page, class2Test);
+    const methodItem = page.getByRole('treeitem', { name: /validateSayHelloTwo/i });
+    await methodItem.waitFor({ state: 'visible', timeout: 30_000 });
+    await debugTestFromTreeItem(page, /validateSayHelloTwo/i);
+    await waitForSuccessNotification(page);
+    await continueDebugSession(page);
+    await saveScreenshot(page, 'step.debug-test-explorer-method.png');
+  });
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/errorPaths.container.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/errorPaths.container.spec.ts
@@ -18,6 +18,7 @@
 
 import { expect } from '@playwright/test';
 import {
+  activateEditorTab,
   clearAllNotifications,
   clearOutputChannel,
   closeAllEditors,
@@ -28,7 +29,6 @@ import {
   ensureSecondarySideBarHidden,
   executeCommandWithCommandPalette,
   NOTIFICATION_LIST_ITEM,
-  openFileByName,
   openFileFromExplorerTree,
   saveScreenshot,
   selectOutputChannel,
@@ -150,7 +150,7 @@ test('Update Checkpoints in Org (Code Builder): shows error when more than 5 che
 
   await test.step('toggle one checkpoint in each of the 6 classes', async () => {
     for (const className of classNames) {
-      await openFileByName(page, `${className}.cls`);
+      await activateEditorTab(page, `${className}.cls`);
       const editor = page.locator(`${EDITOR_WITH_URI}[data-uri$="${className}.cls"]`);
       await editor.waitFor({ state: 'visible', timeout: 15_000 });
 

--- a/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/promptForLogFile.container.spec.ts
+++ b/packages/salesforcedx-vscode-apex-replay-debugger/test/playwright/specs/container/promptForLogFile.container.spec.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Container twin of promptForLogFile.desktop (ADR 0022, W-23898526). Proves an apex-replay launch
+ * config activates the extension and prompts for a log file in the Code Builder image. There is no
+ * host workspaceDir to write a launch.json to, so an INERT config is seeded into the version-
+ * controlled fixture at container-workspace/.vscode/launch.json (mounted at the boot workspace root).
+ * Pressing F5 runs that config, whose `logFile: ${command:AskForLogFileName}` opens the log-file
+ * quick-input picker — the assertion. Nothing is selected (Escape dismisses it), so no debug session
+ * starts. Hardened for the shared, persistent workbench: a beforeEach reset.
+ */
+
+import { expect } from '@playwright/test';
+import {
+  clearAllNotifications,
+  closeAllEditors,
+  closeWelcomeTabs,
+  ensureSecondarySideBarHidden,
+  QUICK_INPUT_WIDGET,
+  saveScreenshot,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  validateNoCriticalErrors
+} from '@salesforce/playwright-vscode-ext';
+
+import { containerTest as test } from '../../fixtures/containerFixtures';
+
+test.beforeEach(async ({ page }) => {
+  await closeWelcomeTabs(page);
+  await ensureSecondarySideBarHidden(page);
+  await closeAllEditors(page);
+  await clearAllNotifications(page);
+});
+
+test('Apex Replay launch (Code Builder): activates the extension and prompts for a log file', async ({ page }) => {
+  test.setTimeout(120_000);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  await test.step('press F5 to run the seeded apex-replay launch config', async () => {
+    // The fixture ships .vscode/launch.json with a single apex-replay config, so F5 runs it without
+    // a config picker. Its ${command:AskForLogFileName} then opens the log-file quick-input.
+    await page.keyboard.press('F5');
+  });
+
+  await test.step('the log-file quick-input picker appears', async () => {
+    const filePicker = page.locator(QUICK_INPUT_WIDGET);
+    await expect(filePicker).toBeVisible({ timeout: 30_000 });
+    await saveScreenshot(page, 'step.log-file-picker.png');
+    // Dismiss so no session starts and the shared workbench is left clean.
+    await page.keyboard.press('Escape');
+    await expect(filePicker).not.toBeVisible({ timeout: 15_000 });
+  });
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/container/inWorkspaceFilter.container.spec.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/container/inWorkspaceFilter.container.spec.ts
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Container port of inWorkspaceFilter.headless.spec.ts. The web twin is desktop-only because
+ * salesforcedx-vscode-apex has no browser bundle, so the Test Controller never surfaces in VS Code
+ * Web. The Code Builder image runs the DESKTOP build in a Node host, so the Apex LSP contributes the
+ * class/method nodes and the `@in-workspace` tag filter is exercisable.
+ *
+ * Regression guard for W-22691592 / issue #7350: the Apex controller tags workspace classes
+ * `in-workspace` and org-only classes `org-only`; `@in-workspace` must show local classes and hide
+ * org-only ones. Discovery starts from the org's Tooling API and resolves each class to the
+ * workspace: `presence === 'both'` -> in-workspace, otherwise org-only. So a class needs to be IN the
+ * org to appear at all, and its workspace presence decides the tag.
+ *
+ * ORG: the BOOT org (minimalTestOrg, the source-tracking scratch org authed as the default
+ * target-org). No second org / no org switching is needed — the in-workspace-vs-org-only distinction
+ * is about workspace presence, not source tracking. (The desktop twin used a NON-tracking org only to
+ * dodge the source-tracked "Override Conflicts and Deploy" UI-deploy modal; the org-only class here is
+ * deployed from the HOST CLI, and the in-workspace class is a fresh uniquely-named class with no
+ * conflict, so neither path hits that modal.)
+ *
+ * TWO CLASSES:
+ *   - in-workspace: created in the mounted workspace AND deployed to the boot org via the extension
+ *     (createAndDeployApexTestClass) -> presence 'both' -> `in-workspace`.
+ *   - org-only: deployed to the boot org from the HOST CLI into a throwaway project, NEVER added to
+ *     the workspace -> presence org-only -> `org-only`. (The desktop twin instead deploys then
+ *     `fs.rm`s the on-disk file; container specs can't, because the workspace is a bind mount inside
+ *     the container whose host path is not exposed to specs.)
+ *
+ * Skips (never false-fails) when the boot org isn't authed on the host — i.e. a local run without the
+ * Code Builder multi-org CI setup that creates and auths minimalTestOrg on the host.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { expect, type Locator } from '@playwright/test';
+import {
+  clearAllNotifications,
+  clearFilter,
+  closeAllEditors,
+  createAndDeployApexTestClass,
+  ensureSecondarySideBarHidden,
+  env,
+  execAsync,
+  focusAndTypeInFilter,
+  MINIMAL_ORG_ALIAS,
+  saveScreenshot,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  TEST_EXPLORER_PANEL,
+  TEST_EXPLORER_TREE_ITEM,
+  validateNoCriticalErrors
+} from '@salesforce/playwright-vscode-ext';
+
+import { containerTest as test } from '../../fixtures/containerFixtures';
+import { TEST_RUN_TIMEOUT } from '../../constants';
+import { openTestExplorerAndDiscover } from '../../helpers/testExplorerHelpers';
+
+const treeRow = (panel: Locator, name: string): Locator =>
+  panel.locator(TEST_EXPLORER_TREE_ITEM).filter({ hasText: new RegExp(name, 'i') });
+
+const APEX_CLASS_META = [
+  '<?xml version="1.0" encoding="UTF-8"?>',
+  '<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">',
+  '    <apiVersion>64.0</apiVersion>',
+  '    <status>Active</status>',
+  '</ApexClass>'
+].join('\n');
+
+const makeClass = (name: string): string =>
+  [
+    '@isTest',
+    `public class ${name} {`,
+    '\t@isTest',
+    '\tstatic void passes() {',
+    `\t\tSystem.assertEquals(1, 1, '${name}');`,
+    '\t}',
+    '}'
+  ].join('\n');
+
+/**
+ * Deploy an Apex test class to the boot org from the HOST CLI into a throwaway project, WITHOUT ever
+ * adding it to the container's mounted workspace — so in-container discovery tags it `org-only`.
+ * `--ignore-conflicts` keeps the source-tracked boot org from prompting on a fresh, unrelated project.
+ */
+const deployOrgOnlyClassFromHost = async (className: string): Promise<void> => {
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'in-workspace-filter-'));
+  const projectDir = path.join(tmpRoot, 'org-only-project');
+  const classesDir = path.join(projectDir, 'force-app', 'main', 'default', 'classes');
+  await fs.mkdir(classesDir, { recursive: true });
+  await fs.writeFile(
+    path.join(projectDir, 'sfdx-project.json'),
+    JSON.stringify(
+      {
+        packageDirectories: [{ path: 'force-app', default: true }],
+        namespace: '',
+        sfdcLoginUrl: 'https://login.salesforce.com',
+        sourceApiVersion: '64.0'
+      },
+      null,
+      2
+    )
+  );
+  await fs.writeFile(path.join(classesDir, `${className}.cls`), makeClass(className));
+  await fs.writeFile(path.join(classesDir, `${className}.cls-meta.xml`), APEX_CLASS_META);
+  await execAsync(
+    `sf project deploy start --source-dir force-app --target-org ${MINIMAL_ORG_ALIAS} --ignore-conflicts --json`,
+    { cwd: projectDir, env }
+  );
+  await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {});
+};
+
+/** Best-effort removal of a class from the shared boot org, so deployed classes don't accumulate. */
+const deleteClassFromOrg = async (className: string): Promise<void> => {
+  await execAsync(
+    `sf project delete source --metadata ApexClass:${className} --target-org ${MINIMAL_ORG_ALIAS} --no-prompt --json`,
+    { env }
+  ).catch(() => {});
+};
+
+// Shared persistent workbench: reset editor + notification state before each test.
+test.beforeEach(async ({ page }) => {
+  await closeAllEditors(page);
+  await clearAllNotifications(page);
+});
+
+test('Apex @in-workspace filter (Code Builder): shows local classes and hides org-only classes', async ({ page }) => {
+  test.setTimeout(TEST_RUN_TIMEOUT);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  // The boot org is authed on the host in the Code Builder CI (createMinimalOrg). Skip — never
+  // false-fail — on a local run without that setup, since the host deploy below can't target it.
+  const bootOrgAuthed = await execAsync(`sf org display -o ${MINIMAL_ORG_ALIAS} --json`, { env })
+    .then(() => true)
+    .catch(() => false);
+  test.skip(!bootOrgAuthed, `boot org "${MINIMAL_ORG_ALIAS}" must be authed on the host to deploy the classes`);
+
+  const stamp = Date.now();
+  const workspaceClassName = `InWorkspaceClass${stamp}`;
+  const orgOnlyClassName = `OrgOnlyClass${stamp}`;
+
+  try {
+    await test.step('create + deploy an in-workspace class, and deploy an org-only class (host CLI)', async () => {
+      await ensureSecondarySideBarHidden(page);
+      // In-workspace class: written to the mounted workspace AND deployed -> presence 'both'.
+      await createAndDeployApexTestClass(page, workspaceClassName, makeClass(workspaceClassName));
+      // Org-only class: deployed to the boot org but never added to the workspace -> org-only.
+      await deployOrgOnlyClassFromHost(orgOnlyClassName);
+      await saveScreenshot(page, 'inWorkspaceFilter.container.setup.classes-deployed.png');
+    });
+
+    let panel: Awaited<ReturnType<typeof openTestExplorerAndDiscover>>;
+    await test.step('discover both classes in the Test Explorer', async () => {
+      // The created class left a preview editor open; close all editors so discovery is clean.
+      await closeAllEditors(page);
+      panel = await openTestExplorerAndDiscover(page);
+      await expect(treeRow(panel, workspaceClassName).first()).toBeVisible({ timeout: 60_000 });
+      await expect(treeRow(panel, orgOnlyClassName).first()).toBeVisible({ timeout: 60_000 });
+      await saveScreenshot(page, 'inWorkspaceFilter.container.01-both-discovered.png');
+    });
+
+    await test.step('apply @in-workspace — local class visible, org-only class hidden', async () => {
+      panel = page.locator(TEST_EXPLORER_PANEL);
+      await expect(async () => {
+        await clearFilter(page);
+        await focusAndTypeInFilter(page, '@in-workspace');
+        await expect(treeRow(panel, workspaceClassName).first()).toBeVisible({ timeout: 3000 });
+        await expect(treeRow(panel, orgOnlyClassName).first()).toBeHidden({ timeout: 3000 });
+      }).toPass({ timeout: 60_000 });
+      await saveScreenshot(page, 'inWorkspaceFilter.container.02-filtered.png');
+    });
+
+    await test.step('clear filter — both classes visible again', async () => {
+      await clearFilter(page);
+      await expect(treeRow(panel, workspaceClassName).first()).toBeVisible({ timeout: 15_000 });
+      await expect(treeRow(panel, orgOnlyClassName).first()).toBeVisible({ timeout: 15_000 });
+      await saveScreenshot(page, 'inWorkspaceFilter.container.03-cleared.png');
+    });
+  } finally {
+    await deleteClassFromOrg(workspaceClassName);
+    await deleteClassFromOrg(orgOnlyClassName);
+  }
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/container/inWorkspaceFilter.container.spec.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/container/inWorkspaceFilter.container.spec.ts
@@ -20,17 +20,22 @@
  * ORG: the BOOT org (minimalTestOrg, the source-tracking scratch org authed as the default
  * target-org). No second org / no org switching is needed — the in-workspace-vs-org-only distinction
  * is about workspace presence, not source tracking. (The desktop twin used a NON-tracking org only to
- * dodge the source-tracked "Override Conflicts and Deploy" UI-deploy modal; the org-only class here is
- * deployed from the HOST CLI, and the in-workspace class is a fresh uniquely-named class with no
- * conflict, so neither path hits that modal.)
+ * dodge the source-tracked "Override Conflicts and Deploy" UI-deploy modal; here nothing deploys
+ * through the extension, so that modal is never in play.)
  *
- * TWO CLASSES:
- *   - in-workspace: created in the mounted workspace AND deployed to the boot org via the extension
- *     (createAndDeployApexTestClass) -> presence 'both' -> `in-workspace`.
- *   - org-only: deployed to the boot org from the HOST CLI into a throwaway project, NEVER added to
- *     the workspace -> presence org-only -> `org-only`. (The desktop twin instead deploys then
- *     `fs.rm`s the on-disk file; container specs can't, because the workspace is a bind mount inside
- *     the container whose host path is not exposed to specs.)
+ * TWO CLASSES — both put in the org by ONE host-CLI deploy (no extension round-trip, no on-disk edit):
+ *   - in-workspace: the SEEDED `PagedResultTest` (already on disk in the mounted fixture workspace).
+ *     Deploying it to the boot org makes its presence 'both' -> `in-workspace`. We deploy the exact
+ *     seeded source (mirrored below) so this is self-contained and does not depend on a sibling spec
+ *     having deployed it first, and is byte-identical to what those specs deploy (no interference).
+ *   - org-only: a fresh uniquely-named class deployed alongside it but NEVER added to the workspace
+ *     -> presence org-only -> `org-only`. (The desktop twin instead deploys then `fs.rm`s the on-disk
+ *     file; container specs can't, because the workspace is a bind mount inside the container whose
+ *     host path is not exposed to specs.)
+ *
+ * COST: this collapses the prior two deploys (an extension UI create-and-deploy for the in-workspace
+ * class + a host deploy for the org-only class) into a SINGLE `sf project deploy start`, which is the
+ * bulk of the spec's runtime — it keeps the apex-testing container suite inside its CI job timeout.
  *
  * Skips (never false-fails) when the boot org isn't authed on the host — i.e. a local run without the
  * Code Builder multi-org CI setup that creates and auths minimalTestOrg on the host.
@@ -45,7 +50,6 @@ import {
   clearAllNotifications,
   clearFilter,
   closeAllEditors,
-  createAndDeployApexTestClass,
   ensureSecondarySideBarHidden,
   env,
   execAsync,
@@ -74,7 +78,49 @@ const APEX_CLASS_META = [
   '</ApexClass>'
 ].join('\n');
 
-const makeClass = (name: string): string =>
+// The in-workspace class we assert on is the seeded PagedResultTest — it already exists on disk in the
+// mounted fixture workspace, so once it is in the org its presence is 'both' -> `in-workspace`.
+const WORKSPACE_TEST_CLASS = 'PagedResultTest';
+
+// Exact mirror of the seeded fixture sources (container-workspace/.../classes). Deploying byte-identical
+// source keeps this spec self-contained AND non-interfering with sibling specs that deploy the same
+// classes. PagedResultTest depends on PagedResult, so both go in the deploy.
+const PAGED_RESULT = [
+  'public with sharing class PagedResult {',
+  '    @AuraEnabled',
+  '    public Integer pageSize { get; set; }',
+  '',
+  '    @AuraEnabled',
+  '    public Integer pageNumber { get; set; }',
+  '',
+  '    @AuraEnabled',
+  '    public Integer totalItemCount { get; set; }',
+  '',
+  '    @AuraEnabled',
+  '    public Object[] records { get; set; }',
+  '}'
+].join('\n');
+
+const PAGED_RESULT_TEST = [
+  '@isTest',
+  'private class PagedResultTest {',
+  '    @isTest',
+  '    static void holdsPageMetadata() {',
+  '        PagedResult result = new PagedResult();',
+  '        result.pageSize = 10;',
+  '        result.pageNumber = 1;',
+  '        result.totalItemCount = 42;',
+  '        result.records = new List<Object>();',
+  '',
+  "        System.assertEquals(10, result.pageSize, 'pageSize round-trips');",
+  "        System.assertEquals(1, result.pageNumber, 'pageNumber round-trips');",
+  "        System.assertEquals(42, result.totalItemCount, 'totalItemCount round-trips');",
+  "        System.assertEquals(0, result.records.size(), 'records starts empty');",
+  '    }',
+  '}'
+].join('\n');
+
+const makeOrgOnlyClass = (name: string): string =>
   [
     '@isTest',
     `public class ${name} {`,
@@ -86,13 +132,14 @@ const makeClass = (name: string): string =>
   ].join('\n');
 
 /**
- * Deploy an Apex test class to the boot org from the HOST CLI into a throwaway project, WITHOUT ever
- * adding it to the container's mounted workspace — so in-container discovery tags it `org-only`.
+ * ONE host-CLI deploy that puts BOTH classes in the boot org: the seeded PagedResult + PagedResultTest
+ * (also on disk in the workspace -> presence 'both'), and a fresh org-only class NEVER added to the
+ * workspace -> presence org-only.
  * `--ignore-conflicts` keeps the source-tracked boot org from prompting on a fresh, unrelated project.
  */
-const deployOrgOnlyClassFromHost = async (className: string): Promise<void> => {
+const deployWorkspaceAndOrgOnlyClasses = async (orgOnlyClassName: string): Promise<void> => {
   const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'in-workspace-filter-'));
-  const projectDir = path.join(tmpRoot, 'org-only-project');
+  const projectDir = path.join(tmpRoot, 'filter-project');
   const classesDir = path.join(projectDir, 'force-app', 'main', 'default', 'classes');
   await fs.mkdir(classesDir, { recursive: true });
   await fs.writeFile(
@@ -108,8 +155,13 @@ const deployOrgOnlyClassFromHost = async (className: string): Promise<void> => {
       2
     )
   );
-  await fs.writeFile(path.join(classesDir, `${className}.cls`), makeClass(className));
-  await fs.writeFile(path.join(classesDir, `${className}.cls-meta.xml`), APEX_CLASS_META);
+  const write = async (name: string, body: string): Promise<void> => {
+    await fs.writeFile(path.join(classesDir, `${name}.cls`), body);
+    await fs.writeFile(path.join(classesDir, `${name}.cls-meta.xml`), APEX_CLASS_META);
+  };
+  await write('PagedResult', PAGED_RESULT);
+  await write(WORKSPACE_TEST_CLASS, PAGED_RESULT_TEST);
+  await write(orgOnlyClassName, makeOrgOnlyClass(orgOnlyClassName));
   await execAsync(
     `sf project deploy start --source-dir force-app --target-org ${MINIMAL_ORG_ALIAS} --ignore-conflicts --json`,
     { cwd: projectDir, env }
@@ -117,13 +169,10 @@ const deployOrgOnlyClassFromHost = async (className: string): Promise<void> => {
   await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {});
 };
 
-/** Best-effort removal of a class from the shared boot org, so deployed classes don't accumulate. */
-const deleteClassFromOrg = async (className: string): Promise<void> => {
-  await execAsync(
-    `sf project delete source --metadata ApexClass:${className} --target-org ${MINIMAL_ORG_ALIAS} --no-prompt --json`,
-    { env }
-  ).catch(() => {});
-};
+// No org cleanup: the boot org is a per-CI-run scratch org deleted at job teardown, the org-only class
+// name is uniquely stamped (no collision on a locally-reused org), and PagedResult/PagedResultTest are
+// seeded classes sibling specs deploy too. (A prior `sf project delete source` here was a no-op anyway —
+// it ran outside any SFDX project dir and failed before touching the org.)
 
 // Shared persistent workbench: reset editor + notification state before each test.
 test.beforeEach(async ({ page }) => {
@@ -143,51 +192,39 @@ test('Apex @in-workspace filter (Code Builder): shows local classes and hides or
     .catch(() => false);
   test.skip(!bootOrgAuthed, `boot org "${MINIMAL_ORG_ALIAS}" must be authed on the host to deploy the classes`);
 
-  const stamp = Date.now();
-  const workspaceClassName = `InWorkspaceClass${stamp}`;
-  const orgOnlyClassName = `OrgOnlyClass${stamp}`;
+  const orgOnlyClassName = `OrgOnlyClass${Date.now()}`;
 
-  try {
-    await test.step('create + deploy an in-workspace class, and deploy an org-only class (host CLI)', async () => {
-      await ensureSecondarySideBarHidden(page);
-      // In-workspace class: written to the mounted workspace AND deployed -> presence 'both'.
-      await createAndDeployApexTestClass(page, workspaceClassName, makeClass(workspaceClassName));
-      // Org-only class: deployed to the boot org but never added to the workspace -> org-only.
-      await deployOrgOnlyClassFromHost(orgOnlyClassName);
-      await saveScreenshot(page, 'inWorkspaceFilter.container.setup.classes-deployed.png');
-    });
+  await test.step('deploy the in-workspace + org-only classes to the boot org (single host CLI deploy)', async () => {
+    await ensureSecondarySideBarHidden(page);
+    await deployWorkspaceAndOrgOnlyClasses(orgOnlyClassName);
+    await saveScreenshot(page, 'inWorkspaceFilter.container.setup.classes-deployed.png');
+  });
 
-    let panel: Awaited<ReturnType<typeof openTestExplorerAndDiscover>>;
-    await test.step('discover both classes in the Test Explorer', async () => {
-      // The created class left a preview editor open; close all editors so discovery is clean.
-      await closeAllEditors(page);
-      panel = await openTestExplorerAndDiscover(page);
-      await expect(treeRow(panel, workspaceClassName).first()).toBeVisible({ timeout: 60_000 });
-      await expect(treeRow(panel, orgOnlyClassName).first()).toBeVisible({ timeout: 60_000 });
-      await saveScreenshot(page, 'inWorkspaceFilter.container.01-both-discovered.png');
-    });
+  let panel: Awaited<ReturnType<typeof openTestExplorerAndDiscover>>;
+  await test.step('discover both classes in the Test Explorer', async () => {
+    panel = await openTestExplorerAndDiscover(page);
+    await expect(treeRow(panel, WORKSPACE_TEST_CLASS).first()).toBeVisible({ timeout: 60_000 });
+    await expect(treeRow(panel, orgOnlyClassName).first()).toBeVisible({ timeout: 60_000 });
+    await saveScreenshot(page, 'inWorkspaceFilter.container.01-both-discovered.png');
+  });
 
-    await test.step('apply @in-workspace — local class visible, org-only class hidden', async () => {
-      panel = page.locator(TEST_EXPLORER_PANEL);
-      await expect(async () => {
-        await clearFilter(page);
-        await focusAndTypeInFilter(page, '@in-workspace');
-        await expect(treeRow(panel, workspaceClassName).first()).toBeVisible({ timeout: 3000 });
-        await expect(treeRow(panel, orgOnlyClassName).first()).toBeHidden({ timeout: 3000 });
-      }).toPass({ timeout: 60_000 });
-      await saveScreenshot(page, 'inWorkspaceFilter.container.02-filtered.png');
-    });
-
-    await test.step('clear filter — both classes visible again', async () => {
+  await test.step('apply @in-workspace — local class visible, org-only class hidden', async () => {
+    panel = page.locator(TEST_EXPLORER_PANEL);
+    await expect(async () => {
       await clearFilter(page);
-      await expect(treeRow(panel, workspaceClassName).first()).toBeVisible({ timeout: 15_000 });
-      await expect(treeRow(panel, orgOnlyClassName).first()).toBeVisible({ timeout: 15_000 });
-      await saveScreenshot(page, 'inWorkspaceFilter.container.03-cleared.png');
-    });
-  } finally {
-    await deleteClassFromOrg(workspaceClassName);
-    await deleteClassFromOrg(orgOnlyClassName);
-  }
+      await focusAndTypeInFilter(page, '@in-workspace');
+      await expect(treeRow(panel, WORKSPACE_TEST_CLASS).first()).toBeVisible({ timeout: 3000 });
+      await expect(treeRow(panel, orgOnlyClassName).first()).toBeHidden({ timeout: 3000 });
+    }).toPass({ timeout: 60_000 });
+    await saveScreenshot(page, 'inWorkspaceFilter.container.02-filtered.png');
+  });
+
+  await test.step('clear filter — both classes visible again', async () => {
+    await clearFilter(page);
+    await expect(treeRow(panel, WORKSPACE_TEST_CLASS).first()).toBeVisible({ timeout: 15_000 });
+    await expect(treeRow(panel, orgOnlyClassName).first()).toBeVisible({ timeout: 15_000 });
+    await saveScreenshot(page, 'inWorkspaceFilter.container.03-cleared.png');
+  });
 
   await validateNoCriticalErrors(test, consoleErrors, networkErrors);
 });

--- a/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/container/orgOnlyClassRetrieve.container.spec.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/container/orgOnlyClassRetrieve.container.spec.ts
@@ -110,13 +110,9 @@ const deployOrgOnlyClassFromHost = async (className: string, methodName: string)
   await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {});
 };
 
-/** Best-effort removal of the org-only class from the shared boot org, so it doesn't accumulate. */
-const deleteClassFromOrg = async (className: string): Promise<void> => {
-  await execAsync(
-    `sf project delete source --metadata ApexClass:${className} --target-org ${MINIMAL_ORG_ALIAS} --no-prompt --json`,
-    { env }
-  ).catch(() => {});
-};
+// No org cleanup: the boot org is a per-CI-run scratch org deleted at job teardown, and the class name
+// is uniquely stamped so it never collides on a locally-reused org. (A prior `sf project delete source`
+// here was a no-op anyway — it ran outside any SFDX project dir and failed before touching the org.)
 
 // Shared persistent workbench: reset editor + notification state before each test.
 test.beforeEach(async ({ page }) => {
@@ -139,48 +135,44 @@ test('Org-only Apex class (Code Builder): retrieve via code lens opens the on-di
   const className = `OrgOnlyRetrieve${Date.now()}`;
   const methodName = 'retrievedFromOrg';
 
-  try {
-    await test.step('deploy an org-only Apex test class to the boot org (host CLI, not in workspace)', async () => {
-      await ensureSecondarySideBarHidden(page);
-      await deployOrgOnlyClassFromHost(className, methodName);
-      await saveScreenshot(page, 'orgOnlyRetrieve.container.setup.org-only-deployed.png');
-    });
+  await test.step('deploy an org-only Apex test class to the boot org (host CLI, not in workspace)', async () => {
+    await ensureSecondarySideBarHidden(page);
+    await deployOrgOnlyClassFromHost(className, methodName);
+    await saveScreenshot(page, 'orgOnlyRetrieve.container.setup.org-only-deployed.png');
+  });
 
-    await test.step('discover and open the org-only class virtual doc', async () => {
-      // Discovery (Tooling API query of the default org) surfaces the class; it resolves to no
-      // workspace file, so it is tagged org-only and its method navigates to the catalog document.
-      const panel = await openTestExplorerAndDiscover(page);
-      const classItem = panel.locator(TEST_EXPLORER_TREE_ITEM).filter({ hasText: new RegExp(className, 'i') });
-      await classItem.first().waitFor({ state: 'visible', timeout: 60_000 });
-      // Expand the class to reveal its leaf method, then double-click it — only a leaf with a range
-      // triggers VS Code's "go to test" navigation, which opens the sf-org-metadata virtual doc (the
-      // one place the retrieve code lens renders).
-      await classItem.first().locator('.monaco-tl-twistie').click({ force: true });
-      const methodItem = findTestExplorerItem(page, methodName);
-      await methodItem.waitFor({ state: 'visible', timeout: 60_000 });
-      await methodItem.dblclick();
-      // Assert the virtual doc actually opened before clicking the code lens, so a broken
-      // open-on-click wiring surfaces here instead of as an opaque codelens-not-found timeout.
-      await expect(page.locator(ORG_METADATA_EDITOR).first()).toBeVisible({ timeout: 60_000 });
-      await saveScreenshot(page, 'orgOnlyRetrieve.container.01-virtual-doc-opened.png');
-    });
+  await test.step('discover and open the org-only class virtual doc', async () => {
+    // Discovery (Tooling API query of the default org) surfaces the class; it resolves to no
+    // workspace file, so it is tagged org-only and its method navigates to the catalog document.
+    const panel = await openTestExplorerAndDiscover(page);
+    const classItem = panel.locator(TEST_EXPLORER_TREE_ITEM).filter({ hasText: new RegExp(className, 'i') });
+    await classItem.first().waitFor({ state: 'visible', timeout: 60_000 });
+    // Expand the class to reveal its leaf method, then double-click it — only a leaf with a range
+    // triggers VS Code's "go to test" navigation, which opens the sf-org-metadata virtual doc (the
+    // one place the retrieve code lens renders).
+    await classItem.first().locator('.monaco-tl-twistie').click({ force: true });
+    const methodItem = findTestExplorerItem(page, methodName);
+    await methodItem.waitFor({ state: 'visible', timeout: 60_000 });
+    await methodItem.dblclick();
+    // Assert the virtual doc actually opened before clicking the code lens, so a broken
+    // open-on-click wiring surfaces here instead of as an opaque codelens-not-found timeout.
+    await expect(page.locator(ORG_METADATA_EDITOR).first()).toBeVisible({ timeout: 60_000 });
+    await saveScreenshot(page, 'orgOnlyRetrieve.container.01-virtual-doc-opened.png');
+  });
 
-    await test.step('click the retrieve code lens and verify the retrieved .cls opens', async () => {
-      await clickCodeLens(page, RETRIEVE_CODELENS, { timeout: 180_000 });
-      await saveScreenshot(page, 'orgOnlyRetrieve.container.02-retrieve-clicked.png');
+  await test.step('click the retrieve code lens and verify the retrieved .cls opens', async () => {
+    await clickCodeLens(page, RETRIEVE_CODELENS, { timeout: 180_000 });
+    await saveScreenshot(page, 'orgOnlyRetrieve.container.02-retrieve-clicked.png');
 
-      // The retrieved on-disk class opens in the editor (showTextDocument with the URI from
-      // getRetrievedFileUri) — passes only if getRetrievedFileUri returned a valid URI end-to-end.
-      // (Unlike the desktop twin we assert via the editor rather than host fs.access: the retrieve
-      // writes into the container's mounted workspace, whose host path specs don't have.)
-      await expect(page.locator(`${EDITOR_WITH_URI}[data-uri$="${className}.cls"]`).first()).toBeVisible({
-        timeout: 60_000
-      });
-      await saveScreenshot(page, 'orgOnlyRetrieve.container.03-retrieved-cls-open.png');
+    // The retrieved on-disk class opens in the editor (showTextDocument with the URI from
+    // getRetrievedFileUri) — passes only if getRetrievedFileUri returned a valid URI end-to-end.
+    // (Unlike the desktop twin we assert via the editor rather than host fs.access: the retrieve
+    // writes into the container's mounted workspace, whose host path specs don't have.)
+    await expect(page.locator(`${EDITOR_WITH_URI}[data-uri$="${className}.cls"]`).first()).toBeVisible({
+      timeout: 60_000
     });
-  } finally {
-    await deleteClassFromOrg(className);
-  }
+    await saveScreenshot(page, 'orgOnlyRetrieve.container.03-retrieved-cls-open.png');
+  });
 
   await validateNoCriticalErrors(test, consoleErrors, networkErrors);
 });

--- a/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/container/orgOnlyClassRetrieve.container.spec.ts
+++ b/packages/salesforcedx-vscode-apex-testing/test/playwright/specs/container/orgOnlyClassRetrieve.container.spec.ts
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Container port of orgOnlyClassRetrieve.headless.spec.ts. The web twin is desktop-only because
+ * salesforcedx-vscode-apex has no browser bundle: the retrieve flow only fires on the
+ * `sf-org-metadata:` virtual doc, which needs the Apex language client. The Code Builder image runs
+ * the DESKTOP build in a Node host, so the Apex LSP is present and this path is exercisable.
+ *
+ * ORG: the BOOT org (minimalTestOrg, the source-tracking scratch org authed as the default
+ * target-org). No second org / no org switching is needed. "Org-only" means the class exists in the
+ * org but NOT in the workspace — a property of org-vs-workspace presence, independent of source
+ * tracking. The desktop twin used a NON-tracking org only to dodge the "Override Conflicts and
+ * Deploy" modal that source-tracked orgs surface when a UI deploy conflicts; we never hit that here
+ * because the org-only class is deployed from the HOST CLI (see below), not through the extension.
+ *
+ * MAKING THE CLASS ORG-ONLY: the desktop twin deploys a class then `fs.rm`s the on-disk `.cls` +
+ * `-meta.xml` to make it org-only. Container specs can't do that — the workspace is a bind mount
+ * INSIDE the container and the host mount path is not exposed to specs (createContainerTest hands
+ * over only a `page`). So instead of deploy-then-delete, we deploy the class to the boot org from the
+ * HOST CLI into a throwaway project and NEVER add it to the mounted workspace: it is org-only by
+ * construction. The in-container test discovery (Tooling API query of the default org, then
+ * workspace resolution) tags it `org-only`, and the retrieve code lens renders on its virtual doc.
+ *
+ * Skips (never false-fails) when the boot org isn't authed on the host — i.e. a local run without the
+ * Code Builder multi-org CI setup that creates and auths minimalTestOrg on the host.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { expect } from '@playwright/test';
+import {
+  clearAllNotifications,
+  clickCodeLens,
+  closeAllEditors,
+  EDITOR_WITH_URI,
+  ensureSecondarySideBarHidden,
+  env,
+  execAsync,
+  MINIMAL_ORG_ALIAS,
+  ORG_METADATA_EDITOR,
+  saveScreenshot,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  TEST_EXPLORER_TREE_ITEM,
+  validateNoCriticalErrors
+} from '@salesforce/playwright-vscode-ext';
+
+import { containerTest as test } from '../../fixtures/containerFixtures';
+import { TEST_RUN_TIMEOUT } from '../../constants';
+import { findTestExplorerItem, openTestExplorerAndDiscover } from '../../helpers/testExplorerHelpers';
+import { messages } from '../../../../src/messages/i18n';
+
+const RETRIEVE_CODELENS = messages.apex_test_retrieve_org_only_class_codelens_text;
+
+const APEX_CLASS_META = [
+  '<?xml version="1.0" encoding="UTF-8"?>',
+  '<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">',
+  '    <apiVersion>64.0</apiVersion>',
+  '    <status>Active</status>',
+  '</ApexClass>'
+].join('\n');
+
+const makeApexTestClass = (name: string, method: string): string =>
+  [
+    '@isTest',
+    `public class ${name} {`,
+    '\t@isTest',
+    `\tstatic void ${method}() {`,
+    `\t\tSystem.assertEquals(1, 1, '${name}');`,
+    '\t}',
+    '}'
+  ].join('\n');
+
+/**
+ * Deploy an Apex test class to the boot org from the HOST CLI into a throwaway project, WITHOUT ever
+ * adding it to the container's mounted workspace — so in-container discovery tags it `org-only`.
+ * `--ignore-conflicts` keeps the source-tracked boot org from prompting on a fresh, unrelated project.
+ */
+const deployOrgOnlyClassFromHost = async (className: string, methodName: string): Promise<void> => {
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'org-only-retrieve-'));
+  const projectDir = path.join(tmpRoot, 'org-only-project');
+  const classesDir = path.join(projectDir, 'force-app', 'main', 'default', 'classes');
+  await fs.mkdir(classesDir, { recursive: true });
+  await fs.writeFile(
+    path.join(projectDir, 'sfdx-project.json'),
+    JSON.stringify(
+      {
+        packageDirectories: [{ path: 'force-app', default: true }],
+        namespace: '',
+        sfdcLoginUrl: 'https://login.salesforce.com',
+        sourceApiVersion: '64.0'
+      },
+      null,
+      2
+    )
+  );
+  await fs.writeFile(path.join(classesDir, `${className}.cls`), makeApexTestClass(className, methodName));
+  await fs.writeFile(path.join(classesDir, `${className}.cls-meta.xml`), APEX_CLASS_META);
+  await execAsync(
+    `sf project deploy start --source-dir force-app --target-org ${MINIMAL_ORG_ALIAS} --ignore-conflicts --json`,
+    { cwd: projectDir, env }
+  );
+  await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {});
+};
+
+/** Best-effort removal of the org-only class from the shared boot org, so it doesn't accumulate. */
+const deleteClassFromOrg = async (className: string): Promise<void> => {
+  await execAsync(
+    `sf project delete source --metadata ApexClass:${className} --target-org ${MINIMAL_ORG_ALIAS} --no-prompt --json`,
+    { env }
+  ).catch(() => {});
+};
+
+// Shared persistent workbench: reset editor + notification state before each test.
+test.beforeEach(async ({ page }) => {
+  await closeAllEditors(page);
+  await clearAllNotifications(page);
+});
+
+test('Org-only Apex class (Code Builder): retrieve via code lens opens the on-disk .cls', async ({ page }) => {
+  test.setTimeout(TEST_RUN_TIMEOUT);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  // The boot org is authed on the host in the Code Builder CI (createMinimalOrg). Skip — never
+  // false-fail — on a local run without that setup, since the host deploy below can't target it.
+  const bootOrgAuthed = await execAsync(`sf org display -o ${MINIMAL_ORG_ALIAS} --json`, { env })
+    .then(() => true)
+    .catch(() => false);
+  test.skip(!bootOrgAuthed, `boot org "${MINIMAL_ORG_ALIAS}" must be authed on the host to deploy the org-only class`);
+
+  const className = `OrgOnlyRetrieve${Date.now()}`;
+  const methodName = 'retrievedFromOrg';
+
+  try {
+    await test.step('deploy an org-only Apex test class to the boot org (host CLI, not in workspace)', async () => {
+      await ensureSecondarySideBarHidden(page);
+      await deployOrgOnlyClassFromHost(className, methodName);
+      await saveScreenshot(page, 'orgOnlyRetrieve.container.setup.org-only-deployed.png');
+    });
+
+    await test.step('discover and open the org-only class virtual doc', async () => {
+      // Discovery (Tooling API query of the default org) surfaces the class; it resolves to no
+      // workspace file, so it is tagged org-only and its method navigates to the catalog document.
+      const panel = await openTestExplorerAndDiscover(page);
+      const classItem = panel.locator(TEST_EXPLORER_TREE_ITEM).filter({ hasText: new RegExp(className, 'i') });
+      await classItem.first().waitFor({ state: 'visible', timeout: 60_000 });
+      // Expand the class to reveal its leaf method, then double-click it — only a leaf with a range
+      // triggers VS Code's "go to test" navigation, which opens the sf-org-metadata virtual doc (the
+      // one place the retrieve code lens renders).
+      await classItem.first().locator('.monaco-tl-twistie').click({ force: true });
+      const methodItem = findTestExplorerItem(page, methodName);
+      await methodItem.waitFor({ state: 'visible', timeout: 60_000 });
+      await methodItem.dblclick();
+      // Assert the virtual doc actually opened before clicking the code lens, so a broken
+      // open-on-click wiring surfaces here instead of as an opaque codelens-not-found timeout.
+      await expect(page.locator(ORG_METADATA_EDITOR).first()).toBeVisible({ timeout: 60_000 });
+      await saveScreenshot(page, 'orgOnlyRetrieve.container.01-virtual-doc-opened.png');
+    });
+
+    await test.step('click the retrieve code lens and verify the retrieved .cls opens', async () => {
+      await clickCodeLens(page, RETRIEVE_CODELENS, { timeout: 180_000 });
+      await saveScreenshot(page, 'orgOnlyRetrieve.container.02-retrieve-clicked.png');
+
+      // The retrieved on-disk class opens in the editor (showTextDocument with the URI from
+      // getRetrievedFileUri) — passes only if getRetrievedFileUri returned a valid URI end-to-end.
+      // (Unlike the desktop twin we assert via the editor rather than host fs.access: the retrieve
+      // writes into the container's mounted workspace, whose host path specs don't have.)
+      await expect(page.locator(`${EDITOR_WITH_URI}[data-uri$="${className}.cls"]`).first()).toBeVisible({
+        timeout: 60_000
+      });
+      await saveScreenshot(page, 'orgOnlyRetrieve.container.03-retrieved-cls-open.png');
+    });
+  } finally {
+    await deleteClassFromOrg(className);
+  }
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-core/test/playwright/fixtures/container-noproject/README.md
+++ b/packages/salesforcedx-vscode-core/test/playwright/fixtures/container-noproject/README.md
@@ -1,0 +1,14 @@
+# container-noproject fixture
+
+A deliberately non-SFDX folder (no `sfdx-project.json` anywhere in it) bind-mounted into the Code
+Builder container as a SECOND workspace shape, alongside the standard `container-workspace` DX
+project.
+
+The orchestrator (`scripts/codeBuilderLocalE2E.ts`) opens `container-workspace` first and runs the
+normal container suites against it. It then re-seeds `coder.json` to point code-server at THIS
+folder and `restart()`s, so the "no project open" visibility suites (`test:container:noproject`,
+e.g. metadata `noProjectCommandsHidden`) run against a workspace where the SFDX project-gated
+commands must NOT be contributed.
+
+Keep it trivial: its only job is to be a folder code-server can open that is not a DX project. Do
+NOT add `sfdx-project.json` or any `force-app` metadata here — that would defeat its purpose.

--- a/packages/salesforcedx-vscode-core/test/playwright/fixtures/container-workspace/.vscode/launch.json
+++ b/packages/salesforcedx-vscode-core/test/playwright/fixtures/container-workspace/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Prompt for Apex Replay Debug Log",
+      "type": "apex-replay",
+      "request": "launch",
+      "logFile": "${command:AskForLogFileName}",
+      "stopOnEntry": true,
+      "trace": true
+    }
+  ]
+}

--- a/packages/salesforcedx-vscode-core/test/playwright/fixtures/container-workspace/README.md
+++ b/packages/salesforcedx-vscode-core/test/playwright/fixtures/container-workspace/README.md
@@ -3,12 +3,14 @@
 A minimal, version-controlled SFDX project mounted into the Code Builder container so container
 Playwright specs open a workspace with real metadata instead of the image's bare generated project.
 
-The mount + open is handled by the `seedWorkspace` function (exported from
-`@salesforce/playwright-vscode-ext`; invoked by the orchestrator/CI): the host dir is bind-mounted
-to `/home/codebuilder/fixture-project`, and `coder.json` is written via `docker exec` to point
-code-server at it. This deliberately bypasses the image's `SFDX_COBU_PROJECTNAME` generate path —
-that runs only on first boot behind the `~/.codebuilder` gate and lives in image code the CB team
-owns. See ADR 0022.
+Mount + open handled by `seedWorkspace` (from `@salesforce/playwright-vscode-ext`; orchestrator/CI):
+host dir bind-mounts to `/home/codebuilder/fixture-project`, `coder.json` written via `docker exec`
+to point code-server at it. Bypasses image `SFDX_COBU_PROJECTNAME` generate path (runs only first boot
+behind `~/.codebuilder` gate; image-owned code). See ADR 0022.
+
+Specs that write files INTO the opened workspace (e.g., metadata `manifestCommandVisibility` adding
+test `.xml` files) access the host path via `CB_FIXTURE_HOST_DIR` env var (set by orchestrator),
+then use `node:fs` — the bind mount reflects writes into the container's opened folder.
 
 This one fixture is shared by every package's container specs (it is the single mounted workspace,
 so the container opens it once and all specs run against it). Keep it small and add metadata only

--- a/packages/salesforcedx-vscode-core/test/playwright/specs/container/workspaceContextOrgSwitch.container.spec.ts
+++ b/packages/salesforcedx-vscode-core/test/playwright/specs/container/workspaceContextOrgSwitch.container.spec.ts
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Code Builder container twin of workspaceContextOrgSwitch.desktop
+ * (see docs/adr/0022-code-builder-e2e-desktop-build-over-browser.md).
+ *
+ * The desktop twin loads a test-only fixture extension (test/playwright/fixtureExtensions/workspaceContext,
+ * via createDesktopTest's `testExtensionPaths`) that consumes Core's public WorkspaceContext API,
+ * captures `onOrgChange` events + synchronous getter values, and writes `.workspace-context-state.json`
+ * for fine-grained assertions (eventCount, per-event username/alias/orgId).
+ *
+ * WHAT THIS PORTS + how it proves the workspace context follows a default-org switch:
+ *   The pre-built Code Builder container runs PRODUCTION extensions only — `createContainerTest`
+ *   has no `testExtensionPaths` hook, so the fixture extension (and thus the state file / test
+ *   commands) cannot be loaded. This port therefore proves the SAME observable outcome — the
+ *   workspace's in-process default-org context tracks a real picker switch — through a production
+ *   signal instead of the fixture extension:
+ *     `SFDX: Display Org Details for Default Org` (orgDisplayDefaultCommand) reads Core's
+ *     `TargetOrgRef` SubscriptionRef (the WorkspaceContext-backed target org) and shells
+ *     `sf org display --target-org "<that username>" --json`. So the org whose table it renders is
+ *     exactly whatever WorkspaceContext currently holds. Asserting the rendered username flips from
+ *     the boot org to the switched org (with no window reload) is the container-observable proof that
+ *     the WorkspaceContext transition completed and downstream commands consume the new default.
+ *
+ * WHAT THIS OMITS (needs the fixture extension the production container can't load): the twin's
+ * exact `onOrgChange` event-count / per-event getter assertions. Those observe the WorkspaceContext
+ * API surface directly from a consumer extension and have no production-command proxy.
+ *
+ * MULTI-ORG (W-23898526): the switch is only possible because the container now has a SECOND org —
+ * the orchestrator auths CB_EXTRA_ORG_ALIASES (nonTrackingTestOrg in CI) into the running container
+ * after boot but before the workbench restart, on top of the token-authed boot org (the DEFAULT).
+ *
+ * ALIAS vs USERNAME: the boot org is token-authed and carries NO alias in-container, so the status
+ * bar / picker show its USERNAME (resolved here from the host CLI); nonTrackingTestOrg was authed
+ * with `--alias`, so it surfaces by that alias. Same rationale as orgPicker.container.
+ *
+ * REQUIRED restore: this shared serial session must be left with the boot org as the default, or
+ * later container specs run against the wrong org — the default is restored in a `finally`.
+ *
+ * Skips (never false-fails) when the host lacks either org — a local run without the multi-org setup
+ * (CB_EXTRA_ORG_ALIASES is CI-only, gated to the multi-org packages).
+ */
+
+import {
+  clearAllNotifications,
+  closeAllEditors,
+  clickOrgPickerStatusBar,
+  closeWelcomeTabs,
+  ensureOutputPanelOpen,
+  ensureSecondarySideBarHidden,
+  env,
+  execAsync,
+  executeCommandWithCommandPalette,
+  expectOrgPickerStatusBar,
+  MINIMAL_ORG_ALIAS,
+  NON_TRACKING_ORG_ALIAS,
+  saveScreenshot,
+  selectOrgInPicker,
+  selectOutputChannel,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  validateNoCriticalErrors,
+  waitForOutputChannelText
+} from '@salesforce/playwright-vscode-ext';
+import { containerTest as test } from '../../fixtures/containerFixtures';
+
+// `channel_name` from salesforcedx-vscode-org/src/messages/i18n.ts — orgDisplay writes its table here.
+const ORG_OUTPUT_CHANNEL = 'Salesforce Org Management';
+// `org_display_default_text` from salesforcedx-vscode-org/package.nls.json. Hardcoded (not imported)
+// to avoid a cross-package relative import from the core test tsconfig.
+const DISPLAY_DEFAULT_ORG_COMMAND = 'SFDX: Display Org Details for Default Org';
+
+/** Resolve an org's username from the host CLI (the label the in-container status bar shows for an unaliased org). */
+const resolveOrgUsername = async (alias: string): Promise<string> => {
+  const { stdout } = await execAsync(`sf org display -o ${alias} --json`, { env });
+  const parsed = JSON.parse(stdout) as { result?: { username?: string } };
+  const username = parsed.result?.username;
+  if (!username) {
+    throw new Error(`could not resolve username for org "${alias}" from \`sf org display\``);
+  }
+  return username;
+};
+
+// Shared persistent workbench: reset editor + notification state before each test rather than
+// assuming a clean slate.
+test.beforeEach(async ({ page }) => {
+  await closeAllEditors(page);
+  await clearAllNotifications(page);
+});
+
+test('core (Code Builder): WorkspaceContext default-org tracks a real picker switch', async ({ page }) => {
+  // Generous budget for slow container startup + two cold `sf org display` shell-outs; no org creation.
+  test.setTimeout(180_000);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  // Boot org is unaliased in-container -> status bar shows its USERNAME; nonTrackingTestOrg keeps its alias.
+  const bootOrgUsername = await resolveOrgUsername(MINIMAL_ORG_ALIAS).catch(() => undefined);
+  const extraOrgUsername = await resolveOrgUsername(NON_TRACKING_ORG_ALIAS).catch(() => undefined);
+
+  // The multi-org capability is CI-only (CB_EXTRA_ORG_ALIASES). Skip — never false-fail — when the
+  // host lacks either org, i.e. a local run without the multi-org setup.
+  test.skip(
+    !bootOrgUsername || !extraOrgUsername,
+    `multi-org port needs both "${MINIMAL_ORG_ALIAS}" (boot) and "${NON_TRACKING_ORG_ALIAS}" (CB_EXTRA_ORG_ALIASES) authed on the host`
+  );
+  const bootOrgLabel = bootOrgUsername!;
+  const extraOrgUsernameValue = extraOrgUsername!;
+
+  await test.step('wait for workbench', async () => {
+    // The containerTest fixture already awaited workbench readiness before handing over `page`.
+    await closeWelcomeTabs(page);
+    await ensureSecondarySideBarHidden(page);
+    await saveScreenshot(page, 'workspaceContextOrgSwitch.container.01-ready.png');
+  });
+
+  await test.step('baseline: status bar shows the boot org as the default', async () => {
+    // Doubles as the activation gate — the org-picker status bar only renders once the org extension
+    // has activated and the TargetOrgRef watcher has resolved the boot default.
+    await expectOrgPickerStatusBar(page, bootOrgLabel, { timeout: 60_000 });
+  });
+
+  await test.step('baseline: default-org command resolves WorkspaceContext to the boot org', async () => {
+    // orgDisplayDefaultCommand reads TargetOrgRef and shells `sf org display --target-org <boot> --json`,
+    // so the boot org's username in the rendered table is the pre-switch snapshot of WorkspaceContext.
+    await executeCommandWithCommandPalette(page, DISPLAY_DEFAULT_ORG_COMMAND);
+    await ensureOutputPanelOpen(page);
+    await selectOutputChannel(page, ORG_OUTPUT_CHANNEL, 30_000);
+    await waitForOutputChannelText(page, { expectedText: bootOrgLabel, timeout: 60_000 });
+    await saveScreenshot(page, 'workspaceContextOrgSwitch.container.02-baseline-boot.png');
+  });
+
+  let switchedToExtra = false;
+  try {
+    await test.step('switch the default org to nonTrackingTestOrg via the status-bar picker', async () => {
+      await clickOrgPickerStatusBar(page, bootOrgLabel);
+      await selectOrgInPicker(page, NON_TRACKING_ORG_ALIAS);
+      switchedToExtra = true;
+      // The TargetOrgRef watcher refreshes the status bar after the config write — no reload needed.
+      await expectOrgPickerStatusBar(page, NON_TRACKING_ORG_ALIAS);
+      await saveScreenshot(page, 'workspaceContextOrgSwitch.container.03-switched-to-extra.png');
+    });
+
+    await test.step('WorkspaceContext now resolves the switched org for the default-org command', async () => {
+      // Same command, no reload: it must now render the SWITCHED org's table. Its username appears in
+      // the channel only after the switch — the container-observable proof the transition completed and
+      // WorkspaceContext-backed commands consume the new default.
+      await executeCommandWithCommandPalette(page, DISPLAY_DEFAULT_ORG_COMMAND);
+      await ensureOutputPanelOpen(page);
+      await selectOutputChannel(page, ORG_OUTPUT_CHANNEL, 30_000);
+      await waitForOutputChannelText(page, { expectedText: extraOrgUsernameValue, timeout: 60_000 });
+      await saveScreenshot(page, 'workspaceContextOrgSwitch.container.04-switched-context.png');
+    });
+  } finally {
+    // REQUIRED save/restore: never leave nonTrackingTestOrg as the default, or later container specs
+    // run against the wrong org. Restore through the SAME picker UI. Defensive Escape closes any picker
+    // left open by a failed assertion above.
+    await page.keyboard.press('Escape').catch(() => {});
+    if (switchedToExtra) {
+      await test.step('restore the default org back to the boot org', async () => {
+        await clickOrgPickerStatusBar(page, NON_TRACKING_ORG_ALIAS);
+        await selectOrgInPicker(page, bootOrgLabel);
+        await expectOrgPickerStatusBar(page, bootOrgLabel);
+        await saveScreenshot(page, 'workspaceContextOrgSwitch.container.05-restored-boot.png');
+      });
+    }
+  }
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-metadata/package.json
+++ b/packages/salesforcedx-vscode-metadata/package.json
@@ -52,6 +52,7 @@
     "test:web:ui": "DEBUG_MODE=1 npm run test:web -- --headed",
     "test:web:debug": "npm run test:web -- --debug",
     "test:container": "wireit",
+    "test:container:noproject": "wireit",
     "test:desktop": "wireit",
     "test:desktop:debug": "npm run test:desktop -- --debug",
     "test:desktop:conflicts": "wireit",
@@ -209,6 +210,28 @@
       "command": "playwright test --config=test/playwright/playwright.config.container.ts",
       "env": {
         "CODE_BUILDER_URL": {
+          "external": true
+        },
+        "CB_GREP": {
+          "external": true
+        }
+      },
+      "dependencies": [
+        "../playwright-vscode-ext:compile"
+      ],
+      "files": [
+        "test/playwright/**",
+        "package*.json"
+      ],
+      "output": []
+    },
+    "test:container:noproject": {
+      "command": "playwright test --config=test/playwright/playwright.config.container.noproject.ts",
+      "env": {
+        "CODE_BUILDER_URL": {
+          "external": true
+        },
+        "CB_GREP": {
           "external": true
         }
       },

--- a/packages/salesforcedx-vscode-metadata/test/playwright/playwright.config.container.noproject.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/playwright.config.container.noproject.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { createContainerConfig } from '@salesforce/playwright-vscode-ext';
+
+// Separate testDir from the standard container suite: these specs require the NON-project workspace
+// shape (no sfdx-project.json open), which the orchestrator sets up in a distinct phase (re-seed
+// coder.json to the container-noproject mount + restart). Keeping them out of ./specs/container means
+// they never run against the DX-project phase (where their "commands hidden" assertions would fail).
+export default createContainerConfig({ testDir: './specs/container-noproject' });

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/container-noproject/noProjectCommandsHidden.container.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/container-noproject/noProjectCommandsHidden.container.spec.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Container parity for the "no SFDX project open" visibility rule. The headless twin
+ * (noProjectCommandsHidden.headless.spec.ts) opens an EMPTY workspace and asserts the project-gated
+ * deploy/retrieve/delete/generate-manifest commands are NOT contributed. This proves the same gate
+ * holds inside the Code Builder image.
+ *
+ * Unlike every other container suite, this one runs against the NON-project workspace shape: the
+ * orchestrator opens the standard DX fixture first (for the ./specs/container suites), then re-seeds
+ * coder.json to the container-noproject mount (a folder with no sfdx-project.json) and restarts, and
+ * runs THIS suite (test:container:noproject) against that shape. It is org-agnostic — the commands
+ * are hidden by the missing project, regardless of the ambient boot org.
+ *
+ * The orchestrator re-runs the extension verify gate after that restart, so reaching a spec here
+ * means the metadata extension IS installed and active — a command missing from the palette is the
+ * project gate hiding it, not a failure to load the extension.
+ */
+
+import {
+  closeWelcomeTabs,
+  ensureSecondarySideBarHidden,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  validateNoCriticalErrors,
+  verifyCommandDoesNotExist
+} from '@salesforce/playwright-vscode-ext';
+import packageNls from '../../../../package.nls.json';
+import { containerTest as test } from '../../fixtures/containerFixtures';
+
+test('No project (Code Builder): deploy/retrieve/delete/generate-manifest commands are hidden', async ({ page }) => {
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  await test.step('workbench ready (non-project folder)', async () => {
+    // The containerTest fixture already awaited workbench readiness before handing over `page`.
+    await closeWelcomeTabs(page);
+    await ensureSecondarySideBarHidden(page);
+  });
+
+  await test.step('project-gated deploy/retrieve/delete/generate-manifest commands do not exist', async () => {
+    await verifyCommandDoesNotExist(page, packageNls.project_deploy_start_default_org_text);
+    await verifyCommandDoesNotExist(page, packageNls.project_deploy_start_ignore_conflicts_default_org_text);
+    await verifyCommandDoesNotExist(page, packageNls.project_retrieve_start_default_org_text);
+    await verifyCommandDoesNotExist(page, packageNls.project_retrieve_start_ignore_conflicts_default_org_text);
+    await verifyCommandDoesNotExist(page, packageNls.deploy_this_source_text);
+    await verifyCommandDoesNotExist(page, packageNls.deploy_in_manifest_text);
+    await verifyCommandDoesNotExist(page, packageNls.retrieve_this_source_text);
+    await verifyCommandDoesNotExist(page, packageNls.retrieve_in_manifest_text);
+    await verifyCommandDoesNotExist(page, packageNls.delete_source_text);
+    await verifyCommandDoesNotExist(page, packageNls.project_generate_manifest_text);
+  });
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/container/manifestCommandVisibility.container.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/container/manifestCommandVisibility.container.spec.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Container parity for manifest command visibility. The headless twin
+ * (manifestCommandVisibility.headless.spec.ts) proves the forcesourcemanifest language pattern
+ * ("**\/*[Pp]ackage.xml") surfaces the in-manifest deploy/retrieve commands for a *Package.xml file
+ * OUTSIDE manifest/ and does NOT surface them for a plain .xml file. This proves the same pattern
+ * holds inside the Code Builder image, driven by the container's boot-authed org (the in-manifest
+ * when-clauses also gate on sf:has_target_org, which the ambient boot org satisfies).
+ *
+ * This needs the container's existing shape (standard DX project + org), so it drops the headless
+ * twin's createMinimalOrg / settings upsert (the org is ambient). It writes uniquely-named files into
+ * the bind-mounted fixture root (via CB_FIXTURE_HOST_DIR, the host side of the mount) so the shared,
+ * persistent workbench never collides across runs, and removes them in afterEach.
+ */
+
+import { expect } from '@playwright/test';
+import {
+  clearAllNotifications,
+  closeAllEditors,
+  closeWelcomeTabs,
+  EDITOR,
+  ensureSecondarySideBarHidden,
+  openFileByName,
+  saveScreenshot,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  validateNoCriticalErrors,
+  verifyCommandDoesNotExist,
+  verifyCommandExists
+} from '@salesforce/playwright-vscode-ext';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import packageNls from '../../../../package.nls.json';
+import { containerTest as test } from '../../fixtures/containerFixtures';
+
+// A *Package.xml file at the project root (outside manifest/ and outside the package directories) must
+// still get the forcesourcemanifest language (filenamePatterns "**/*[Pp]ackage.xml"), so the
+// in-manifest deploy/retrieve menus appear. A plain *.xml file must NOT match, guarding against an
+// over-broad pattern.
+const MANIFEST_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+  <types>
+    <members>*</members>
+    <name>ApexClass</name>
+  </types>
+  <version>62.0</version>
+</Package>`;
+
+const PLAIN_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<root></root>`;
+
+/*
+ * The host side of the bind mount, published by the orchestrator (scripts/codeBuilderLocalE2E.ts). A
+ * host-side node:fs write here lands in the container's opened folder through the mount, so the files
+ * become part of the workspace code-server has open. Resolved once at load; a missing var is a
+ * wiring bug (the orchestrator always sets it), so fail loud rather than write to a guessed path.
+ */
+const fixtureHostDir = process.env.CB_FIXTURE_HOST_DIR;
+
+// Unique per run so the shared, persistent workbench never sees a leftover file from a prior run. The
+// unique token goes BEFORE "Package.xml"/".xml" so the manifest file still ends with "Package.xml"
+// (the pattern the language association matches on).
+const stamp = Date.now();
+const manifestFileName = `sfdx${stamp}Package.xml`;
+const plainFileName = `foo${stamp}.xml`;
+
+const createdFiles: string[] = [];
+
+test.beforeEach(async ({ page }) => {
+  await closeAllEditors(page);
+  await clearAllNotifications(page);
+});
+
+test.afterEach(async () => {
+  // Remove any files this spec wrote into the shared fixture so the workspace shape is left as found.
+  await Promise.all(createdFiles.splice(0).map(file => fs.rm(file, { force: true })));
+});
+
+test('Manifest command visibility (Code Builder): *Package.xml shows in-manifest commands, plain xml does not', async ({
+  page
+}) => {
+  test.setTimeout(180_000);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  if (!fixtureHostDir) {
+    throw new Error(
+      'CB_FIXTURE_HOST_DIR is not set — the orchestrator (scripts/codeBuilderLocalE2E.ts) must publish the ' +
+        'host side of the fixture bind mount so this spec can write files into the opened workspace.'
+    );
+  }
+
+  const manifestPath = path.join(fixtureHostDir, manifestFileName);
+  const plainPath = path.join(fixtureHostDir, plainFileName);
+
+  await test.step('workbench ready + stage both fixture files', async () => {
+    // The containerTest fixture already awaited workbench readiness before handing over `page`.
+    await closeWelcomeTabs(page);
+    await ensureSecondarySideBarHidden(page);
+
+    // Write BOTH files at the project root (outside any manifest/ dir and outside the package
+    // directories) BEFORE the first Quick Open. VS Code builds its Go-to-File index lazily on first
+    // use and refreshes it from a file watcher that can miss host-side writes to a bind mount on some
+    // platforms (macOS Docker); staging both up front guarantees both are in that first index build,
+    // so each openFileByName below resolves regardless of watcher behavior.
+    createdFiles.push(manifestPath, plainPath);
+    await fs.writeFile(manifestPath, MANIFEST_XML);
+    await fs.writeFile(plainPath, PLAIN_XML);
+    await saveScreenshot(page, 'manifestCommandVisibility.container.01-ready.png');
+  });
+
+  await test.step('*Package.xml outside manifest/ shows in-manifest commands', async () => {
+    await openFileByName(page, manifestFileName);
+    await expect(
+      page.locator(`${EDITOR}[data-uri*="${manifestFileName}"]`).first(),
+      `${manifestFileName} should be the active editor`
+    ).toBeVisible({ timeout: 15_000 });
+    await saveScreenshot(page, 'manifestCommandVisibility.container.02-manifest-open.png');
+
+    // The in-manifest when-clauses also gate on sf:has_target_org; the generous timeout rides out the
+    // brief window while the ambient boot org's context propagates into the workbench.
+    await verifyCommandExists(page, packageNls.deploy_in_manifest_text, 60_000);
+    await verifyCommandExists(page, packageNls.retrieve_in_manifest_text, 60_000);
+  });
+
+  await test.step('plain xml does not match the *Package.xml suffix', async () => {
+    await openFileByName(page, plainFileName);
+    await expect(
+      page.locator(`${EDITOR}[data-uri*="${plainFileName}"]`).first(),
+      `${plainFileName} should be the active editor`
+    ).toBeVisible({ timeout: 15_000 });
+    await saveScreenshot(page, 'manifestCommandVisibility.container.03-plain-open.png');
+
+    await verifyCommandDoesNotExist(page, packageNls.deploy_in_manifest_text);
+    await verifyCommandDoesNotExist(page, packageNls.retrieve_in_manifest_text);
+  });
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/container/nonTrackingOrgDeployRetrieveManifest.container.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/container/nonTrackingOrgDeployRetrieveManifest.container.spec.ts
@@ -25,7 +25,6 @@ import {
   activeQuickInputWidget,
   clearAllNotifications,
   clearOutputChannel,
-  clickOrgPickerStatusBar,
   closeAllEditors,
   closeWelcomeTabs,
   EDITOR,
@@ -35,16 +34,15 @@ import {
   execAsync,
   executeCommandWithCommandPalette,
   executeEditorContextMenuCommand,
-  expectOrgPickerListsOrg,
   expectOrgPickerStatusBar,
   MINIMAL_ORG_ALIAS,
   NON_TRACKING_ORG_ALIAS,
   openFileFromExplorerTree,
   saveScreenshot,
-  selectOrgInPicker,
   selectOutputChannel,
   setupConsoleMonitoring,
   setupNetworkMonitoring,
+  switchDefaultOrgViaPicker,
   validateNoCriticalErrors,
   verifyCommandExists,
   waitForOutputChannelText
@@ -99,11 +97,14 @@ test('Non-Tracking Org (Code Builder): deploy/retrieve via manifest work without
   try {
     await test.step('switch default org to nonTrackingTestOrg and assert it took', async () => {
       await expectOrgPickerStatusBar(page, bootOrgLabel);
-      await clickOrgPickerStatusBar(page, bootOrgLabel);
-      await expectOrgPickerListsOrg(page, NON_TRACKING_ORG_ALIAS);
-      await selectOrgInPicker(page, NON_TRACKING_ORG_ALIAS);
+      // Re-drives the picker if the status-bar switch doesn't take (container config-watcher race).
       switchedToExtra = true;
-      await expectOrgPickerStatusBar(page, NON_TRACKING_ORG_ALIAS);
+      await switchDefaultOrgViaPicker(page, {
+        fromLabel: bootOrgLabel,
+        filterText: NON_TRACKING_ORG_ALIAS,
+        expectLabel: NON_TRACKING_ORG_ALIAS,
+        assertListsOrg: NON_TRACKING_ORG_ALIAS
+      });
       await saveScreenshot(page, 'nonTrackingDeployRetrieveManifest.container.02-switched-to-nontracking.png');
     });
 
@@ -166,9 +167,13 @@ test('Non-Tracking Org (Code Builder): deploy/retrieve via manifest work without
     await closeAllEditors(page).catch(() => {});
     if (switchedToExtra) {
       await test.step('restore default org back to the boot org', async () => {
-        await clickOrgPickerStatusBar(page, NON_TRACKING_ORG_ALIAS);
-        await selectOrgInPicker(page, bootOrgLabel);
-        await expectOrgPickerStatusBar(page, bootOrgLabel);
+        // Re-drives the picker if the restore doesn't take, so the shared serial session isn't left
+        // on nonTrackingTestOrg (which cascades into the next spec's pre-switch assertion).
+        await switchDefaultOrgViaPicker(page, {
+          fromLabel: NON_TRACKING_ORG_ALIAS,
+          filterText: bootOrgLabel,
+          expectLabel: bootOrgLabel
+        });
         await saveScreenshot(page, 'nonTrackingDeployRetrieveManifest.container.06-restored-boot-org.png');
       });
     }

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/container/nonTrackingOrgDeployRetrieveManifest.container.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/container/nonTrackingOrgDeployRetrieveManifest.container.spec.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Code Builder container twin of nonTrackingOrgDeployRetrieveManifest.headless.
+ *
+ * The twin proves manifest-driven deploy + retrieve work when the DEFAULT org has NO source tracking. The
+ * container boots a source-TRACKING org as its default, so this spec uses the multi-org capability
+ * (W-23898526): switch the DEFAULT to the second, NON-tracking org (nonTrackingTestOrg,
+ * CB_EXTRA_ORG_ALIASES) via the status-bar picker, then deploy + retrieve a manifest against it, and
+ * RESTORE the boot org as default (REQUIRED) so the shared serial session is not contaminated.
+ *
+ * To avoid mutating the mounted fixture, the manifest is generated from the SEEDED PagedResult.cls (as the
+ * boot deploy/retrieve container twins do) under a unique name, rather than creating a new class. The
+ * distinct value over deployManifest/retrieveInManifest container twins is that the target default org is
+ * NON-tracking. Depends on CB_EXTRA_ORG_ALIASES; skips (never false-fails) when the extra org isn't authed.
+ */
+
+import {
+  activeQuickInputTextField,
+  activeQuickInputWidget,
+  clearAllNotifications,
+  clearOutputChannel,
+  clickOrgPickerStatusBar,
+  closeAllEditors,
+  closeWelcomeTabs,
+  EDITOR,
+  ensureOutputPanelOpen,
+  ensureSecondarySideBarHidden,
+  env,
+  execAsync,
+  executeCommandWithCommandPalette,
+  executeEditorContextMenuCommand,
+  expectOrgPickerListsOrg,
+  expectOrgPickerStatusBar,
+  MINIMAL_ORG_ALIAS,
+  NON_TRACKING_ORG_ALIAS,
+  openFileFromExplorerTree,
+  saveScreenshot,
+  selectOrgInPicker,
+  selectOutputChannel,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  validateNoCriticalErrors,
+  verifyCommandExists,
+  waitForOutputChannelText
+} from '@salesforce/playwright-vscode-ext';
+import { messages } from '../../../../src/messages/i18n';
+import packageNls from '../../../../package.nls.json';
+import { DEPLOY_TIMEOUT, RETRIEVE_TIMEOUT } from '../../../constants';
+import { containerTest as test } from '../../fixtures/containerFixtures';
+
+const FIXTURE_CLASS = 'PagedResult';
+
+/** Resolve an org's username from the host CLI (the label the in-container picker shows for an unaliased org). */
+const resolveOrgUsername = async (alias: string): Promise<string> => {
+  const { stdout } = await execAsync(`sf org display -o ${alias} --json`, { env });
+  const parsed = JSON.parse(stdout) as { result?: { username?: string } };
+  const username = parsed.result?.username;
+  if (!username) {
+    throw new Error(`could not resolve username for org "${alias}" from \`sf org display\``);
+  }
+  return username;
+};
+
+test.beforeEach(async ({ page }) => {
+  await closeAllEditors(page);
+  await clearAllNotifications(page);
+});
+
+test('Non-Tracking Org (Code Builder): deploy/retrieve via manifest work without tracking', async ({ page }) => {
+  test.setTimeout(RETRIEVE_TIMEOUT);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  const bootOrgUsername = await resolveOrgUsername(MINIMAL_ORG_ALIAS).catch(() => undefined);
+  const extraOrgAuthed = await resolveOrgUsername(NON_TRACKING_ORG_ALIAS).catch(() => undefined);
+
+  test.skip(
+    !bootOrgUsername || !extraOrgAuthed,
+    `needs both "${MINIMAL_ORG_ALIAS}" (boot) and "${NON_TRACKING_ORG_ALIAS}" (CB_EXTRA_ORG_ALIASES) authed on the host`
+  );
+  const bootOrgLabel = bootOrgUsername!;
+
+  // Unique manifest name avoids the overwrite modal and collisions in the shared persistent workbench.
+  const manifestFile = `nonTrackingManifest${Date.now()}.xml`;
+
+  await test.step('workbench ready', async () => {
+    await closeWelcomeTabs(page);
+    await ensureSecondarySideBarHidden(page);
+    await saveScreenshot(page, 'nonTrackingDeployRetrieveManifest.container.01-ready.png');
+  });
+
+  let switchedToExtra = false;
+  try {
+    await test.step('switch default org to nonTrackingTestOrg and assert it took', async () => {
+      await expectOrgPickerStatusBar(page, bootOrgLabel);
+      await clickOrgPickerStatusBar(page, bootOrgLabel);
+      await expectOrgPickerListsOrg(page, NON_TRACKING_ORG_ALIAS);
+      await selectOrgInPicker(page, NON_TRACKING_ORG_ALIAS);
+      switchedToExtra = true;
+      await expectOrgPickerStatusBar(page, NON_TRACKING_ORG_ALIAS);
+      await saveScreenshot(page, 'nonTrackingDeployRetrieveManifest.container.02-switched-to-nontracking.png');
+    });
+
+    await test.step('generate a manifest from the fixture class', async () => {
+      await openFileFromExplorerTree(page, `${FIXTURE_CLASS}.cls`, ['force-app', 'main', 'default', 'classes']);
+      const editor = page.locator(`[data-uri*="${FIXTURE_CLASS}.cls"]`).first();
+      await editor.waitFor({ state: 'visible', timeout: 15_000 });
+      await editor.click();
+
+      await executeCommandWithCommandPalette(page, packageNls.project_generate_manifest_text);
+
+      const quickInput = activeQuickInputWidget(page);
+      await quickInput.waitFor({ state: 'attached', timeout: 10_000 });
+      await quickInput.getByText(messages.manifest_input_save_prompt).waitFor({ state: 'attached', timeout: 10_000 });
+
+      await activeQuickInputTextField(page).fill(manifestFile.replace(/\.xml$/i, ''));
+      await page.keyboard.press('Enter');
+
+      const manifestEditor = page.locator(`${EDITOR}[data-uri*="manifest/${manifestFile}"]`).first();
+      await manifestEditor.waitFor({ state: 'visible', timeout: 15_000 });
+      await saveScreenshot(page, 'nonTrackingDeployRetrieveManifest.container.03-manifest-generated.png');
+    });
+
+    await test.step('deploy via manifest against the non-tracking org', async () => {
+      const manifestEditor = page.locator(`${EDITOR}[data-uri*="manifest/${manifestFile}"]`).first();
+      await manifestEditor.waitFor({ state: 'visible', timeout: 10_000 });
+      await manifestEditor.click();
+      // The deploy command is only contributed once the manifest editor context keys settle.
+      await verifyCommandExists(page, packageNls.deploy_in_manifest_text, 60_000);
+
+      await ensureOutputPanelOpen(page);
+      await selectOutputChannel(page, 'Salesforce Metadata', 60_000);
+      await clearOutputChannel(page);
+
+      await executeEditorContextMenuCommand(page, packageNls.deploy_in_manifest_text, `manifest/${manifestFile}`);
+      // The transient "Deploying" toast is racy on a fast container deploy; assert completion via output.
+      await waitForOutputChannelText(page, { expectedText: 'Deployed Source', timeout: DEPLOY_TIMEOUT });
+      await saveScreenshot(page, 'nonTrackingDeployRetrieveManifest.container.04-deployed.png');
+    });
+
+    await test.step('retrieve via manifest against the non-tracking org', async () => {
+      const manifestEditor = page.locator(`${EDITOR}[data-uri*="manifest/${manifestFile}"]`).first();
+      await manifestEditor.waitFor({ state: 'visible', timeout: 10_000 });
+      await manifestEditor.click();
+
+      await ensureOutputPanelOpen(page);
+      await selectOutputChannel(page, 'Salesforce Metadata', 60_000);
+      await clearOutputChannel(page);
+
+      await executeEditorContextMenuCommand(page, packageNls.retrieve_in_manifest_text, `manifest/${manifestFile}`);
+
+      await waitForOutputChannelText(page, { expectedText: 'Retrieving', timeout: 30_000 });
+      await waitForOutputChannelText(page, { expectedText: 'Retrieved Source', timeout: RETRIEVE_TIMEOUT });
+      await saveScreenshot(page, 'nonTrackingDeployRetrieveManifest.container.05-retrieved.png');
+    });
+  } finally {
+    // REQUIRED save/restore so later container specs run against the boot org. Close editors first so the
+    // restore step interacts only with the status bar picker.
+    await page.keyboard.press('Escape').catch(() => {});
+    await closeAllEditors(page).catch(() => {});
+    if (switchedToExtra) {
+      await test.step('restore default org back to the boot org', async () => {
+        await clickOrgPickerStatusBar(page, NON_TRACKING_ORG_ALIAS);
+        await selectOrgInPicker(page, bootOrgLabel);
+        await expectOrgPickerStatusBar(page, bootOrgLabel);
+        await saveScreenshot(page, 'nonTrackingDeployRetrieveManifest.container.06-restored-boot-org.png');
+      });
+    }
+  }
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/container/nonTrackingOrgDeployRetrieveOperations.container.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/container/nonTrackingOrgDeployRetrieveOperations.container.spec.ts
@@ -25,7 +25,6 @@ import {
   clearAllNotifications,
   clearOutputChannel,
   clickModalDialogButton,
-  clickOrgPickerStatusBar,
   closeAllEditors,
   closeWelcomeTabs,
   createApexClass,
@@ -34,16 +33,15 @@ import {
   env,
   execAsync,
   executeCommandWithCommandPalette,
-  expectOrgPickerListsOrg,
   expectOrgPickerStatusBar,
   MINIMAL_ORG_ALIAS,
   NON_TRACKING_ORG_ALIAS,
   openFileByName,
   saveScreenshot,
-  selectOrgInPicker,
   selectOutputChannel,
   setupConsoleMonitoring,
   setupNetworkMonitoring,
+  switchDefaultOrgViaPicker,
   validateNoCriticalErrors,
   verifyCommandExists,
   waitForOutputChannelText
@@ -96,11 +94,14 @@ test('Non-Tracking Org (Code Builder): deploy/retrieve operations work without t
   try {
     await test.step('switch default org to nonTrackingTestOrg and assert it took', async () => {
       await expectOrgPickerStatusBar(page, bootOrgLabel);
-      await clickOrgPickerStatusBar(page, bootOrgLabel);
-      await expectOrgPickerListsOrg(page, NON_TRACKING_ORG_ALIAS);
-      await selectOrgInPicker(page, NON_TRACKING_ORG_ALIAS);
+      // Re-drives the picker if the status-bar switch doesn't take (container config-watcher race).
       switchedToExtra = true;
-      await expectOrgPickerStatusBar(page, NON_TRACKING_ORG_ALIAS);
+      await switchDefaultOrgViaPicker(page, {
+        fromLabel: bootOrgLabel,
+        filterText: NON_TRACKING_ORG_ALIAS,
+        expectLabel: NON_TRACKING_ORG_ALIAS,
+        assertListsOrg: NON_TRACKING_ORG_ALIAS
+      });
       await saveScreenshot(page, 'nonTrackingDeployRetrieveOps.container.02-switched-to-nontracking.png');
     });
 
@@ -174,9 +175,13 @@ test('Non-Tracking Org (Code Builder): deploy/retrieve operations work without t
     await closeAllEditors(page).catch(() => {});
     if (switchedToExtra) {
       await test.step('restore default org back to the boot org', async () => {
-        await clickOrgPickerStatusBar(page, NON_TRACKING_ORG_ALIAS);
-        await selectOrgInPicker(page, bootOrgLabel);
-        await expectOrgPickerStatusBar(page, bootOrgLabel);
+        // Re-drives the picker if the restore doesn't take, so the shared serial session isn't left
+        // on nonTrackingTestOrg (which cascades into the next spec's pre-switch assertion).
+        await switchDefaultOrgViaPicker(page, {
+          fromLabel: NON_TRACKING_ORG_ALIAS,
+          filterText: bootOrgLabel,
+          expectLabel: bootOrgLabel
+        });
         await saveScreenshot(page, 'nonTrackingDeployRetrieveOps.container.08-restored-boot-org.png');
       });
     }

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/container/nonTrackingOrgDeployRetrieveOperations.container.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/container/nonTrackingOrgDeployRetrieveOperations.container.spec.ts
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Code Builder container twin of nonTrackingOrgDeployRetrieveOperations.headless.
+ *
+ * The twin proves deploy / retrieve / delete of a single class work when the DEFAULT org has NO source
+ * tracking. The container boots a source-TRACKING org as its default, so this spec uses the multi-org
+ * capability (W-23898526): switch the DEFAULT to the second, NON-tracking org (nonTrackingTestOrg,
+ * CB_EXTRA_ORG_ALIASES) via the status-bar picker, run the operations against it, and RESTORE the boot org
+ * as default (REQUIRED) so the shared serial session is not contaminated.
+ *
+ * A uniquely-named throwaway class is created, deployed, retrieved, then deleted from project + org (as the
+ * deleteSource container twin does), so the mounted fixture and seeded classes are untouched. The throwaway
+ * class is created only AFTER the non-tracking org is the default and is removed BEFORE the boot org is
+ * restored, so no stray local change leaks into the tracking boot org. Depends on CB_EXTRA_ORG_ALIASES;
+ * skips (never false-fails) when the extra org isn't authed.
+ */
+
+import {
+  clearAllNotifications,
+  clearOutputChannel,
+  clickModalDialogButton,
+  clickOrgPickerStatusBar,
+  closeAllEditors,
+  closeWelcomeTabs,
+  createApexClass,
+  ensureOutputPanelOpen,
+  ensureSecondarySideBarHidden,
+  env,
+  execAsync,
+  executeCommandWithCommandPalette,
+  expectOrgPickerListsOrg,
+  expectOrgPickerStatusBar,
+  MINIMAL_ORG_ALIAS,
+  NON_TRACKING_ORG_ALIAS,
+  openFileByName,
+  saveScreenshot,
+  selectOrgInPicker,
+  selectOutputChannel,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  validateNoCriticalErrors,
+  verifyCommandExists,
+  waitForOutputChannelText
+} from '@salesforce/playwright-vscode-ext';
+import { expect } from '@playwright/test';
+import { messages } from '../../../../src/messages/i18n';
+import { DEPLOY_TIMEOUT, RETRIEVE_TIMEOUT } from '../../../constants';
+import { containerTest as test } from '../../fixtures/containerFixtures';
+
+/** Resolve an org's username from the host CLI (the label the in-container picker shows for an unaliased org). */
+const resolveOrgUsername = async (alias: string): Promise<string> => {
+  const { stdout } = await execAsync(`sf org display -o ${alias} --json`, { env });
+  const parsed = JSON.parse(stdout) as { result?: { username?: string } };
+  const username = parsed.result?.username;
+  if (!username) {
+    throw new Error(`could not resolve username for org "${alias}" from \`sf org display\``);
+  }
+  return username;
+};
+
+test.beforeEach(async ({ page }) => {
+  await closeAllEditors(page);
+  await clearAllNotifications(page);
+});
+
+test('Non-Tracking Org (Code Builder): deploy/retrieve operations work without tracking', async ({ page }) => {
+  test.setTimeout(RETRIEVE_TIMEOUT);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  const bootOrgUsername = await resolveOrgUsername(MINIMAL_ORG_ALIAS).catch(() => undefined);
+  const extraOrgAuthed = await resolveOrgUsername(NON_TRACKING_ORG_ALIAS).catch(() => undefined);
+
+  test.skip(
+    !bootOrgUsername || !extraOrgAuthed,
+    `needs both "${MINIMAL_ORG_ALIAS}" (boot) and "${NON_TRACKING_ORG_ALIAS}" (CB_EXTRA_ORG_ALIASES) authed on the host`
+  );
+  const bootOrgLabel = bootOrgUsername!;
+
+  // Unique per run so the shared, persistent workbench never collides across runs.
+  const className = `NonTrackingOpsTest${Date.now()}`;
+
+  await test.step('workbench ready', async () => {
+    await closeWelcomeTabs(page);
+    await ensureSecondarySideBarHidden(page);
+    await saveScreenshot(page, 'nonTrackingDeployRetrieveOps.container.01-ready.png');
+  });
+
+  let switchedToExtra = false;
+  try {
+    await test.step('switch default org to nonTrackingTestOrg and assert it took', async () => {
+      await expectOrgPickerStatusBar(page, bootOrgLabel);
+      await clickOrgPickerStatusBar(page, bootOrgLabel);
+      await expectOrgPickerListsOrg(page, NON_TRACKING_ORG_ALIAS);
+      await selectOrgInPicker(page, NON_TRACKING_ORG_ALIAS);
+      switchedToExtra = true;
+      await expectOrgPickerStatusBar(page, NON_TRACKING_ORG_ALIAS);
+      await saveScreenshot(page, 'nonTrackingDeployRetrieveOps.container.02-switched-to-nontracking.png');
+    });
+
+    await test.step('create a throwaway apex class', async () => {
+      await createApexClass(page, className);
+      const createdEditor = page.locator(`[data-uri*="${className}.cls"]`).first();
+      await createdEditor.waitFor({ state: 'visible', timeout: 15_000 });
+      await createdEditor.click();
+      // The editor context keys (sf:in_package_directories) settle a beat after the file opens.
+      await verifyCommandExists(page, messages.deploy_this_source_text, 60_000);
+      await saveScreenshot(page, 'nonTrackingDeployRetrieveOps.container.03-created.png');
+    });
+
+    await test.step('deploy class to the non-tracking org', async () => {
+      await ensureOutputPanelOpen(page);
+      await selectOutputChannel(page, 'Salesforce Metadata', 60_000);
+      await clearOutputChannel(page);
+      await openFileByName(page, `${className}.cls`);
+
+      await executeCommandWithCommandPalette(page, messages.deploy_this_source_text);
+      await waitForOutputChannelText(page, { expectedText: 'Deployed Source', timeout: DEPLOY_TIMEOUT });
+      await saveScreenshot(page, 'nonTrackingDeployRetrieveOps.container.04-deployed.png');
+    });
+
+    await test.step('retrieve class from the non-tracking org', async () => {
+      await ensureOutputPanelOpen(page);
+      await selectOutputChannel(page, 'Salesforce Metadata', 60_000);
+      await clearOutputChannel(page);
+      await openFileByName(page, `${className}.cls`);
+
+      await executeCommandWithCommandPalette(page, messages.retrieve_this_source_text);
+      await waitForOutputChannelText(page, { expectedText: 'Retrieving', timeout: 30_000 });
+      await waitForOutputChannelText(page, { expectedText: 'Retrieved Source', timeout: RETRIEVE_TIMEOUT });
+      await saveScreenshot(page, 'nonTrackingDeployRetrieveOps.container.05-retrieved.png');
+    });
+
+    await test.step('delete class from project and the non-tracking org', async () => {
+      await ensureOutputPanelOpen(page);
+      await selectOutputChannel(page, 'Salesforce Metadata', 60_000);
+      await clearOutputChannel(page);
+      await openFileByName(page, `${className}.cls`);
+
+      await executeCommandWithCommandPalette(page, messages.delete_source_text);
+
+      // The delete confirmation is a modal warning dialog (showWarningMessage({ modal: true })).
+      const deleteConfirmation = page.locator('.monaco-dialog-box, .dialog-shadow').first();
+      await expect(deleteConfirmation).toBeVisible({ timeout: 10_000 });
+      await expect(deleteConfirmation).toContainText(messages.delete_source_confirmation_message);
+      await clickModalDialogButton(page, messages.confirm_delete_source_button_text);
+
+      await waitForOutputChannelText(page, { expectedText: 'Deleting', timeout: 30_000 });
+      await waitForOutputChannelText(page, { expectedText: 'Deleted Source', timeout: DEPLOY_TIMEOUT });
+      await saveScreenshot(page, 'nonTrackingDeployRetrieveOps.container.06-deleted.png');
+
+      // File should leave the explorer (desktop explorer refresh can lag, so poll).
+      await expect(async () => {
+        expect(
+          await page
+            .locator('[role="treeitem"]')
+            .filter({ hasText: new RegExp(`${className}\\.cls$`, 'i') })
+            .count(),
+          `File ${className}.cls should not be in explorer after delete from org`
+        ).toBe(0);
+      }).toPass({ timeout: 60_000 });
+      await saveScreenshot(page, 'nonTrackingDeployRetrieveOps.container.07-removed-from-explorer.png');
+    });
+  } finally {
+    // REQUIRED save/restore so later container specs run against the boot org. The throwaway class was
+    // already deleted above; close editors so the restore interacts only with the status bar picker.
+    await page.keyboard.press('Escape').catch(() => {});
+    await closeAllEditors(page).catch(() => {});
+    if (switchedToExtra) {
+      await test.step('restore default org back to the boot org', async () => {
+        await clickOrgPickerStatusBar(page, NON_TRACKING_ORG_ALIAS);
+        await selectOrgInPicker(page, bootOrgLabel);
+        await expectOrgPickerStatusBar(page, bootOrgLabel);
+        await saveScreenshot(page, 'nonTrackingDeployRetrieveOps.container.08-restored-boot-org.png');
+      });
+    }
+  }
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/container/nonTrackingOrgTrackingCommandsHidden.container.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/container/nonTrackingOrgTrackingCommandsHidden.container.spec.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Code Builder container twin of nonTrackingOrgTrackingCommandsHidden.headless (desktop-only there,
+ * see docs/adr/0022-code-builder-e2e-desktop-build-over-browser.md).
+ *
+ * The web/desktop twin authenticates a fresh non-tracking scratch org and makes it the DEFAULT, then
+ * asserts every source-tracking command (push/pull, view-changes, reset) and the tracking status bar are
+ * hidden. The container image boots a source-TRACKING scratch org (minimalTestOrg, unaliased in-container
+ * so it surfaces by USERNAME) as the default, so we cannot assert "hidden" against it. Instead we lean on
+ * the multi-org capability (W-23898526): the orchestrator auths a SECOND, NON-tracking org
+ * (nonTrackingTestOrg, CB_EXTRA_ORG_ALIASES) into the running container. This spec switches the DEFAULT to
+ * that non-tracking org through the status-bar picker, proves the tracking status bar disappears and the
+ * tracking commands are no longer contributed, then RESTORES the boot org as default so the shared serial
+ * session is not contaminated (REQUIRED).
+ *
+ * Depends on the CB_EXTRA_ORG_ALIASES multi-org capability; skips (rather than false-failing) when the
+ * extra org isn't authed on the host — i.e. a local run without the multi-org setup.
+ */
+
+import {
+  clearAllNotifications,
+  clickOrgPickerStatusBar,
+  closeAllEditors,
+  closeWelcomeTabs,
+  ensureSecondarySideBarHidden,
+  env,
+  execAsync,
+  expectOrgPickerListsOrg,
+  expectOrgPickerStatusBar,
+  MINIMAL_ORG_ALIAS,
+  NON_TRACKING_ORG_ALIAS,
+  saveScreenshot,
+  selectOrgInPicker,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  validateNoCriticalErrors,
+  verifyCommandDoesNotExist,
+  verifyCommandExists
+} from '@salesforce/playwright-vscode-ext';
+import { expect } from '@playwright/test';
+import { SourceTrackingStatusBarPage } from '../../pages/sourceTrackingStatusBarPage';
+import { containerTest as test } from '../../fixtures/containerFixtures';
+import packageNls from '../../../../package.nls.json';
+
+/** Resolve an org's username from the host CLI (the label the in-container picker shows for an unaliased org). */
+const resolveOrgUsername = async (alias: string): Promise<string> => {
+  const { stdout } = await execAsync(`sf org display -o ${alias} --json`, { env });
+  const parsed = JSON.parse(stdout) as { result?: { username?: string } };
+  const username = parsed.result?.username;
+  if (!username) {
+    throw new Error(`could not resolve username for org "${alias}" from \`sf org display\``);
+  }
+  return username;
+};
+
+// Shared persistent workbench: reset editor + notification state before each test rather than
+// assuming a clean slate.
+test.beforeEach(async ({ page }) => {
+  await closeAllEditors(page);
+  await clearAllNotifications(page);
+});
+
+test('Non-Tracking Org (Code Builder): source tracking commands and status bar hidden', async ({ page }) => {
+  // Switching + restoring the default org are quick config writes; the generous budget only covers slow
+  // container startup and the async org/context refresh, not org creation (there is none here).
+  test.setTimeout(180_000);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  // Boot org is unaliased in-container, so the picker/status bar show its USERNAME (resolve from host CLI);
+  // nonTrackingTestOrg keeps its alias in-container.
+  const bootOrgUsername = await resolveOrgUsername(MINIMAL_ORG_ALIAS).catch(() => undefined);
+  const extraOrgAuthed = await resolveOrgUsername(NON_TRACKING_ORG_ALIAS).catch(() => undefined);
+
+  // The multi-org capability is CI-only (CB_EXTRA_ORG_ALIASES, set for this package). Skip — never
+  // false-fail — when the host lacks either org, i.e. a local run without the multi-org setup.
+  test.skip(
+    !bootOrgUsername || !extraOrgAuthed,
+    `needs both "${MINIMAL_ORG_ALIAS}" (boot) and "${NON_TRACKING_ORG_ALIAS}" (CB_EXTRA_ORG_ALIASES) authed on the host`
+  );
+  const bootOrgLabel = bootOrgUsername!;
+
+  await test.step('workbench ready', async () => {
+    await closeWelcomeTabs(page);
+    await ensureSecondarySideBarHidden(page);
+    await saveScreenshot(page, 'nonTrackingCommandsHidden.container.01-ready.png');
+  });
+
+  // Gate on an always-present activation command (sobjects_refresh is gated on sf:project_opened only, so
+  // its presence confirms the metadata extension is fully initialized before we assert command absence).
+  await test.step('verify extension-activated command is present', async () => {
+    await verifyCommandExists(page, packageNls.sobjects_refresh, 60_000);
+  });
+
+  let switchedToExtra = false;
+  try {
+    await test.step('switch default org to nonTrackingTestOrg and assert it took', async () => {
+      // Boot org is the default, so the status bar shows its username.
+      await expectOrgPickerStatusBar(page, bootOrgLabel);
+      await clickOrgPickerStatusBar(page, bootOrgLabel);
+      await expectOrgPickerListsOrg(page, NON_TRACKING_ORG_ALIAS);
+      await selectOrgInPicker(page, NON_TRACKING_ORG_ALIAS);
+      switchedToExtra = true;
+      await expectOrgPickerStatusBar(page, NON_TRACKING_ORG_ALIAS);
+      await saveScreenshot(page, 'nonTrackingCommandsHidden.container.02-switched-to-nontracking.png');
+    });
+
+    await test.step('source tracking status bar disappears once the non-tracking org is default', async () => {
+      // On the boot (tracking) org the status bar is visible; switching to a non-tracking default must
+      // remove it. Waiting for it to leave also confirms the org/context refresh completed before we
+      // assert the tracking commands are gone (avoids a false pass on stale, still-tracking context).
+      const statusBar = new SourceTrackingStatusBarPage(page);
+      await expect(statusBar.statusBarItem).not.toBeVisible({ timeout: 60_000 });
+      await saveScreenshot(page, 'nonTrackingCommandsHidden.container.03-status-bar-hidden.png');
+    });
+
+    await test.step('push/pull and view-changes commands do not exist', async () => {
+      await verifyCommandDoesNotExist(page, packageNls.project_deploy_start_default_org_text);
+      await verifyCommandDoesNotExist(page, packageNls.project_deploy_start_ignore_conflicts_default_org_text);
+      await verifyCommandDoesNotExist(page, packageNls.project_retrieve_start_default_org_text);
+      await verifyCommandDoesNotExist(page, packageNls.project_retrieve_start_ignore_conflicts_default_org_text);
+      await verifyCommandDoesNotExist(page, packageNls.view_all_changes_text);
+      await verifyCommandDoesNotExist(page, packageNls.view_local_changes_text);
+      await verifyCommandDoesNotExist(page, packageNls.view_remote_changes_text);
+      await verifyCommandDoesNotExist(page, packageNls.reset_remote_tracking_text);
+    });
+  } finally {
+    // REQUIRED save/restore: this shared serial session must not be left with nonTrackingTestOrg as the
+    // default, or later container specs run against the wrong org. Restore through the SAME picker UI.
+    // Defensive Escape closes any picker left open by a failed assertion above.
+    await page.keyboard.press('Escape').catch(() => {});
+    if (switchedToExtra) {
+      await test.step('restore default org back to the boot org', async () => {
+        await clickOrgPickerStatusBar(page, NON_TRACKING_ORG_ALIAS);
+        await selectOrgInPicker(page, bootOrgLabel);
+        await expectOrgPickerStatusBar(page, bootOrgLabel);
+        await saveScreenshot(page, 'nonTrackingCommandsHidden.container.04-restored-boot-org.png');
+      });
+    }
+  }
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/container/nonTrackingOrgTrackingCommandsHidden.container.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/container/nonTrackingOrgTrackingCommandsHidden.container.spec.ts
@@ -66,7 +66,20 @@ test.beforeEach(async ({ page }) => {
   await clearAllNotifications(page);
 });
 
-test('Non-Tracking Org (Code Builder): source tracking commands and status bar hidden', async ({ page }) => {
+// fixme (W-23898526): the metadata extension's source-tracking status bar does NOT re-evaluate when the
+// default org is switched at runtime in the code-server container, so it keeps polling the boot (tracking)
+// org and never hides. Root cause: that widget reacts to default-org changes only through the config-file
+// watcher (services `watchConfigFiles` -> `FileChangePubSub` on the GLOBAL ~/.sf/config.json). The org
+// picker's OWN status bar updates because the org extension performs the config write in-process; the
+// metadata extension is a separate host and learns of the switch only via that file-change event, which
+// code-server does not deliver cross-extension for a file outside the workspace. CI run 34544008449 proved
+// this: `.not.toBeVisible({ timeout: 60_000 })` failed on all three attempts with the widget actively
+// refreshing the boot org's Remote/Local/Conflicts counts the whole time (a missing event, not lag). The
+// sibling nonTrackingOrgDeployRetrieve* container specs PASS because deploy/retrieve re-resolve the target
+// org fresh from config at command time, so only the reactive status-bar refresh is affected. Fixing this
+// needs a product change (metadata ext observing the org switch without a reload) or a window reload, which
+// code-server cannot do. Re-enable once the metadata source-tracking widget refreshes on a runtime switch.
+test.fixme('Non-Tracking Org (Code Builder): source tracking commands and status bar hidden', async ({ page }) => {
   // Switching + restoring the default org are quick config writes; the generous budget only covers slow
   // container startup and the async org/context refresh, not org creation (there is none here).
   test.setTimeout(180_000);

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/container/nonTrackingOrgTrackingUIHidden.container.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/container/nonTrackingOrgTrackingUIHidden.container.spec.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Code Builder container twin of nonTrackingOrgTrackingUIHidden.headless.
+ *
+ * The twin makes a fresh non-tracking scratch org the DEFAULT and asserts the source-tracking status bar
+ * widget and the tracking UI commands (reset, view-changes) are hidden. The container boots a SOURCE-
+ * TRACKING org as its default, so — as with the commands-hidden twin — this spec uses the multi-org
+ * capability (W-23898526): switch the DEFAULT to the second, NON-tracking org (nonTrackingTestOrg,
+ * CB_EXTRA_ORG_ALIASES) via the status-bar picker, assert the tracking UI is gone, then RESTORE the boot
+ * org as default (REQUIRED) so the shared serial session is not contaminated.
+ *
+ * Overlaps the commands-hidden twin but keeps the twin's distinct UI-focus: the status-bar WIDGET plus the
+ * reset/view-changes commands. Depends on CB_EXTRA_ORG_ALIASES; skips (never false-fails) when the extra
+ * org isn't authed on the host.
+ */
+
+import {
+  clearAllNotifications,
+  clickOrgPickerStatusBar,
+  closeAllEditors,
+  closeWelcomeTabs,
+  ensureSecondarySideBarHidden,
+  env,
+  execAsync,
+  expectOrgPickerListsOrg,
+  expectOrgPickerStatusBar,
+  MINIMAL_ORG_ALIAS,
+  NON_TRACKING_ORG_ALIAS,
+  saveScreenshot,
+  selectOrgInPicker,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  validateNoCriticalErrors,
+  verifyCommandDoesNotExist,
+  verifyCommandExists
+} from '@salesforce/playwright-vscode-ext';
+import { expect } from '@playwright/test';
+import { SourceTrackingStatusBarPage } from '../../pages/sourceTrackingStatusBarPage';
+import { containerTest as test } from '../../fixtures/containerFixtures';
+import packageNls from '../../../../package.nls.json';
+
+/** Resolve an org's username from the host CLI (the label the in-container picker shows for an unaliased org). */
+const resolveOrgUsername = async (alias: string): Promise<string> => {
+  const { stdout } = await execAsync(`sf org display -o ${alias} --json`, { env });
+  const parsed = JSON.parse(stdout) as { result?: { username?: string } };
+  const username = parsed.result?.username;
+  if (!username) {
+    throw new Error(`could not resolve username for org "${alias}" from \`sf org display\``);
+  }
+  return username;
+};
+
+test.beforeEach(async ({ page }) => {
+  await closeAllEditors(page);
+  await clearAllNotifications(page);
+});
+
+test('Non-Tracking Org (Code Builder): tracking UI elements are hidden', async ({ page }) => {
+  test.setTimeout(180_000);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  const bootOrgUsername = await resolveOrgUsername(MINIMAL_ORG_ALIAS).catch(() => undefined);
+  const extraOrgAuthed = await resolveOrgUsername(NON_TRACKING_ORG_ALIAS).catch(() => undefined);
+
+  test.skip(
+    !bootOrgUsername || !extraOrgAuthed,
+    `needs both "${MINIMAL_ORG_ALIAS}" (boot) and "${NON_TRACKING_ORG_ALIAS}" (CB_EXTRA_ORG_ALIASES) authed on the host`
+  );
+  const bootOrgLabel = bootOrgUsername!;
+
+  await test.step('workbench ready', async () => {
+    await closeWelcomeTabs(page);
+    await ensureSecondarySideBarHidden(page);
+    await saveScreenshot(page, 'nonTrackingUIHidden.container.01-ready.png');
+  });
+
+  await test.step('verify extension-activated command is present', async () => {
+    await verifyCommandExists(page, packageNls.sobjects_refresh, 60_000);
+  });
+
+  let switchedToExtra = false;
+  try {
+    await test.step('switch default org to nonTrackingTestOrg and assert it took', async () => {
+      await expectOrgPickerStatusBar(page, bootOrgLabel);
+      await clickOrgPickerStatusBar(page, bootOrgLabel);
+      await expectOrgPickerListsOrg(page, NON_TRACKING_ORG_ALIAS);
+      await selectOrgInPicker(page, NON_TRACKING_ORG_ALIAS);
+      switchedToExtra = true;
+      await expectOrgPickerStatusBar(page, NON_TRACKING_ORG_ALIAS);
+      await saveScreenshot(page, 'nonTrackingUIHidden.container.02-switched-to-nontracking.png');
+    });
+
+    await test.step('source tracking status bar widget does not appear for the non-tracking org', async () => {
+      // On the boot (tracking) org the widget is visible; switching to a non-tracking default must remove
+      // it. Waiting for it to leave also confirms the org/context refresh completed.
+      const statusBar = new SourceTrackingStatusBarPage(page);
+      await expect(statusBar.statusBarItem).not.toBeVisible({ timeout: 60_000 });
+      await saveScreenshot(page, 'nonTrackingUIHidden.container.03-status-bar-hidden.png');
+    });
+
+    await test.step('reset tracking command does not exist', async () => {
+      await verifyCommandDoesNotExist(page, packageNls.reset_remote_tracking_text);
+    });
+
+    await test.step('view changes commands do not exist', async () => {
+      await verifyCommandDoesNotExist(page, packageNls.view_all_changes_text);
+      await verifyCommandDoesNotExist(page, packageNls.view_local_changes_text);
+      await verifyCommandDoesNotExist(page, packageNls.view_remote_changes_text);
+    });
+  } finally {
+    await page.keyboard.press('Escape').catch(() => {});
+    if (switchedToExtra) {
+      await test.step('restore default org back to the boot org', async () => {
+        await clickOrgPickerStatusBar(page, NON_TRACKING_ORG_ALIAS);
+        await selectOrgInPicker(page, bootOrgLabel);
+        await expectOrgPickerStatusBar(page, bootOrgLabel);
+        await saveScreenshot(page, 'nonTrackingUIHidden.container.04-restored-boot-org.png');
+      });
+    }
+  }
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/container/nonTrackingOrgTrackingUIHidden.container.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/container/nonTrackingOrgTrackingUIHidden.container.spec.ts
@@ -61,7 +61,20 @@ test.beforeEach(async ({ page }) => {
   await clearAllNotifications(page);
 });
 
-test('Non-Tracking Org (Code Builder): tracking UI elements are hidden', async ({ page }) => {
+// fixme (W-23898526): the metadata extension's source-tracking status bar does NOT re-evaluate when the
+// default org is switched at runtime in the code-server container, so it keeps polling the boot (tracking)
+// org and never hides. Root cause: that widget reacts to default-org changes only through the config-file
+// watcher (services `watchConfigFiles` -> `FileChangePubSub` on the GLOBAL ~/.sf/config.json). The org
+// picker's OWN status bar updates because the org extension performs the config write in-process; the
+// metadata extension is a separate host and learns of the switch only via that file-change event, which
+// code-server does not deliver cross-extension for a file outside the workspace. CI run 34544008449 proved
+// this: `.not.toBeVisible({ timeout: 60_000 })` failed on all three attempts with the widget actively
+// refreshing the boot org's Remote/Local/Conflicts counts the whole time (a missing event, not lag). The
+// sibling nonTrackingOrgDeployRetrieve* container specs PASS because deploy/retrieve re-resolve the target
+// org fresh from config at command time, so only the reactive status-bar refresh is affected. Fixing this
+// needs a product change (metadata ext observing the org switch without a reload) or a window reload, which
+// code-server cannot do. Re-enable once the metadata source-tracking widget refreshes on a runtime switch.
+test.fixme('Non-Tracking Org (Code Builder): tracking UI elements are hidden', async ({ page }) => {
   test.setTimeout(180_000);
   const consoleErrors = setupConsoleMonitoring(page);
   const networkErrors = setupNetworkMonitoring(page);

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/container/refreshSObjectDefinitions.container.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/container/refreshSObjectDefinitions.container.spec.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Code Builder container twin of refreshSObjectDefinitions.headless.
+ *
+ * The web twin creates a Dreamhouse scratch org, makes it the DEFAULT, and runs `SFDX: Refresh SObject
+ * Definitions` to regenerate the faux Apex / typings under `.sfdx/tools/sobjects/...` from that org's
+ * schema. The container image boots ONE minimal org (minimalTestOrg, unaliased in-container so it
+ * surfaces by USERNAME) that has NO custom objects, so a refresh against it would do no meaningful custom
+ * work. This spec leans on the multi-org capability (W-23898526): the orchestrator auths a second,
+ * REAL-metadata Dreamhouse org (orgBrowserDreamhouseTestOrg, CB_EXTRA_ORG_ALIASES) into the running
+ * container. It switches the DEFAULT to that org through the status-bar picker, runs the CUSTOM refresh,
+ * confirms completion via the Salesforce Metadata output channel, then RESTORES the boot org as default
+ * so the shared serial session is not contaminated (REQUIRED).
+ *
+ * WORKABLE (unlike the source-tracking status-bar twins that hit the cross-extension-host config-watcher
+ * wall): the refresh command re-resolves the target-org connection FRESH at command time, so — like the
+ * sibling deploy/retrieve container specs — it queries whichever org is default when the command runs, no
+ * window reload needed. Depends on the CB_EXTRA_ORG_ALIASES multi-org capability; skips (never
+ * false-fails) when either org isn't authed on the host — i.e. a local run without the multi-org setup.
+ */
+
+import {
+  activeQuickInputWidget,
+  clearAllNotifications,
+  clearOutputChannel,
+  closeAllEditors,
+  closeWelcomeTabs,
+  DREAMHOUSE_ORG_ALIAS,
+  ensureOutputPanelOpen,
+  ensureSecondarySideBarHidden,
+  env,
+  execAsync,
+  executeCommandWithCommandPalette,
+  MINIMAL_ORG_ALIAS,
+  QUICK_INPUT_LIST_ROW,
+  saveScreenshot,
+  selectOutputChannel,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  switchDefaultOrgViaPicker,
+  validateNoCriticalErrors,
+  verifyCommandExists,
+  waitForOutputChannelText,
+  WORKBENCH
+} from '@salesforce/playwright-vscode-ext';
+import { containerTest as test } from '../../fixtures/containerFixtures';
+import packageNls from '../../../../package.nls.json';
+
+/** Resolve an org's username from the host CLI (the label the in-container picker shows for an unaliased org). */
+const resolveOrgUsername = async (alias: string): Promise<string | undefined> => {
+  const { stdout } = await execAsync(`sf org display -o ${alias} --json`, { env });
+  const parsed = JSON.parse(stdout) as { result?: { username?: string } };
+  return parsed.result?.username;
+};
+
+// Shared, long-lived workbench: reset editor + notification state before each test rather than assuming a
+// clean slate.
+test.beforeEach(async ({ page }) => {
+  await closeAllEditors(page);
+  await clearAllNotifications(page);
+});
+
+test('Refresh SObject Definitions (Code Builder): refreshes custom sObjects from the switched Dreamhouse org', async ({
+  page
+}) => {
+  // Budget covers slow container startup, the org switch, and a live Custom-sObject describe against the
+  // Dreamhouse org — not org creation (there is none here).
+  test.setTimeout(4 * 60 * 1000);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  // Boot org is unaliased in-container, so the picker/status bar show its USERNAME (resolve from host CLI);
+  // the Dreamhouse org keeps its alias in-container.
+  const bootOrgUsername = await resolveOrgUsername(MINIMAL_ORG_ALIAS).catch(() => undefined);
+  const dreamhouseAuthed = await resolveOrgUsername(DREAMHOUSE_ORG_ALIAS).catch(() => undefined);
+
+  // The Dreamhouse multi-org capability is CI-only (CB_EXTRA_ORG_ALIASES includes orgBrowserDreamhouseTestOrg
+  // for this package). Skip — never false-fail — when the host lacks either org, i.e. a local run without it.
+  test.skip(
+    !bootOrgUsername || !dreamhouseAuthed,
+    `needs both "${MINIMAL_ORG_ALIAS}" (boot) and "${DREAMHOUSE_ORG_ALIAS}" (CB_EXTRA_ORG_ALIASES) authed on the host`
+  );
+  const bootOrgLabel = bootOrgUsername!;
+
+  await test.step('workbench ready', async () => {
+    await closeWelcomeTabs(page);
+    await ensureSecondarySideBarHidden(page);
+    await saveScreenshot(page, 'refreshSObjectDefinitions.container.01-ready.png');
+  });
+
+  await test.step('verify the refresh command is present (extension activated)', async () => {
+    await verifyCommandExists(page, packageNls.sobjects_refresh, 60_000);
+  });
+
+  let switched = false;
+  try {
+    await test.step('switch default org to the Dreamhouse org and assert it took', async () => {
+      await switchDefaultOrgViaPicker(page, {
+        fromLabel: bootOrgLabel,
+        filterText: DREAMHOUSE_ORG_ALIAS,
+        expectLabel: DREAMHOUSE_ORG_ALIAS,
+        assertListsOrg: DREAMHOUSE_ORG_ALIAS
+      });
+      switched = true;
+      await saveScreenshot(page, 'refreshSObjectDefinitions.container.02-switched-to-dreamhouse.png');
+    });
+
+    await test.step('run Refresh SObject Definitions for Custom SObjects and confirm via output channel', async () => {
+      await ensureOutputPanelOpen(page);
+      await selectOutputChannel(page, 'Salesforce Metadata', 60_000);
+      await clearOutputChannel(page);
+      await page.locator(WORKBENCH).click();
+
+      await executeCommandWithCommandPalette(page, packageNls.sobjects_refresh);
+
+      // Refresh prompts for the category; pick Custom SObjects (the Dreamhouse org's real strength — the
+      // boot minimal org has none, so a green result here proves the command re-targeted the switched org).
+      const quickInput = activeQuickInputWidget(page);
+      await quickInput.waitFor({ state: 'attached', timeout: 10_000 });
+      await quickInput.locator(QUICK_INPUT_LIST_ROW).filter({ hasText: packageNls.sobject_refresh_custom }).click({
+        force: true
+      });
+      await saveScreenshot(page, 'refreshSObjectDefinitions.container.03-after-command.png');
+
+      // "Processed N Custom sObjects" line confirms the refresh ran to completion against the default org.
+      await waitForOutputChannelText(page, {
+        expectedText: packageNls.sobject_refresh_output_custom,
+        timeout: 120_000
+      });
+      await saveScreenshot(page, 'refreshSObjectDefinitions.container.04-refresh-complete.png');
+    });
+  } finally {
+    // REQUIRED save/restore: this shared serial session must not be left with the Dreamhouse org as the
+    // default, or later container specs (which assume the boot org) run against the wrong org. Restore
+    // through the SAME picker UI. Defensive Escape closes any picker left open by a failed assertion.
+    await page.keyboard.press('Escape').catch(() => {});
+    if (switched) {
+      await test.step('restore the default org back to the boot org', async () => {
+        await switchDefaultOrgViaPicker(page, {
+          fromLabel: DREAMHOUSE_ORG_ALIAS,
+          filterText: bootOrgLabel,
+          expectLabel: bootOrgLabel
+        });
+        await saveScreenshot(page, 'refreshSObjectDefinitions.container.05-restored-boot-org.png');
+      });
+    }
+  }
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-metadata/test/playwright/specs/container/sourceTrackingStatusBar.container.spec.ts
+++ b/packages/salesforcedx-vscode-metadata/test/playwright/specs/container/sourceTrackingStatusBar.container.spec.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Code Builder container twin of sourceTrackingStatusBar.headless.
+ *
+ * The web twin creates a Dreamhouse scratch org, makes it the default, and drives the source-tracking
+ * status-bar widget through a full local-change → deploy cycle (create Apex class → local count goes up →
+ * push → local count back to 0). This container twin runs against the BOOT org (minimalTestOrg) with NO
+ * runtime org switch — deliberately.
+ *
+ * Why no switch (and why this one IS workable where the sibling non-tracking twins are test.fixme'd): the
+ * source-tracking status bar refreshes on the metadata extension's own FileChangePubSub (workspace file
+ * events) and a ~60s poll — both of which the code-server container delivers fine. What it does NOT react
+ * to in the container is a RUNTIME DEFAULT-ORG SWITCH: that path fires only through a file-change event on
+ * the GLOBAL ~/.sf/config.json, which code-server does not deliver cross-extension-host (see the
+ * test.fixme reason on nonTrackingOrgTracking{UI,Commands}Hidden.container). This spec sidesteps that wall
+ * entirely: the boot org is source-tracking and is the default from activation, so the widget reflects it
+ * without any switch, and the local-change → deploy cycle exercises exactly the workspace-file/operation
+ * refresh paths that DO work in the container.
+ *
+ * Shared serial session hardening: absolute initial counts are NOT asserted (a prior spec may have left
+ * local changes or conflicts). Instead the invariants asserted are relative — the local count RISES by one
+ * after creating one class, and returns to 0 after an (ignore-conflicts) push of all local changes — plus
+ * the always-true "error background iff conflicts > 0" check.
+ */
+
+import { expect } from '@playwright/test';
+import {
+  clearAllNotifications,
+  closeAllEditors,
+  closeWelcomeTabs,
+  createApexClass,
+  editOpenFile,
+  ensureSecondarySideBarHidden,
+  executeCommandWithCommandPalette,
+  saveScreenshot,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  upsertSettings,
+  validateNoCriticalErrors,
+  verifyCommandExists
+} from '@salesforce/playwright-vscode-ext';
+import { SourceTrackingStatusBarPage } from '../../pages/sourceTrackingStatusBarPage';
+import { waitForDeployProgressNotificationToAppear } from '../../pages/notifications';
+import { containerTest as test } from '../../fixtures/containerFixtures';
+import packageNls from '../../../../package.nls.json';
+import { DEPLOY_TIMEOUT } from '../../../constants';
+import { CORE_CONFIG_SECTION, DEPLOY_ON_SAVE_ENABLED } from '../../../../src/constants';
+
+// Shared persistent workbench: reset editor + notification state before each test rather than assuming a
+// clean slate.
+test.beforeEach(async ({ page }) => {
+  await closeAllEditors(page);
+  await clearAllNotifications(page);
+});
+
+test('Source Tracking Status Bar (Code Builder): reflects local changes through a deploy cycle on the boot org', async ({
+  page
+}) => {
+  test.setTimeout(DEPLOY_TIMEOUT);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  await test.step('workbench ready', async () => {
+    // The containerTest fixture already awaited workbench readiness before handing over `page`.
+    await closeWelcomeTabs(page);
+    await ensureSecondarySideBarHidden(page);
+    await saveScreenshot(page, 'sourceTrackingStatusBar.container.01-ready.png');
+  });
+
+  await test.step('disable deploy-on-save so the created class stays a local change', async () => {
+    await upsertSettings(page, { [`${CORE_CONFIG_SECTION}.${DEPLOY_ON_SAVE_ENABLED}`]: 'false' });
+  });
+
+  const statusBar = new SourceTrackingStatusBarPage(page);
+
+  await test.step('status bar is visible against the boot (source-tracking) org', async () => {
+    // The boot org tracks source and is default from activation, so the widget shows its counts without
+    // any org switch — the whole point of running this twin against the boot org.
+    await statusBar.waitForVisible(120_000);
+    await verifyCommandExists(page, 'SFDX: Create Apex Class', 30_000);
+    await saveScreenshot(page, 'sourceTrackingStatusBar.container.02-visible.png');
+  });
+
+  const baseline = await test.step('read baseline counts (shared session — absolute values not assumed)', async () => {
+    const counts = await statusBar.getCounts();
+    // Invariant that holds regardless of what prior specs left behind: the red/error background appears
+    // exactly when there are conflicts.
+    const hasError = await statusBar.hasErrorBackground();
+    expect(hasError, 'Status bar error background should be present iff there are conflicts').toBe(
+      counts.conflicts > 0
+    );
+    return counts;
+  });
+
+  await test.step('create a new apex class and verify the local count rises by one', async () => {
+    const className = `StatusBarClass${Date.now()}`;
+    await createApexClass(page, className);
+    // Refresh may arrive via the workspace file event (fast) or the ~60s poll (fallback), so allow a
+    // generous window; only the LOCAL delta is asserted, so a nonzero baseline is fine.
+    await statusBar.waitForCounts({ local: baseline.local + 1 }, 90_000);
+    await saveScreenshot(page, 'sourceTrackingStatusBar.container.03-local-incremented.png');
+  });
+
+  await test.step('edit the open class and verify the local count stays the same', async () => {
+    await editOpenFile(page, '// Source tracking status bar container test');
+    const afterEdit = await statusBar.getCounts();
+    expect(afterEdit.local, 'Editing an already-changed component must not add another local change').toBe(
+      baseline.local + 1
+    );
+  });
+
+  await test.step('push all local changes and verify the local count returns to 0', async () => {
+    // Shared boot org can already differ remotely, so use the ignore-conflicts push to stay deterministic
+    // (matches the projectDeployStart container twin).
+    await executeCommandWithCommandPalette(page, packageNls.project_deploy_start_ignore_conflicts_default_org_text);
+    const deployingNotification = await waitForDeployProgressNotificationToAppear(page, 30_000);
+    await expect(deployingNotification).not.toBeVisible({ timeout: DEPLOY_TIMEOUT });
+
+    await statusBar.waitForCounts({ local: 0 }, 90_000);
+    await saveScreenshot(page, 'sourceTrackingStatusBar.container.04-local-cleared.png');
+  });
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-org-browser/test/playwright/pages/orgBrowserPage.ts
+++ b/packages/salesforcedx-vscode-org-browser/test/playwright/pages/orgBrowserPage.ts
@@ -254,6 +254,21 @@ export class OrgBrowserPage {
     return true;
   }
 
+  /**
+   * Force-refresh a metadata type by clicking its "Refresh Type" toolbar button. This re-queries the
+   * CURRENT default org for that type's component list (the underlying command invalidates the cache
+   * with `consistency: 'refresh'`). Used after switching the default org so the tree re-targets the
+   * new org instead of serving the previous org's cached listing.
+   */
+  public async refreshMetadataType(typeName: string): Promise<void> {
+    const typeItem = await this.findMetadataType(typeName);
+    await typeItem.hover();
+    const refreshButton = typeItem.locator('.action-label[aria-label="Refresh Type"]').first();
+    await expect(refreshButton, 'Refresh Type button should be visible').toBeVisible({ timeout: 5000 });
+    await refreshButton.click();
+    await saveScreenshot(this.page, `orgBrowserPage.refreshMetadataType.${typeName}.png`, true);
+  }
+
   // TODO: pass in a file name you expect.  Or have a new method that just waits for that element to be visible
   /**
    * Wait for any file to open in the editor

--- a/packages/salesforcedx-vscode-org-browser/test/playwright/specs/container/containerHelpers.ts
+++ b/packages/salesforcedx-vscode-org-browser/test/playwright/specs/container/containerHelpers.ts
@@ -18,7 +18,14 @@
  * This is not a `*.spec.ts` file, so Playwright does not collect it as a test.
  */
 
-import { expect } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
+import {
+  DREAMHOUSE_ORG_ALIAS,
+  env,
+  execAsync,
+  MINIMAL_ORG_ALIAS,
+  switchDefaultOrgViaPicker
+} from '@salesforce/playwright-vscode-ext';
 import type { OrgBrowserPage } from '../../pages/orgBrowserPage';
 
 const FILTER_TOOLBAR_BUTTON = '[aria-label="Filter by Type/Component"], [aria-label="Edit Filter (active)"]';
@@ -53,3 +60,47 @@ export const normalizeOrgBrowserFilters = async (orgBrowserPage: OrgBrowserPage)
   // Leave the view closed so each test's openOrgBrowser() opens it fresh with a single click.
   await activityBarItem.click();
 };
+
+/**
+ * Resolve an org's username from the host CLI. The container boots the minimal org UNALIASED, so the
+ * in-container picker/status bar show its USERNAME (not its host alias) — the label the switch helpers
+ * must target. The Dreamhouse extra org keeps its alias in-container. Returns undefined when the alias
+ * isn't authed on the host (a local run without the multi-org + Dreamhouse setup), so callers `test.skip`.
+ */
+const resolveOrgUsername = async (alias: string): Promise<string | undefined> => {
+  const { stdout } = await execAsync(`sf org display -o ${alias} --json`, { env });
+  const parsed = JSON.parse(stdout) as { result?: { username?: string } };
+  return parsed.result?.username;
+};
+
+/**
+ * Resolve the boot org's in-container label (its username) and confirm the Dreamhouse extra org is
+ * authed. Container Dreamhouse specs `test.skip` when either is missing (CI-only capability via
+ * CB_EXTRA_ORG_ALIASES=orgBrowserDreamhouseTestOrg for this package).
+ */
+export const resolveMultiOrgLabels = async (): Promise<{ bootOrgUsername?: string; dreamhouseAuthed?: string }> => {
+  const bootOrgUsername = await resolveOrgUsername(MINIMAL_ORG_ALIAS).catch(() => undefined);
+  const dreamhouseAuthed = await resolveOrgUsername(DREAMHOUSE_ORG_ALIAS).catch(() => undefined);
+  return { bootOrgUsername, dreamhouseAuthed };
+};
+
+/** Switch the default org from the boot org to the aliased Dreamhouse org via the status-bar picker. */
+export const switchToDreamhouseOrg = (page: Page, bootOrgLabel: string): Promise<void> =>
+  switchDefaultOrgViaPicker(page, {
+    fromLabel: bootOrgLabel,
+    filterText: DREAMHOUSE_ORG_ALIAS,
+    expectLabel: DREAMHOUSE_ORG_ALIAS,
+    assertListsOrg: DREAMHOUSE_ORG_ALIAS
+  });
+
+/**
+ * Restore the default org back to the boot org (by username) through the SAME picker UI. REQUIRED in a
+ * `finally`: the shared serial container session must not be left defaulted to the Dreamhouse org, or
+ * later container specs (which assume the boot org) run against the wrong org.
+ */
+export const restoreBootOrg = (page: Page, bootOrgLabel: string): Promise<void> =>
+  switchDefaultOrgViaPicker(page, {
+    fromLabel: DREAMHOUSE_ORG_ALIAS,
+    filterText: bootOrgLabel,
+    expectLabel: bootOrgLabel
+  });

--- a/packages/salesforcedx-vscode-org-browser/test/playwright/specs/container/orgBrowser.textFilter.container.spec.ts
+++ b/packages/salesforcedx-vscode-org-browser/test/playwright/specs/container/orgBrowser.textFilter.container.spec.ts
@@ -203,7 +203,9 @@ test('Org Browser - text filter: wildcard component pattern *Test* filters child
 });
 
 /*
- * SKIPPED (not ported): the headless twin's "Type:component filters expanded children"
- * (CustomObject:Broker__c) and "combined wildcard *Object:*Broker* works" subtests both assert on
- * the Dreamhouse CustomObject `Broker__c`, which the bare boot scratch org does not contain.
+ * MOVED (not omitted): the headless twin's "Type:component filters expanded children"
+ * (CustomObject:Broker__c) and "combined wildcard *Object:*Broker* works" subtests both assert on the
+ * Dreamhouse CustomObject `Broker__c`, which the bare boot scratch org does not contain. They are now
+ * ported to orgBrowserTextFilterDreamhouse.container.spec.ts, which switches the default org to the
+ * Dreamhouse org (multi-org capability) before filtering. This spec keeps only the boot-org subtests.
  */

--- a/packages/salesforcedx-vscode-org-browser/test/playwright/specs/container/orgBrowserCustomObject.container.spec.ts
+++ b/packages/salesforcedx-vscode-org-browser/test/playwright/specs/container/orgBrowserCustomObject.container.spec.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * FEASIBILITY SPIKE (W-23898526): Dreamhouse-org support for the Org Browser in the Code Builder
+ * container. The web twins (orgBrowser.customObject.headless) retrieve Dreamhouse metadata against a
+ * per-test Dreamhouse scratch org; the org-light container twins (orgBrowser.container /
+ * orgBrowser.describe.container) only prove universal types resolve against the boot org. This spec
+ * bridges the two: it browses REAL custom metadata (Dreamhouse `Property__c`/`Broker__c`) inside the
+ * container — the thing the boot minimal org lacks.
+ *
+ * THE SPIKE QUESTION: Org Browser always browses the DEFAULT org's metadata. The container boots ONE
+ * org (minimalTestOrg, unaliased — see orgPicker.container.spec.ts). CI additionally auths a Dreamhouse
+ * scratch org aliased `orgBrowserDreamhouseTestOrg` into the container via CB_EXTRA_ORG_ALIASES
+ * (.github/workflows/codeBuilderE2E.yml). The unknown: after the Org Browser has already opened against
+ * the boot org (caching its describe), does SWITCHING the default to the Dreamhouse org make the panel
+ * surface THAT org's custom objects — WITHOUT the window reload the code-server web container can't do?
+ * (The metadata source-tracking status bar hit exactly this cross-extension-host caching wall and had
+ * two specs test.fixme'd.) So this spec deliberately opens the browser against the boot org FIRST, then
+ * switches, so the probe exercises the "re-target a cached panel" path, not a fresh open.
+ *
+ * READ ON FEASIBILITY (harness evidence, not a guarantee — CI is the real probe): the Org Browser
+ * reacts to the default-org change in-process. src/index.ts subscribes to `TargetOrgRef.changes`
+ * (deduped by orgId) and calls `treeProvider.refreshType()` on every switch; and getChildren reads the
+ * CURRENT TargetOrgRef orgId on demand and queries a per-org OrgMetadataCatalog (former-org acquisitions
+ * are discarded via suppressInactiveOrgOperation). So it does NOT bake in the boot org at activation.
+ * This spec ALSO explicitly clicks the type's "Refresh Type" toolbar action (consistency: 'refresh')
+ * after the switch to force the new-org re-query rather than leaning on the auto-refresh timing. RISK:
+ * if TargetOrgRef doesn't propagate the switch to the Org Browser's (web) extension host without a
+ * reload — the same wall source-tracking hit — this spec fails in CI and the answer to the spike is
+ * "Org Browser needs a reload the web container can't do", i.e. this spec would need test.fixme like the
+ * source-tracking twins. That failure is the intended signal.
+ *
+ * Skips (never false-fails) when the boot org or the Dreamhouse extra org isn't authed on the host —
+ * i.e. a local run without the multi-org + Dreamhouse setup — mirroring orgPicker.container.spec.ts.
+ */
+
+import { expect } from '@playwright/test';
+import {
+  clearAllNotifications,
+  closeAllEditors,
+  closeWelcomeTabs,
+  DREAMHOUSE_ORG_ALIAS,
+  ensureSecondarySideBarHidden,
+  env,
+  execAsync,
+  MINIMAL_ORG_ALIAS,
+  saveScreenshot,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  switchDefaultOrgViaPicker,
+  validateNoCriticalErrors
+} from '@salesforce/playwright-vscode-ext';
+import { OrgBrowserPage } from '../../pages/orgBrowserPage';
+import { containerTest as test } from '../../fixtures/containerFixtures';
+import { normalizeOrgBrowserFilters } from './containerHelpers';
+
+/** A Dreamhouse custom object present after `sf project deploy start` of trailheadapps/dreamhouse-lwc. */
+const DREAMHOUSE_CUSTOM_OBJECT = 'Property__c';
+
+/** Resolve an org's username from the host CLI (the label the in-container picker shows for an unaliased org). */
+const resolveOrgUsername = async (alias: string): Promise<string | undefined> => {
+  const { stdout } = await execAsync(`sf org display -o ${alias} --json`, { env });
+  const parsed = JSON.parse(stdout) as { result?: { username?: string } };
+  return parsed.result?.username;
+};
+
+// Shared, long-lived workbench: reset editor + notification state and normalize the persisted Org
+// Browser filters (both toggles ON, no text filter) so a prior spec can't hide the org's components.
+test.beforeEach(async ({ page }) => {
+  await closeWelcomeTabs(page);
+  await ensureSecondarySideBarHidden(page);
+  await closeAllEditors(page);
+  await clearAllNotifications(page);
+  await normalizeOrgBrowserFilters(new OrgBrowserPage(page));
+});
+
+test('Org Browser (Code Builder): surfaces the switched Dreamhouse org custom objects', async ({ page }) => {
+  // Budget covers slow container startup, the async status-bar refresh after the switch, and a live
+  // CustomObject listMetadata against the Dreamhouse org — not org creation (there is none here).
+  test.setTimeout(4 * 60 * 1000);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+  const orgBrowserPage = new OrgBrowserPage(page);
+
+  // Boot org is unaliased in-container, so the picker/status bar show its USERNAME — resolve it from the
+  // host CLI (the host authed both orgs). The Dreamhouse org keeps its alias in-container.
+  const bootOrgUsername = await resolveOrgUsername(MINIMAL_ORG_ALIAS).catch(() => undefined);
+  const dreamhouseAuthed = await resolveOrgUsername(DREAMHOUSE_ORG_ALIAS).catch(() => undefined);
+
+  // The Dreamhouse multi-org capability is CI-only (CB_EXTRA_ORG_ALIASES=orgBrowserDreamhouseTestOrg for
+  // this package). Skip — never false-fail — when the host lacks either org, i.e. a local run without it.
+  test.skip(
+    !bootOrgUsername || !dreamhouseAuthed,
+    `dreamhouse probe needs both "${MINIMAL_ORG_ALIAS}" (boot) and "${DREAMHOUSE_ORG_ALIAS}" (CB_EXTRA_ORG_ALIASES) authed on the host`
+  );
+  const bootOrgLabel = bootOrgUsername!;
+
+  await test.step('open the Org Browser against the boot org (caches its describe)', async () => {
+    // Opening FIRST, before the switch, is deliberate: it makes the switch below re-target an
+    // already-populated panel — the actual spike question — rather than a fresh open.
+    await orgBrowserPage.openOrgBrowser();
+    await saveScreenshot(page, 'orgBrowserCustomObject.container.01-boot-org-open.png');
+  });
+
+  let switched = false;
+  try {
+    await test.step('switch the default org to the Dreamhouse org', async () => {
+      await switchDefaultOrgViaPicker(page, {
+        fromLabel: bootOrgLabel,
+        filterText: DREAMHOUSE_ORG_ALIAS,
+        expectLabel: DREAMHOUSE_ORG_ALIAS,
+        assertListsOrg: DREAMHOUSE_ORG_ALIAS
+      });
+      switched = true;
+      await saveScreenshot(page, 'orgBrowserCustomObject.container.02-switched-to-dreamhouse.png');
+    });
+
+    await test.step('refresh CustomObject so the tree re-queries the switched (Dreamhouse) org', async () => {
+      // Force the new-org re-query rather than depending on the auto-refresh watcher's timing. If the
+      // Org Browser could NOT re-target the switched org without a window reload, this + the assertion
+      // below is where the spike fails in CI (see the file header risk note).
+      await orgBrowserPage.refreshMetadataType('CustomObject');
+    });
+
+    await test.step(`expand CustomObject and assert the Dreamhouse object ${DREAMHOUSE_CUSTOM_OBJECT} is listed`, async () => {
+      await orgBrowserPage.expandFolder('CustomObject');
+      const item = await orgBrowserPage.getMetadataItem('CustomObject', DREAMHOUSE_CUSTOM_OBJECT);
+      await expect(item).toHaveRole('treeitem');
+      await expect(item).toHaveAttribute('aria-level', '2');
+      await expect(item).toHaveAccessibleName(new RegExp(DREAMHOUSE_CUSTOM_OBJECT));
+      await saveScreenshot(page, 'orgBrowserCustomObject.container.03-dreamhouse-custom-object.png');
+    });
+  } finally {
+    // REQUIRED save/restore: this shared serial session must not be left with the Dreamhouse org as the
+    // default, or later container specs (which assume the boot org) run against the wrong org. Restore
+    // through the SAME picker UI. Defensive Escape closes any picker left open by a failed assertion.
+    await page.keyboard.press('Escape').catch(() => {});
+    if (switched) {
+      await test.step('restore the default org back to the boot org', async () => {
+        await switchDefaultOrgViaPicker(page, {
+          fromLabel: DREAMHOUSE_ORG_ALIAS,
+          filterText: bootOrgLabel,
+          expectLabel: bootOrgLabel
+        });
+        await saveScreenshot(page, 'orgBrowserCustomObject.container.04-restored-boot-org.png');
+      });
+    }
+  }
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-org-browser/test/playwright/specs/container/orgBrowserCustomTab.container.spec.ts
+++ b/packages/salesforcedx-vscode-org-browser/test/playwright/specs/container/orgBrowserCustomTab.container.spec.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Container twin of orgBrowser.customTab.headless (ADR 0022), using the PROVEN Dreamhouse multi-org
+ * pattern (orgBrowserCustomObject.container.spec.ts). The headless twin retrieves the Dreamhouse
+ * `Broker__c` CustomTab from a per-test Dreamhouse scratch org; the boot minimal org the container
+ * boots has no such tab. This spec opens the Org Browser against the boot org FIRST (so the switch
+ * below re-targets an already-populated panel — the actual spike question), SWITCHES the default to
+ * the Dreamhouse org (aliased `orgBrowserDreamhouseTestOrg`, authed via CB_EXTRA_ORG_ALIASES), forces
+ * a CustomTab re-query with "Refresh Type", and asserts the Dreamhouse `Broker__c` CustomTab node.
+ * RESTORES the default to the boot org in `finally` so later serial specs run against the right org.
+ *
+ * Skips (never false-fails) when the boot org or the Dreamhouse extra org isn't authed on the host —
+ * a local run without the multi-org + Dreamhouse setup — mirroring orgBrowserCustomObject.container.
+ */
+
+import { expect } from '@playwright/test';
+import {
+  clearAllNotifications,
+  closeAllEditors,
+  closeWelcomeTabs,
+  DREAMHOUSE_ORG_ALIAS,
+  ensureSecondarySideBarHidden,
+  MINIMAL_ORG_ALIAS,
+  saveScreenshot,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  validateNoCriticalErrors
+} from '@salesforce/playwright-vscode-ext';
+import { OrgBrowserPage } from '../../pages/orgBrowserPage';
+import { containerTest as test } from '../../fixtures/containerFixtures';
+import {
+  normalizeOrgBrowserFilters,
+  resolveMultiOrgLabels,
+  restoreBootOrg,
+  switchToDreamhouseOrg
+} from './containerHelpers';
+
+/** A Dreamhouse CustomTab present after `sf project deploy start` of trailheadapps/dreamhouse-lwc. */
+const DREAMHOUSE_CUSTOM_TAB = 'Broker__c';
+
+// Shared, long-lived workbench: reset editor + notification state and normalize the persisted Org
+// Browser filters (both toggles ON, no text filter) so a prior spec can't hide the org's components.
+test.beforeEach(async ({ page }) => {
+  await closeWelcomeTabs(page);
+  await ensureSecondarySideBarHidden(page);
+  await closeAllEditors(page);
+  await clearAllNotifications(page);
+  await normalizeOrgBrowserFilters(new OrgBrowserPage(page));
+});
+
+test('Org Browser (Code Builder): surfaces the switched Dreamhouse org CustomTab', async ({ page }) => {
+  test.setTimeout(4 * 60 * 1000);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+  const orgBrowserPage = new OrgBrowserPage(page);
+
+  const { bootOrgUsername, dreamhouseAuthed } = await resolveMultiOrgLabels();
+  test.skip(
+    !bootOrgUsername || !dreamhouseAuthed,
+    `dreamhouse probe needs both "${MINIMAL_ORG_ALIAS}" (boot) and "${DREAMHOUSE_ORG_ALIAS}" (CB_EXTRA_ORG_ALIASES) authed on the host`
+  );
+  const bootOrgLabel = bootOrgUsername!;
+
+  await test.step('open the Org Browser against the boot org (caches its describe)', async () => {
+    await orgBrowserPage.openOrgBrowser();
+    await saveScreenshot(page, 'orgBrowserCustomTab.container.01-boot-org-open.png');
+  });
+
+  let switched = false;
+  try {
+    await test.step('switch the default org to the Dreamhouse org', async () => {
+      await switchToDreamhouseOrg(page, bootOrgLabel);
+      switched = true;
+      await saveScreenshot(page, 'orgBrowserCustomTab.container.02-switched-to-dreamhouse.png');
+    });
+
+    await test.step('refresh CustomTab so the tree re-queries the switched (Dreamhouse) org', async () => {
+      await orgBrowserPage.refreshMetadataType('CustomTab');
+    });
+
+    await test.step(`expand CustomTab and assert the Dreamhouse tab ${DREAMHOUSE_CUSTOM_TAB} is listed`, async () => {
+      await orgBrowserPage.expandFolder('CustomTab');
+      const item = await orgBrowserPage.getMetadataItem('CustomTab', DREAMHOUSE_CUSTOM_TAB);
+      await expect(item).toHaveRole('treeitem');
+      await expect(item).toHaveAttribute('aria-level', '2');
+      await expect(item).toHaveAccessibleName(new RegExp(DREAMHOUSE_CUSTOM_TAB));
+      await saveScreenshot(page, 'orgBrowserCustomTab.container.03-dreamhouse-custom-tab.png');
+    });
+  } finally {
+    // Defensive Escape closes any picker left open by a failed assertion.
+    await page.keyboard.press('Escape').catch(() => {});
+    if (switched) {
+      await test.step('restore the default org back to the boot org', async () => {
+        await restoreBootOrg(page, bootOrgLabel);
+        await saveScreenshot(page, 'orgBrowserCustomTab.container.04-restored-boot-org.png');
+      });
+    }
+  }
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-org-browser/test/playwright/specs/container/orgBrowserFolderedReport.container.spec.ts
+++ b/packages/salesforcedx-vscode-org-browser/test/playwright/specs/container/orgBrowserFolderedReport.container.spec.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Container twin of orgBrowser.folderedReport.headless (ADR 0022), using the PROVEN Dreamhouse
+ * multi-org pattern (orgBrowserCustomObject.container.spec.ts). Exercises FOLDERED metadata navigation
+ * (type -> report folder -> report), which universal boot-org types don't cover. NOTE (honesty):
+ * trailheadapps/dreamhouse-lwc ships NO reports directory; the report asserted here
+ * (`unfiled$public/flow_screen_prebuilt_report`) is a STANDARD org report present in the Dreamhouse
+ * scratch org — the same node the headless twin asserts. The value ported is the container's ability
+ * to surface a foldered Report against the SWITCHED default org, not Dreamhouse-authored report metadata.
+ *
+ * Opens the Org Browser against the boot org FIRST (so the switch re-targets an already-populated
+ * panel), SWITCHES the default to the Dreamhouse org (aliased `orgBrowserDreamhouseTestOrg`, authed via
+ * CB_EXTRA_ORG_ALIASES), forces a Report re-query with "Refresh Type", then navigates
+ * Report -> unfiled$public -> the report node. RESTORES the default to the boot org in `finally`.
+ *
+ * Skips (never false-fails) when the boot org or the Dreamhouse extra org isn't authed on the host.
+ */
+
+import { expect } from '@playwright/test';
+import {
+  clearAllNotifications,
+  closeAllEditors,
+  closeWelcomeTabs,
+  DREAMHOUSE_ORG_ALIAS,
+  ensureSecondarySideBarHidden,
+  MINIMAL_ORG_ALIAS,
+  saveScreenshot,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  validateNoCriticalErrors
+} from '@salesforce/playwright-vscode-ext';
+import { OrgBrowserPage } from '../../pages/orgBrowserPage';
+import { containerTest as test } from '../../fixtures/containerFixtures';
+import {
+  normalizeOrgBrowserFilters,
+  resolveMultiOrgLabels,
+  restoreBootOrg,
+  switchToDreamhouseOrg
+} from './containerHelpers';
+
+const REPORT_TYPE = 'Report';
+/** Public report folder present in every org (Dreamhouse scratch org included). */
+const REPORT_FOLDER = 'unfiled$public';
+/** Standard report node under the public folder — the same node the headless twin asserts. */
+const REPORT_ITEM = 'unfiled$public/flow_screen_prebuilt_report';
+
+// Shared, long-lived workbench: reset editor + notification state and normalize the persisted Org
+// Browser filters (both toggles ON, no text filter) so a prior spec can't hide the org's components.
+test.beforeEach(async ({ page }) => {
+  await closeWelcomeTabs(page);
+  await ensureSecondarySideBarHidden(page);
+  await closeAllEditors(page);
+  await clearAllNotifications(page);
+  await normalizeOrgBrowserFilters(new OrgBrowserPage(page));
+});
+
+test('Org Browser (Code Builder): surfaces a foldered Report against the switched Dreamhouse org', async ({ page }) => {
+  test.setTimeout(4 * 60 * 1000);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+  const orgBrowserPage = new OrgBrowserPage(page);
+
+  const { bootOrgUsername, dreamhouseAuthed } = await resolveMultiOrgLabels();
+  test.skip(
+    !bootOrgUsername || !dreamhouseAuthed,
+    `dreamhouse probe needs both "${MINIMAL_ORG_ALIAS}" (boot) and "${DREAMHOUSE_ORG_ALIAS}" (CB_EXTRA_ORG_ALIASES) authed on the host`
+  );
+  const bootOrgLabel = bootOrgUsername!;
+
+  await test.step('open the Org Browser against the boot org (caches its describe)', async () => {
+    await orgBrowserPage.openOrgBrowser();
+    await saveScreenshot(page, 'orgBrowserFolderedReport.container.01-boot-org-open.png');
+  });
+
+  let switched = false;
+  try {
+    await test.step('switch the default org to the Dreamhouse org', async () => {
+      await switchToDreamhouseOrg(page, bootOrgLabel);
+      switched = true;
+      await saveScreenshot(page, 'orgBrowserFolderedReport.container.02-switched-to-dreamhouse.png');
+    });
+
+    await test.step('refresh Report so the tree re-queries the switched (Dreamhouse) org', async () => {
+      await orgBrowserPage.refreshMetadataType(REPORT_TYPE);
+    });
+
+    await test.step(`expand ${REPORT_TYPE} and locate the ${REPORT_FOLDER} folder`, async () => {
+      await orgBrowserPage.expandFolder(REPORT_TYPE);
+      const folder = await orgBrowserPage.getMetadataItem(REPORT_TYPE, REPORT_FOLDER, 2);
+      await expect(folder).toHaveRole('treeitem');
+      await expect(folder).toHaveAttribute('aria-level', '2');
+      await orgBrowserPage.expandFolder(REPORT_FOLDER, 2);
+      await saveScreenshot(page, 'orgBrowserFolderedReport.container.03-report-folder.png');
+    });
+
+    await test.step(`assert the foldered report ${REPORT_ITEM} is listed at level 3`, async () => {
+      const item = await orgBrowserPage.getMetadataItem(REPORT_FOLDER, REPORT_ITEM, 3);
+      await expect(item).toHaveRole('treeitem');
+      await expect(item).toHaveAttribute('aria-level', '3');
+      await saveScreenshot(page, 'orgBrowserFolderedReport.container.04-foldered-report.png');
+    });
+  } finally {
+    // Defensive Escape closes any picker left open by a failed assertion.
+    await page.keyboard.press('Escape').catch(() => {});
+    if (switched) {
+      await test.step('restore the default org back to the boot org', async () => {
+        await restoreBootOrg(page, bootOrgLabel);
+        await saveScreenshot(page, 'orgBrowserFolderedReport.container.05-restored-boot-org.png');
+      });
+    }
+  }
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-org-browser/test/playwright/specs/container/orgBrowserTextFilterDreamhouse.container.spec.ts
+++ b/packages/salesforcedx-vscode-org-browser/test/playwright/specs/container/orgBrowserTextFilterDreamhouse.container.spec.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Container coverage for the two Broker__c-specific text-filter subtests of orgBrowser.textFilter.headless
+ * that orgBrowser.textFilter.container.spec.ts intentionally OMITS (its boot minimal org has no
+ * Dreamhouse `Broker__c` CustomObject). Kept in a SEPARATE spec — rather than mixing switch/non-switch
+ * subtests into the boot-org textFilter container spec — using the PROVEN Dreamhouse multi-org pattern
+ * (orgBrowserCustomObject.container.spec.ts): each test opens the Org Browser against the boot org,
+ * SWITCHES the default to the Dreamhouse org (aliased `orgBrowserDreamhouseTestOrg`, authed via
+ * CB_EXTRA_ORG_ALIASES), forces a CustomObject re-query with "Refresh Type", applies the text filter,
+ * asserts against `Broker__c`, and RESTORES the default to the boot org in `finally`.
+ *
+ * Skips (never false-fails) when the boot org or the Dreamhouse extra org isn't authed on the host.
+ */
+
+import { expect } from '@playwright/test';
+import {
+  clearAllNotifications,
+  closeAllEditors,
+  closeWelcomeTabs,
+  DREAMHOUSE_ORG_ALIAS,
+  ensureSecondarySideBarHidden,
+  MINIMAL_ORG_ALIAS,
+  saveScreenshot,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  validateNoCriticalErrors
+} from '@salesforce/playwright-vscode-ext';
+import { OrgBrowserPage } from '../../pages/orgBrowserPage';
+import { containerTest as test } from '../../fixtures/containerFixtures';
+import {
+  normalizeOrgBrowserFilters,
+  resolveMultiOrgLabels,
+  restoreBootOrg,
+  switchToDreamhouseOrg
+} from './containerHelpers';
+
+// Shared, long-lived workbench: reset editor + notification state and normalize the persisted Org
+// Browser filters (both toggles ON, no text filter) so a prior spec can't hide the org's components.
+test.beforeEach(async ({ page }) => {
+  await closeWelcomeTabs(page);
+  await ensureSecondarySideBarHidden(page);
+  await closeAllEditors(page);
+  await clearAllNotifications(page);
+  await normalizeOrgBrowserFilters(new OrgBrowserPage(page));
+});
+
+test('Org Browser (Code Builder): text filter CustomObject:Broker__c narrows to the Dreamhouse component', async ({
+  page
+}) => {
+  test.setTimeout(4 * 60 * 1000);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+  const orgBrowserPage = new OrgBrowserPage(page);
+
+  const { bootOrgUsername, dreamhouseAuthed } = await resolveMultiOrgLabels();
+  test.skip(
+    !bootOrgUsername || !dreamhouseAuthed,
+    `dreamhouse probe needs both "${MINIMAL_ORG_ALIAS}" (boot) and "${DREAMHOUSE_ORG_ALIAS}" (CB_EXTRA_ORG_ALIASES) authed on the host`
+  );
+  const bootOrgLabel = bootOrgUsername!;
+
+  await test.step('open the Org Browser against the boot org (caches its describe)', async () => {
+    await orgBrowserPage.openOrgBrowser();
+  });
+
+  let switched = false;
+  try {
+    await test.step('switch the default org to the Dreamhouse org', async () => {
+      await switchToDreamhouseOrg(page, bootOrgLabel);
+      switched = true;
+    });
+
+    await test.step('refresh CustomObject so the tree re-queries the switched (Dreamhouse) org', async () => {
+      await orgBrowserPage.refreshMetadataType('CustomObject');
+    });
+
+    await test.step('apply CustomObject:Broker__c and assert the Broker__c child is listed', async () => {
+      await orgBrowserPage.applyTextFilter('CustomObject:Broker__c');
+      await orgBrowserPage.expandFolder('CustomObject');
+      const components = orgBrowserPage.sidebar.getByRole('treeitem', { level: 2 });
+      await expect(components.first()).toBeVisible({ timeout: 10_000 });
+      await expect(components.first()).toHaveAccessibleName(/Broker__c/i);
+      await saveScreenshot(page, 'orgBrowserTextFilterDreamhouse.container.01-custom-object-broker.png');
+    });
+  } finally {
+    // Defensive Escape closes any picker left open by a failed assertion.
+    await page.keyboard.press('Escape').catch(() => {});
+    if (switched) {
+      await test.step('restore the default org back to the boot org', async () => {
+        await restoreBootOrg(page, bootOrgLabel);
+      });
+    }
+  }
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});
+
+test('Org Browser (Code Builder): combined wildcard *Object:*Broker* resolves to Dreamhouse CustomObject Broker__c', async ({
+  page
+}) => {
+  test.setTimeout(4 * 60 * 1000);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+  const orgBrowserPage = new OrgBrowserPage(page);
+
+  const { bootOrgUsername, dreamhouseAuthed } = await resolveMultiOrgLabels();
+  test.skip(
+    !bootOrgUsername || !dreamhouseAuthed,
+    `dreamhouse probe needs both "${MINIMAL_ORG_ALIAS}" (boot) and "${DREAMHOUSE_ORG_ALIAS}" (CB_EXTRA_ORG_ALIASES) authed on the host`
+  );
+  const bootOrgLabel = bootOrgUsername!;
+
+  await test.step('open the Org Browser against the boot org (caches its describe)', async () => {
+    await orgBrowserPage.openOrgBrowser();
+  });
+
+  let switched = false;
+  try {
+    await test.step('switch the default org to the Dreamhouse org', async () => {
+      await switchToDreamhouseOrg(page, bootOrgLabel);
+      switched = true;
+    });
+
+    await test.step('refresh CustomObject so the tree re-queries the switched (Dreamhouse) org', async () => {
+      await orgBrowserPage.refreshMetadataType('CustomObject');
+    });
+
+    await test.step('apply *Object:*Broker* and assert it resolves to CustomObject -> Broker__c', async () => {
+      await orgBrowserPage.applyTextFilter('*Object:*Broker*');
+
+      const types = orgBrowserPage.sidebar.getByRole('treeitem', { level: 1 });
+      await expect(types).toHaveCount(1, { timeout: 10_000 });
+      await expect(types.first()).toHaveAccessibleName(/^CustomObject/);
+
+      await orgBrowserPage.expandFolder('CustomObject');
+      const components = orgBrowserPage.sidebar.getByRole('treeitem', { level: 2 });
+      await expect(components).toHaveCount(1, { timeout: 10_000 });
+      await expect(components.first()).toHaveAccessibleName(/Broker__c/i);
+      await saveScreenshot(page, 'orgBrowserTextFilterDreamhouse.container.02-wildcard-broker.png');
+    });
+  } finally {
+    // Defensive Escape closes any picker left open by a failed assertion.
+    await page.keyboard.press('Escape').catch(() => {});
+    if (switched) {
+      await test.step('restore the default org back to the boot org', async () => {
+        await restoreBootOrg(page, bootOrgLabel);
+      });
+    }
+  }
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-org/test/playwright/specs/container/orgPicker.container.spec.ts
+++ b/packages/salesforcedx-vscode-org/test/playwright/specs/container/orgPicker.container.spec.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Code Builder container twin of orgPicker.desktop (see docs/adr/0022-code-builder-e2e-desktop-build-over-browser.md).
+ *
+ * FEASIBILITY SPIKE (W-23898526): this is the probe for the multi-org capability. The container image
+ * boots ONE org (SF_ACCESS_TOKEN/INSTANCE_URL token injection, see codeBuilder/auth.ts). The orchestrator
+ * additionally auths every alias in CB_EXTRA_ORG_ALIASES into the running container via `sf org login
+ * sfdx-url` BEFORE the workbench restart (codeBuilderLocalE2E.ts authExtraOrgsIntoContainer). In CI that
+ * env is set to `nonTrackingTestOrg` only for this package (.github/workflows/codeBuilderE2E.yml). The
+ * single unknown this spec answers: does the in-container extension's org picker SURFACE that second org,
+ * given it was authed after boot but before the restart re-activated the extension — WITHOUT a window
+ * reload (which the web/code-server container can't do)?
+ *
+ * ALIAS vs USERNAME (important): the boot org is authed via token injection and gets NO `minimalTestOrg`
+ * alias inside the container (same reason aliasList.container asserts only the table header). orgList.ts
+ * renders a picker row / status-bar label as the org ALIAS when present, else the USERNAME. So the boot
+ * org appears by USERNAME (resolved here from the host CLI), while nonTrackingTestOrg — authed with an
+ * explicit `--alias` — appears by that alias. This spec therefore asserts the boot org by username and the
+ * extra org by alias; asserting the literal `minimalTestOrg` alias would never pass in-container.
+ *
+ * Depends on the CB_EXTRA_ORG_ALIASES multi-org capability. Skips (rather than false-failing) when the
+ * extra org isn't authed on the host — i.e. a local run without the multi-org setup.
+ */
+
+import {
+  clearAllNotifications,
+  clickOrgPickerStatusBar,
+  closeAllEditors,
+  closeWelcomeTabs,
+  ensureSecondarySideBarHidden,
+  env,
+  execAsync,
+  expectOrgPickerListsOrg,
+  expectOrgPickerStatusBar,
+  MINIMAL_ORG_ALIAS,
+  NON_TRACKING_ORG_ALIAS,
+  saveScreenshot,
+  selectOrgInPicker,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  validateNoCriticalErrors,
+  verifyCommandExists
+} from '@salesforce/playwright-vscode-ext';
+import { containerTest as test } from '../../fixtures/containerFixtures';
+import packageNls from '../../../../package.nls.json';
+
+/** Resolve an org's username from the host CLI (the label the in-container picker shows for an unaliased org). */
+const resolveOrgUsername = async (alias: string): Promise<string> => {
+  const { stdout } = await execAsync(`sf org display -o ${alias} --json`, { env });
+  const parsed = JSON.parse(stdout) as { result?: { username?: string } };
+  const username = parsed.result?.username;
+  if (!username) {
+    throw new Error(`could not resolve username for org "${alias}" from \`sf org display\``);
+  }
+  return username;
+};
+
+// Shared persistent workbench: reset editor + notification state before each test rather than
+// assuming a clean slate.
+test.beforeEach(async ({ page }) => {
+  await closeAllEditors(page);
+  await clearAllNotifications(page);
+});
+
+test('org extension (Code Builder): org picker surfaces the boot org AND the extra multi-org (nonTrackingTestOrg)', async ({
+  page
+}) => {
+  // Switching the default org + restoring it are quick config writes; the generous budget only covers
+  // slow container startup / async status-bar refresh, not org creation (there is none here).
+  test.setTimeout(180_000);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  // The boot org is unaliased in-container, so the picker/status bar show its USERNAME — resolve it from
+  // the host CLI (the host authed both orgs). nonTrackingTestOrg keeps its alias in-container.
+  const defaultOrgUsername = await resolveOrgUsername(MINIMAL_ORG_ALIAS).catch(() => undefined);
+  const extraOrgAuthed = await resolveOrgUsername(NON_TRACKING_ORG_ALIAS).catch(() => undefined);
+
+  // The multi-org capability is CI-only (CB_EXTRA_ORG_ALIASES, set for this package). Skip — never
+  // false-fail — when the host lacks either org, i.e. a local run without the multi-org setup.
+  test.skip(
+    !defaultOrgUsername || !extraOrgAuthed,
+    `multi-org probe needs both "${MINIMAL_ORG_ALIAS}" (boot) and "${NON_TRACKING_ORG_ALIAS}" (CB_EXTRA_ORG_ALIASES) authed on the host`
+  );
+  const bootOrgLabel = defaultOrgUsername!;
+
+  await test.step('wait for workbench', async () => {
+    // The containerTest fixture already awaited workbench readiness before handing over `page`.
+    await closeWelcomeTabs(page);
+    await ensureSecondarySideBarHidden(page);
+    await saveScreenshot(page, 'orgPicker.container.01-ready.png');
+  });
+
+  // Gate on an always-present activation command so we don't get a false negative on slow startup.
+  await test.step('verify extension-activated command is present', async () => {
+    await verifyCommandExists(page, packageNls.org_login_web_authorize_org_text, 60_000);
+  });
+
+  // Track whether we actually switched, so the restore step is a no-op if the CORE proof failed before
+  // the switch (the picker is then closed defensively below either way).
+  let switchedToExtra = false;
+  try {
+    await test.step('org picker lists BOTH the boot org and nonTrackingTestOrg (core capability proof)', async () => {
+      // The boot org is the default, so the status bar shows its username (not "No Default Org Set").
+      await expectOrgPickerStatusBar(page, bootOrgLabel);
+      await clickOrgPickerStatusBar(page, bootOrgLabel);
+      // Both orgs must be listed in the same freshly-opened picker. The extra-org row is THE proof that
+      // an org authed after boot (pre-restart) surfaces without a window reload.
+      await expectOrgPickerListsOrg(page, bootOrgLabel);
+      await expectOrgPickerListsOrg(page, NON_TRACKING_ORG_ALIAS);
+      await saveScreenshot(page, 'orgPicker.container.02-both-orgs-listed.png');
+    });
+
+    await test.step('switch default org to nonTrackingTestOrg and assert it took', async () => {
+      // Picker is still open from the step above; select the extra org row to set it as the default.
+      await selectOrgInPicker(page, NON_TRACKING_ORG_ALIAS);
+      switchedToExtra = true;
+      // The TargetOrgRef watcher refreshes the status bar after the config write — no reload needed.
+      await expectOrgPickerStatusBar(page, NON_TRACKING_ORG_ALIAS);
+      await saveScreenshot(page, 'orgPicker.container.03-switched-to-extra.png');
+    });
+  } finally {
+    // REQUIRED save/restore: this shared serial session must not be left with nonTrackingTestOrg as the
+    // default, or later container specs run against the wrong org. Restore through the SAME picker UI.
+    // Defensive Escape closes any picker left open by a failed assertion above.
+    await page.keyboard.press('Escape').catch(() => {});
+    if (switchedToExtra) {
+      await test.step('restore default org back to the boot org', async () => {
+        await clickOrgPickerStatusBar(page, NON_TRACKING_ORG_ALIAS);
+        await selectOrgInPicker(page, bootOrgLabel);
+        await expectOrgPickerStatusBar(page, bootOrgLabel);
+        await saveScreenshot(page, 'orgPicker.container.04-restored-boot-org.png');
+      });
+    }
+  }
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-org/test/playwright/specs/container/orgPickers.container.spec.ts
+++ b/packages/salesforcedx-vscode-org/test/playwright/specs/container/orgPickers.container.spec.ts
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/*
+ * Code Builder container twin of orgPickers.desktop (see docs/adr/0022-code-builder-e2e-desktop-build-over-browser.md).
+ *
+ * The desktop twin exercises the three migrated org pickers (selectOrgForDisplay single-pick,
+ * selectDeletableOrg multi-pick, orgLogoutAllCommand inline multi-pick) plus their cancel mappings,
+ * AND performs REAL logout/logout-default against dedicated throwaway orgs it creates on the fly.
+ *
+ * Multi-org capability (W-23898526): the container now boots the tracking org (SF_ACCESS_TOKEN
+ * injection) as the DEFAULT and the orchestrator additionally auths CB_EXTRA_ORG_ALIASES
+ * (nonTrackingTestOrg in CI) into the running container before the workbench restart. That second org
+ * is what makes these pickers meaningful in-container: they now enumerate TWO orgs, so "pick a
+ * specific org from the list" is a real choice rather than a one-row rubber stamp.
+ *
+ * WHAT THIS PORTS (all non-destructive, safe for the shared serial session):
+ *   - DISPLAY (single-pick): the picker lists BOTH orgs; picking the extra org shells
+ *     `sf org display --target-org <picked>` and its username lands in the output channel — the proof
+ *     that the picked (non-default) org drove the command.
+ *   - DISPLAY / LOGOUT cancel: Esc on the picker maps to CANCEL (no error toast).
+ *   - DELETE (multi-pick): the picker lists BOTH orgs; toggling the extra org + Enter reaches the
+ *     confirm modal, which is Escaped (CANCEL) so NOTHING is deleted.
+ *   - DELETE cancel: pick-nothing + Enter ([] empty array) maps to CANCEL.
+ *   - LOGOUT (multi-pick): the picker lists BOTH orgs; toggle + Enter reaches the confirm modal,
+ *     which is Escaped (CANCEL) so NOTHING is logged out.
+ *
+ * WHAT THIS OMITS (cannot run in the shared container — the honesty carve-out): the twin's REAL
+ * logout / logout-default steps. Those need (a) `createThrowawayOrg` sacrificial orgs, which the
+ * container cannot mint (no dev-hub-backed scratch creation inside the code-server image), and
+ * (b) actually removing auth — which, against either of the two pre-provisioned orgs, would corrupt
+ * the shared serial session that every later container spec depends on. There is no third,
+ * disposable org to sacrifice, so the destructive removeAuth paths are intentionally not ported.
+ *
+ * ALIAS vs USERNAME: the boot org is token-authed and carries NO alias in-container, so it surfaces
+ * by USERNAME (resolved here from the host CLI); nonTrackingTestOrg was authed with `--alias`, so it
+ * surfaces by that alias. Same rationale as orgPicker.container / aliasList.container.
+ *
+ * Skips (never false-fails) when the host lacks either org — i.e. a local run without the multi-org
+ * setup (CB_EXTRA_ORG_ALIASES is CI-only, set for this package).
+ */
+
+import { expect, type Page } from '@playwright/test';
+import {
+  activeQuickInputWidget,
+  clearAllNotifications,
+  closeAllEditors,
+  closeWelcomeTabs,
+  ensureOutputPanelOpen,
+  ensureSecondarySideBarHidden,
+  env,
+  execAsync,
+  executeCommandWithCommandPalette,
+  expectOrgPickerListsOrg,
+  MINIMAL_ORG_ALIAS,
+  NON_TRACKING_ORG_ALIAS,
+  NOTIFICATION_LIST_ITEM,
+  QUICK_INPUT_LIST_ROW,
+  QUICK_INPUT_WIDGET,
+  saveScreenshot,
+  selectOrgInPicker,
+  selectOutputChannel,
+  setupConsoleMonitoring,
+  setupNetworkMonitoring,
+  validateNoCriticalErrors,
+  verifyCommandExists,
+  waitForOutputChannelText
+} from '@salesforce/playwright-vscode-ext';
+import { containerTest as test } from '../../fixtures/containerFixtures';
+import packageNls from '../../../../package.nls.json';
+
+// `channel_name` from salesforcedx-vscode-org/src/messages/i18n.ts (orgDisplay writes its table here).
+const ORG_OUTPUT_CHANNEL = 'Salesforce Org Management';
+
+/** Resolve an org's username from the host CLI (the label the in-container picker shows for an unaliased org). */
+const resolveOrgUsername = async (alias: string): Promise<string> => {
+  const { stdout } = await execAsync(`sf org display -o ${alias} --json`, { env });
+  const parsed = JSON.parse(stdout) as { result?: { username?: string } };
+  const username = parsed.result?.username;
+  if (!username) {
+    throw new Error(`could not resolve username for org "${alias}" from \`sf org display\``);
+  }
+  return username;
+};
+
+/** Toggle a `canPickMany` quick-pick row's checkbox by typing the label and clicking the matching org row. */
+const toggleMultiPickRow = async (page: Page, label: string): Promise<void> => {
+  await page.keyboard.type(label);
+  const row = activeQuickInputWidget(page)
+    .locator(QUICK_INPUT_LIST_ROW)
+    .filter({ hasText: label })
+    .filter({ hasNotText: 'SFDX:' })
+    .first();
+  await row.waitFor({ state: 'visible', timeout: 10_000 });
+  await row.click({ force: true });
+};
+
+/** Assert no error toast surfaced (UserCancellationError must map to CANCEL, never an error notification). */
+const expectNoErrorNotification = async (page: Page): Promise<void> => {
+  await expect(
+    page.locator(NOTIFICATION_LIST_ITEM).filter({ has: page.locator('.codicon-error') }),
+    'a CANCEL flow must not surface an error notification'
+  ).toHaveCount(0);
+};
+
+// Shared persistent workbench: reset editor + notification state before each test rather than
+// assuming a clean slate.
+test.beforeEach(async ({ page }) => {
+  await closeAllEditors(page);
+  await clearAllNotifications(page);
+});
+
+test('org extension (Code Builder): migrated pickers enumerate BOTH orgs across display/delete/logout (non-destructive)', async ({
+  page
+}) => {
+  // Generous budget for slow container startup + several cold sf shell-outs; no org creation here.
+  test.setTimeout(180_000);
+  const consoleErrors = setupConsoleMonitoring(page);
+  const networkErrors = setupNetworkMonitoring(page);
+
+  // Boot org is unaliased in-container -> pickers show its USERNAME; nonTrackingTestOrg keeps its alias.
+  const bootOrgUsername = await resolveOrgUsername(MINIMAL_ORG_ALIAS).catch(() => undefined);
+  const extraOrgUsername = await resolveOrgUsername(NON_TRACKING_ORG_ALIAS).catch(() => undefined);
+
+  // The multi-org capability is CI-only (CB_EXTRA_ORG_ALIASES). Skip — never false-fail — when the
+  // host lacks either org, i.e. a local run without the multi-org setup.
+  test.skip(
+    !bootOrgUsername || !extraOrgUsername,
+    `multi-org port needs both "${MINIMAL_ORG_ALIAS}" (boot) and "${NON_TRACKING_ORG_ALIAS}" (CB_EXTRA_ORG_ALIASES) authed on the host`
+  );
+  const bootOrgLabel = bootOrgUsername!;
+  const extraOrgUsernameValue = extraOrgUsername!;
+
+  await test.step('wait for workbench', async () => {
+    // The containerTest fixture already awaited workbench readiness before handing over `page`.
+    await closeWelcomeTabs(page);
+    await ensureSecondarySideBarHidden(page);
+    await saveScreenshot(page, 'orgPickers.container.01-ready.png');
+  });
+
+  // Gate on an always-present activation command so we don't false-negative on slow startup.
+  await test.step('verify extension is activated', async () => {
+    await verifyCommandExists(page, packageNls.org_login_web_authorize_org_text, 60_000);
+  });
+
+  await test.step('DISPLAY: selectOrgForDisplay lists BOTH orgs; pick the extra org, assert its username in output', async () => {
+    await executeCommandWithCommandPalette(page, packageNls.org_display_username_text);
+    // Multi-org proof: the single-pick display picker enumerates both authed orgs.
+    await expectOrgPickerListsOrg(page, bootOrgLabel);
+    await expectOrgPickerListsOrg(page, NON_TRACKING_ORG_ALIAS);
+    await saveScreenshot(page, 'orgPickers.container.02-display-both-listed.png');
+    // Pick the NON-default extra org; orgDisplay shells `sf org display --target-org <picked> --json`.
+    await selectOrgInPicker(page, NON_TRACKING_ORG_ALIAS);
+    await ensureOutputPanelOpen(page);
+    await selectOutputChannel(page, ORG_OUTPUT_CHANNEL, 30_000);
+    // The picked (extra) org's username in the rendered table proves the picked org — not the default —
+    // drove the display round-trip.
+    await waitForOutputChannelText(page, { expectedText: extraOrgUsernameValue, timeout: 60_000 });
+    await saveScreenshot(page, 'orgPickers.container.03-display-extra-username.png');
+  });
+
+  await test.step('DISPLAY cancel: Esc on the picker maps to CANCEL (no error toast)', async () => {
+    await executeCommandWithCommandPalette(page, packageNls.org_display_username_text);
+    await expectOrgPickerListsOrg(page, NON_TRACKING_ORG_ALIAS);
+    await page.keyboard.press('Escape');
+    await expect(page.locator(QUICK_INPUT_WIDGET)).toBeHidden({ timeout: 10_000 });
+    await expectNoErrorNotification(page);
+  });
+
+  await test.step('DELETE: selectDeletableOrg multi-pick lists BOTH orgs, toggle extra, then Esc-cancel the confirm', async () => {
+    await executeCommandWithCommandPalette(page, packageNls.org_delete_username_text);
+    await expectOrgPickerListsOrg(page, bootOrgLabel);
+    await expectOrgPickerListsOrg(page, NON_TRACKING_ORG_ALIAS);
+    // Toggle the extra org row (canPickMany), accept to reach the confirm modal, then CANCEL it so
+    // NOTHING is deleted (non-destructive against the shared session).
+    await toggleMultiPickRow(page, NON_TRACKING_ORG_ALIAS);
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Escape');
+    await expectNoErrorNotification(page);
+  });
+
+  await test.step('DELETE cancel: multi-pick pick-nothing + Enter ([] empty array) maps to CANCEL', async () => {
+    await executeCommandWithCommandPalette(page, packageNls.org_delete_username_text);
+    await expectOrgPickerListsOrg(page, NON_TRACKING_ORG_ALIAS);
+    // Accept with nothing selected -> [] -> empty-array guard -> CANCEL (no confirm modal).
+    await page.keyboard.press('Enter');
+    await expect(page.locator(QUICK_INPUT_WIDGET)).toBeHidden({ timeout: 10_000 });
+    await expectNoErrorNotification(page);
+  });
+
+  await test.step('LOGOUT: orgLogoutAllCommand multi-pick lists BOTH orgs, toggle extra, then Esc-cancel the confirm', async () => {
+    await executeCommandWithCommandPalette(page, packageNls.org_logout_all_text);
+    await expectOrgPickerListsOrg(page, bootOrgLabel);
+    await expectOrgPickerListsOrg(page, NON_TRACKING_ORG_ALIAS);
+    await toggleMultiPickRow(page, NON_TRACKING_ORG_ALIAS);
+    await page.keyboard.press('Enter');
+    // CANCEL the confirm modal so NO org is logged out (removeAuth must not run against a shared org).
+    await page.keyboard.press('Escape');
+    await expectNoErrorNotification(page);
+  });
+
+  await test.step('LOGOUT cancel: Esc on the picker maps to CANCEL', async () => {
+    await executeCommandWithCommandPalette(page, packageNls.org_logout_all_text);
+    await expectOrgPickerListsOrg(page, NON_TRACKING_ORG_ALIAS);
+    await page.keyboard.press('Escape');
+    await expect(page.locator(QUICK_INPUT_WIDGET)).toBeHidden({ timeout: 10_000 });
+    await expectNoErrorNotification(page);
+  });
+
+  await validateNoCriticalErrors(test, consoleErrors, networkErrors);
+});

--- a/packages/salesforcedx-vscode-org/test/playwright/specs/container/orgPickers.container.spec.ts
+++ b/packages/salesforcedx-vscode-org/test/playwright/specs/container/orgPickers.container.spec.ts
@@ -23,11 +23,11 @@
  *     `sf org display --target-org <picked>` and its username lands in the output channel — the proof
  *     that the picked (non-default) org drove the command.
  *   - DISPLAY / LOGOUT cancel: Esc on the picker maps to CANCEL (no error toast).
- *   - DELETE (multi-pick): the picker lists BOTH orgs; toggling the extra org + Enter reaches the
- *     confirm modal, which is Escaped (CANCEL) so NOTHING is deleted.
+ *   - DELETE (multi-pick): the picker opens; Esc maps to CANCEL. (It enumerates NEITHER org here — see
+ *     the carve-out below — so this asserts the cancel mapping, not enumeration.)
  *   - DELETE cancel: pick-nothing + Enter ([] empty array) maps to CANCEL.
- *   - LOGOUT (multi-pick): the picker lists BOTH orgs; toggle + Enter reaches the confirm modal,
- *     which is Escaped (CANCEL) so NOTHING is logged out.
+ *   - LOGOUT (multi-pick): the picker lists BOTH orgs (the logout gatherer applies NO scratch/sandbox
+ *     filter, unlike delete); Esc maps to CANCEL so NOTHING is logged out.
  *
  * WHAT THIS OMITS (cannot run in the shared container — the honesty carve-out): the twin's REAL
  * logout / logout-default steps. Those need (a) `createThrowawayOrg` sacrificial orgs, which the
@@ -35,6 +35,13 @@
  * (b) actually removing auth — which, against either of the two pre-provisioned orgs, would corrupt
  * the shared serial session that every later container spec depends on. There is no third,
  * disposable org to sacrifice, so the destructive removeAuth paths are intentionally not ported.
+ *
+ * The DELETE picker's multi-org ENUMERATION is likewise carved out: `selectDeletableOrg` filters to
+ * scratch orgs + sandboxes (isScratchOrg || isSandbox), but the boot org is access-token-authed (its
+ * auth file carries no scratch metadata, so isScratchOrg is unset even though it IS a scratch org) and
+ * the extra org is non-tracking, so the delete picker enumerates NEITHER in-container. Delete is
+ * therefore exercised only for its CANCEL mappings; the "enumerate BOTH orgs" proof lives in the
+ * DISPLAY and LOGOUT steps, whose gatherers apply no such filter.
  *
  * ALIAS vs USERNAME: the boot org is token-authed and carries NO alias in-container, so it surfaces
  * by USERNAME (resolved here from the host CLI); nonTrackingTestOrg was authed with `--alias`, so it
@@ -46,7 +53,6 @@
 
 import { expect, type Page } from '@playwright/test';
 import {
-  activeQuickInputWidget,
   clearAllNotifications,
   closeAllEditors,
   closeWelcomeTabs,
@@ -59,7 +65,6 @@ import {
   MINIMAL_ORG_ALIAS,
   NON_TRACKING_ORG_ALIAS,
   NOTIFICATION_LIST_ITEM,
-  QUICK_INPUT_LIST_ROW,
   QUICK_INPUT_WIDGET,
   saveScreenshot,
   selectOrgInPicker,
@@ -85,18 +90,6 @@ const resolveOrgUsername = async (alias: string): Promise<string> => {
     throw new Error(`could not resolve username for org "${alias}" from \`sf org display\``);
   }
   return username;
-};
-
-/** Toggle a `canPickMany` quick-pick row's checkbox by typing the label and clicking the matching org row. */
-const toggleMultiPickRow = async (page: Page, label: string): Promise<void> => {
-  await page.keyboard.type(label);
-  const row = activeQuickInputWidget(page)
-    .locator(QUICK_INPUT_LIST_ROW)
-    .filter({ hasText: label })
-    .filter({ hasNotText: 'SFDX:' })
-    .first();
-  await row.waitFor({ state: 'visible', timeout: 10_000 });
-  await row.click({ force: true });
 };
 
 /** Assert no error toast surfaced (UserCancellationError must map to CANCEL, never an error notification). */
@@ -171,40 +164,37 @@ test('org extension (Code Builder): migrated pickers enumerate BOTH orgs across 
     await expectNoErrorNotification(page);
   });
 
-  await test.step('DELETE: selectDeletableOrg multi-pick lists BOTH orgs, toggle extra, then Esc-cancel the confirm', async () => {
+  await test.step('DELETE: selectDeletableOrg multi-pick opens, then Esc maps to CANCEL', async () => {
+    // selectDeletableOrg filters to scratch orgs + sandboxes (isScratchOrg || isSandbox). Neither
+    // pre-provisioned org qualifies in-container (see the honesty carve-out at the top of this file):
+    // the boot org is access-token-authed so its auth file carries no scratch metadata (isScratchOrg
+    // unset even though it IS a scratch org), and the extra org is non-tracking. So this picker
+    // enumerates NEITHER org here — asserting "lists BOTH orgs" is impossible. Instead assert the
+    // picker opens and Esc maps to CANCEL (non-destructive; the multi-org enumeration proof lives in
+    // DISPLAY and LOGOUT, which apply no such filter).
     await executeCommandWithCommandPalette(page, packageNls.org_delete_username_text);
-    await expectOrgPickerListsOrg(page, bootOrgLabel);
-    await expectOrgPickerListsOrg(page, NON_TRACKING_ORG_ALIAS);
-    // Toggle the extra org row (canPickMany), accept to reach the confirm modal, then CANCEL it so
-    // NOTHING is deleted (non-destructive against the shared session).
-    await toggleMultiPickRow(page, NON_TRACKING_ORG_ALIAS);
-    await page.keyboard.press('Enter');
+    await expect(page.locator(QUICK_INPUT_WIDGET)).toBeVisible({ timeout: 10_000 });
     await page.keyboard.press('Escape');
+    await expect(page.locator(QUICK_INPUT_WIDGET)).toBeHidden({ timeout: 10_000 });
     await expectNoErrorNotification(page);
   });
 
   await test.step('DELETE cancel: multi-pick pick-nothing + Enter ([] empty array) maps to CANCEL', async () => {
     await executeCommandWithCommandPalette(page, packageNls.org_delete_username_text);
-    await expectOrgPickerListsOrg(page, NON_TRACKING_ORG_ALIAS);
-    // Accept with nothing selected -> [] -> empty-array guard -> CANCEL (no confirm modal).
+    await expect(page.locator(QUICK_INPUT_WIDGET)).toBeVisible({ timeout: 10_000 });
+    // Accept with nothing selected -> [] -> considerEmptySelectionAsCancellation -> CANCEL (no confirm modal).
     await page.keyboard.press('Enter');
     await expect(page.locator(QUICK_INPUT_WIDGET)).toBeHidden({ timeout: 10_000 });
     await expectNoErrorNotification(page);
   });
 
-  await test.step('LOGOUT: orgLogoutAllCommand multi-pick lists BOTH orgs, toggle extra, then Esc-cancel the confirm', async () => {
+  await test.step('LOGOUT: orgLogoutAllCommand multi-pick lists BOTH orgs, then Esc maps to CANCEL', async () => {
+    // The logout gatherer (selectOrgsForLogout) applies NO scratch/sandbox filter, so it enumerates
+    // every authed org — the multi-org proof for logout. Esc-cancel the picker so NO org is logged out
+    // (removeAuth must never run against a shared org; Esc before any selection is strictly
+    // non-destructive).
     await executeCommandWithCommandPalette(page, packageNls.org_logout_all_text);
     await expectOrgPickerListsOrg(page, bootOrgLabel);
-    await expectOrgPickerListsOrg(page, NON_TRACKING_ORG_ALIAS);
-    await toggleMultiPickRow(page, NON_TRACKING_ORG_ALIAS);
-    await page.keyboard.press('Enter');
-    // CANCEL the confirm modal so NO org is logged out (removeAuth must not run against a shared org).
-    await page.keyboard.press('Escape');
-    await expectNoErrorNotification(page);
-  });
-
-  await test.step('LOGOUT cancel: Esc on the picker maps to CANCEL', async () => {
-    await executeCommandWithCommandPalette(page, packageNls.org_logout_all_text);
     await expectOrgPickerListsOrg(page, NON_TRACKING_ORG_ALIAS);
     await page.keyboard.press('Escape');
     await expect(page.locator(QUICK_INPUT_WIDGET)).toBeHidden({ timeout: 10_000 });

--- a/scripts/codeBuilderLocalE2E.ts
+++ b/scripts/codeBuilderLocalE2E.ts
@@ -672,13 +672,6 @@ const authExtraOrgsIntoContainer = (containerName: string): void => {
         console.warn(`      stderr: ${login.stderr.trim()}`);
       }
     }
-    // Diagnostic (spike): confirm the exec's user/HOME match the workbench and whether the
-    // container's own `sf` lists the org — distinguishes an sf-side auth problem from the extension
-    // caching/filtering externally-added auths. Kept terse; remove once multi-org is proven.
-    const diag = execInContainer(
-      'printf "user=%s home=%s\\n" "$(whoami)" "$HOME"; sf org list --json 2>&1 | head -c 1400'
-    );
-    console.log(`    [diag] ${alias}: ${(diag.stdout || diag.stderr || '').trim()}`);
   }
 };
 

--- a/scripts/codeBuilderLocalE2E.ts
+++ b/scripts/codeBuilderLocalE2E.ts
@@ -97,6 +97,25 @@ const FIXTURE_HOST_DIR = join(
   'container-workspace'
 );
 
+/*
+ * A SECOND, deliberately non-SFDX fixture (no sfdx-project.json). Mounted alongside the DX fixture so
+ * the orchestrator can, after the standard container suites run, re-seed coder.json to point
+ * code-server here + restart() — giving the "no project open" visibility suites
+ * (test:container:noproject) the workspace shape they need. Kept as its own mount (not a subfolder of
+ * the DX fixture) so opening it never sees the DX project's sfdx-project.json up the tree.
+ */
+const NOPROJECT_FIXTURE_HOST_DIR = join(
+  REPO_ROOT,
+  'packages',
+  'salesforcedx-vscode-core',
+  'test',
+  'playwright',
+  'fixtures',
+  'container-noproject'
+);
+/** Where the non-project fixture is bind-mounted in the container (distinct from FIXTURE_MOUNT_PATH). */
+const NOPROJECT_MOUNT_PATH = '/home/codebuilder/noproject-workspace';
+
 type Options = {
   runId?: string;
   grep?: string;
@@ -428,7 +447,7 @@ const modernVsixName = (pkgDir: string): string | null => {
  * adding a container suite to a new package wires it in with no edit here. core sorts first (its
  * specs smoke-test the mounted fixture), the rest alphabetically.
  */
-const discoverContainerPackages = (): string[] => {
+const discoverPackagesWithScript = (scriptName: string): string[] => {
   const packagesDir = join(REPO_ROOT, 'packages');
   const CORE = 'salesforcedx-vscode-core';
   return readdirSync(packagesDir)
@@ -436,13 +455,16 @@ const discoverContainerPackages = (): string[] => {
       try {
         // Untyped JSON.parse to match this file's other package.json reads (e.g. modernVsixName).
         const { scripts } = JSON.parse(readFileSync(join(packagesDir, pkg, 'package.json'), 'utf-8'));
-        return Boolean(scripts?.['test:container']);
+        return Boolean(scripts?.[scriptName]);
       } catch {
         return false;
       }
     })
     .toSorted((a, b) => (a === CORE ? -1 : b === CORE ? 1 : a.localeCompare(b)));
 };
+
+/** The standard (DX-project-shape) container suites — every package declaring `test:container`. */
+const discoverContainerPackages = (): string[] => discoverPackagesWithScript('test:container');
 
 /* --- gather the VSIX under test (backgroundable) --------------------------- */
 const acquireVsix = async (): Promise<string[]> => {
@@ -695,8 +717,13 @@ const main = async (): Promise<number> => {
     url: CODE_BUILDER_URL,
     bootEnv,
     // No SFDX_COBU_PROJECTNAME — that generate path would collide with the mount and only runs first
-    // boot. seedWorkspace points code-server at the mount instead.
-    mounts: [{ hostPath: FIXTURE_HOST_DIR, containerPath: FIXTURE_MOUNT_PATH }]
+    // boot. seedWorkspace points code-server at a mount instead. Both fixture shapes are mounted up
+    // front (the DX project the standard suites use, and the non-project folder the noproject phase
+    // re-seeds to); seedWorkspace validates its fixturePath against these recorded mounts.
+    mounts: [
+      { hostPath: FIXTURE_HOST_DIR, containerPath: FIXTURE_MOUNT_PATH },
+      { hostPath: NOPROJECT_FIXTURE_HOST_DIR, containerPath: NOPROJECT_MOUNT_PATH }
+    ]
   });
 
   // A bind mount keeps the host's ownership, so the container's workbench user can't write into the
@@ -705,16 +732,14 @@ const main = async (): Promise<number> => {
   // that writes one on activation. Make the mounted tree writable by any uid so those writes land.
   // `a+rwX` only adds the execute bit to dirs/already-exec files, so it doesn't flip tracked file
   // modes (git sees no change). Runs as root inside the container; a failure is a warning, not fatal.
-  log('Making the mounted fixture writable by the container user (chmod a+rwX)');
-  const chmodMount = spawnSync(
-    'docker',
-    ['exec', '-u', 'root', handle.name, 'chmod', '-R', 'a+rwX', FIXTURE_MOUNT_PATH],
-    {
+  log('Making the mounted fixtures writable by the container user (chmod a+rwX)');
+  for (const mountPath of [FIXTURE_MOUNT_PATH, NOPROJECT_MOUNT_PATH]) {
+    const chmodMount = spawnSync('docker', ['exec', '-u', 'root', handle.name, 'chmod', '-R', 'a+rwX', mountPath], {
       stdio: 'ignore'
+    });
+    if (chmodMount.status !== 0) {
+      console.warn(`    WARNING: could not chmod ${mountPath} — settings-writing specs may hit EACCES.`);
     }
-  );
-  if (chmodMount.status !== 0) {
-    console.warn('    WARNING: could not chmod the mounted fixture — settings-writing specs may hit EACCES.');
   }
 
   // Point code-server at the mounted fixture + disable workspace trust (one toolkit exec does both).
@@ -760,30 +785,72 @@ const main = async (): Promise<number> => {
   }
   log(`Running container Playwright specs for ${containerPackages.length} package(s): ${containerPackages.join(', ')}`);
 
-  const testEnv: NodeJS.ProcessEnv = { ...process.env, CODE_BUILDER_URL };
+  // CB_FIXTURE_HOST_DIR: the HOST side of the bind mount. Specs that need to place files INTO the
+  // opened workspace (e.g. metadata manifestCommandVisibility, which writes a *Package.xml + a plain
+  // .xml at the project root) write here with node:fs — the bind mount reflects the write into the
+  // container's opened folder. The container path (FIXTURE_MOUNT_PATH) is where code-server reads;
+  // the host path is where a host-side spec can write. Both local and CI drive this orchestrator, so
+  // this one env var covers both.
+  const testEnv: NodeJS.ProcessEnv = { ...process.env, CODE_BUILDER_URL, CB_FIXTURE_HOST_DIR: FIXTURE_HOST_DIR };
   if (opts.debug) {
     testEnv.PWDEBUG = '1';
   }
+  // --grep is forwarded to Playwright via CB_GREP (an env var), NOT a `--grep` CLI arg: the suites run
+  // through `npm run … -w <pkg>` → wireit, which does not shell-quote forwarded args, so a title regex
+  // with spaces or a `|` alternation would be split/mis-parsed. createContainerConfig reads CB_GREP.
+  if (opts.grep) {
+    testEnv.CB_GREP = opts.grep;
+  }
 
-  const failed: string[] = [];
-  for (const pkg of containerPackages) {
-    log(`Specs: ${pkg}`);
-    const testArgs = ['run', 'test:container', '-w', pkg];
-    if (opts.grep) {
-      testArgs.push('--', '--grep', opts.grep);
+  // Run one npm script across the given packages sequentially, returning the ones that failed.
+  // `label` distinguishes the phases in the log (DX-project vs no-project). Shared by both phases so
+  // the run-a-suite mechanics (grep passthrough, SPECS_TIMEOUT_MS backstop, per-package failure
+  // collection) live in one place.
+  const runSuites = (packages: string[], scriptName: string, label: string): string[] => {
+    const suiteFailed: string[] = [];
+    for (const pkg of packages) {
+      log(`Specs [${label}]: ${pkg}`);
+      // grep is passed via testEnv.CB_GREP (see above), not a forwarded --grep arg, so the argv is a
+      // fixed, quoting-safe token list.
+      const testArgs = ['run', scriptName, '-w', pkg];
+      // SPECS_TIMEOUT_MS backstop: a single stuck browser/page is a routine Playwright failure mode,
+      // and this is the most expensive step (after the pull + org setup). Without it a wedged run
+      // hangs the loop forever here; on timeout the child is killed and the package counts as failed.
+      const specs = spawnSync('npm', testArgs, {
+        cwd: REPO_ROOT,
+        stdio: 'inherit',
+        env: testEnv,
+        timeout: SPECS_TIMEOUT_MS
+      });
+      if ((specs.status ?? 1) !== 0) {
+        suiteFailed.push(pkg);
+      }
     }
-    // SPECS_TIMEOUT_MS backstop: a single stuck browser/page is a routine Playwright failure mode, and
-    // this is the most expensive step (after the pull + org setup). Without it a wedged run hangs the
-    // loop forever here; on timeout the child is killed and the package counts as failed.
-    const specs = spawnSync('npm', testArgs, {
-      cwd: REPO_ROOT,
-      stdio: 'inherit',
-      env: testEnv,
-      timeout: SPECS_TIMEOUT_MS
-    });
-    if ((specs.status ?? 1) !== 0) {
-      failed.push(pkg);
-    }
+    return suiteFailed;
+  };
+
+  // Phase 1 — standard container suites against the DX-project shape (the seeded fixture).
+  const failed = runSuites(containerPackages, 'test:container', 'dx-project');
+
+  // Phase 2 — no-project shape. Any package declaring `test:container:noproject` needs a workspace
+  // with NO sfdx-project.json open (project-gated commands must be hidden). Change the shape at a
+  // phase boundary — re-seed coder.json to the non-project mount + restart() — never mid-suite in the
+  // shared session. Discovered self-maintaining like phase 1; a no-op when no package declares it.
+  const noProjectPackages = opts.only
+    ? discoverPackagesWithScript('test:container:noproject').filter(p => opts.only!.includes(p))
+    : discoverPackagesWithScript('test:container:noproject');
+  if (noProjectPackages.length > 0) {
+    log(`Re-seeding code-server at the non-project folder (${NOPROJECT_MOUNT_PATH}) + restarting`);
+    seedWorkspace(handle, { fixturePath: NOPROJECT_MOUNT_PATH });
+    // restart() resolves only once the workbench URL answers again, so returning from it is the proof
+    // code-server reopened the re-seeded non-project folder cleanly (the workspace-shape re-seed spike).
+    await restart(handle);
+    log(`Workbench came up after re-seed+restart to the non-project shape (re-seed spike: PASS)`);
+    // Re-run the verify gate: the restart re-scans the overrides, so confirm the swapped extensions
+    // are STILL present at the expected bytes. Without this a lost extension would make the
+    // "commands hidden" assertions pass for the wrong reason (no extension = no commands either).
+    assertVerified(handle.name, manifest);
+    failed.push(...runSuites(noProjectPackages, 'test:container:noproject', 'no-project'));
   }
 
   if (failed.length > 0) {

--- a/scripts/codeBuilderLocalE2E.ts
+++ b/scripts/codeBuilderLocalE2E.ts
@@ -635,13 +635,22 @@ const authExtraOrgsIntoContainer = (containerName: string): void => {
       console.warn(`    WARNING: could not read sfdxAuthUrl for '${alias}' on the host — skipping.`);
       continue;
     }
+    // `bash -lc` (LOGIN shell) so the container's profile is sourced and `sf` is on PATH — a plain
+    // `bash -c` is non-login and may not find `sf`. Capture stdout/stderr (not ignore) so a failure
+    // surfaces the real CLI error instead of a bare warning.
     const login = spawnSync(
       'docker',
-      ['exec', '-i', containerName, 'bash', '-c', `sf org login sfdx-url --sfdx-url-stdin --alias ${alias}`],
-      { input: authUrl, stdio: ['pipe', 'ignore', 'ignore'], timeout: CAPTURE_TIMEOUT_MS }
+      ['exec', '-i', containerName, 'bash', '-lc', `sf org login sfdx-url --sfdx-url-stdin --alias ${alias}`],
+      { input: authUrl, encoding: 'utf-8', timeout: CAPTURE_TIMEOUT_MS }
     );
     if (login.status !== 0) {
-      console.warn(`    WARNING: 'sf org login sfdx-url' for '${alias}' failed inside the container.`);
+      console.warn(`    WARNING: 'sf org login sfdx-url' for '${alias}' failed inside the container:`);
+      if (login.stdout?.trim()) {
+        console.warn(`      stdout: ${login.stdout.trim()}`);
+      }
+      if (login.stderr?.trim()) {
+        console.warn(`      stderr: ${login.stderr.trim()}`);
+      }
     }
   }
 };

--- a/scripts/codeBuilderLocalE2E.ts
+++ b/scripts/codeBuilderLocalE2E.ts
@@ -609,8 +609,9 @@ const setUpInfra = async (): Promise<BootEnv> => {
  * non-tracking, Dreamhouse) need more. `CB_EXTRA_ORG_ALIASES` (comma-separated host aliases the CI
  * workflow pre-created) drives this: for each we resolve its access token + instance URL on the host
  * and run `sf org login access-token` INSIDE the container so the alias resolves there too. Called
- * BEFORE the restart below so the re-activated extensions enumerate the full org list — the container
- * filesystem (and thus these logins) persists across `restart`. No-op when the env var is unset.
+ * AFTER the restart (the restart re-runs the image's boot org auth, which re-initializes the auth dir
+ * and would wipe an earlier login); the org extension reads the org list fresh on each picker open, so
+ * a login before the specs run is enumerated without a window reload. No-op when the env var is unset.
  * The boot org stays the default; specs that switch to an extra org save/restore the default themselves.
  */
 const authExtraOrgsIntoContainer = (containerName: string): void => {
@@ -719,10 +720,6 @@ const main = async (): Promise<number> => {
   log('Seeding workspace (point code-server at the mounted fixture, disable workspace trust)');
   seedWorkspace(handle);
 
-  // Auth any extra pre-created orgs into the container now — BEFORE the restart below, so the
-  // re-activated extensions enumerate them (no-op unless CB_EXTRA_ORG_ALIASES is set).
-  authExtraOrgsIntoContainer(handle.name);
-
   // Swap the built VSIXes into the override dirs and capture the manifest the gate checks against.
   log('Swapping in built extensions');
   const manifest = swap(handle.name, vsixPaths, { publisherPrefix: PUBLISHER_PREFIX });
@@ -735,6 +732,12 @@ const main = async (): Promise<number> => {
   // mismatch means the swap did not take, not a spec bug — assertVerified throws loud saying so.
   log('Verifying extension versions (gate)');
   assertVerified(handle.name, manifest);
+
+  // Auth extra orgs AFTER the restart: the restart re-runs the image's boot org auth, which
+  // re-initializes the auth dir and would wipe a login done earlier. The org extension reads the org
+  // list fresh on every picker open, so a login now (before the specs run) is enumerated without any
+  // window reload. No-op unless CB_EXTRA_ORG_ALIASES is set.
+  authExtraOrgsIntoContainer(handle.name);
 
   /* --- run the specs ------------------------------------------------------- */
   // Run every package's container suite against the one shared container, SEQUENTIALLY: a single

--- a/scripts/codeBuilderLocalE2E.ts
+++ b/scripts/codeBuilderLocalE2E.ts
@@ -607,10 +607,10 @@ const setUpInfra = async (): Promise<BootEnv> => {
  * Auth additional pre-created orgs INTO the running container (beyond the boot org). The image's boot
  * script authenticates only one org (SF_ACCESS_TOKEN/INSTANCE_URL); multi-org specs (org picker/switch,
  * non-tracking, Dreamhouse) need more. `CB_EXTRA_ORG_ALIASES` (comma-separated host aliases the CI
- * workflow pre-created) drives this: for each we read its sfdx auth URL on the host and run
- * `sf org login sfdx-url` INSIDE the container so the alias resolves there too. Called BEFORE the
- * restart below so the re-activated extensions enumerate the full org list — the container filesystem
- * (and thus these logins) persists across `restart`. No-op when the env var is unset (the common path).
+ * workflow pre-created) drives this: for each we resolve its access token + instance URL on the host
+ * and run `sf org login access-token` INSIDE the container so the alias resolves there too. Called
+ * BEFORE the restart below so the re-activated extensions enumerate the full org list — the container
+ * filesystem (and thus these logins) persists across `restart`. No-op when the env var is unset.
  * The boot org stays the default; specs that switch to an extra org save/restore the default themselves.
  */
 const authExtraOrgsIntoContainer = (containerName: string): void => {
@@ -623,61 +623,52 @@ const authExtraOrgsIntoContainer = (containerName: string): void => {
   }
   // Run a bash LOGIN shell (`-lc`) inside the container so its profile is sourced and `sf` is on
   // PATH (a plain `bash -c` is non-login and may not find it). SF_*_DISABLE_TELEMETRY suppresses the
-  // CLI's first-run data-collection notice, which otherwise prints to stderr and muddies diagnostics.
-  const execInContainer = (script: string, input?: string) =>
-    spawnSync(
-      'docker',
-      [
-        'exec',
-        '-i',
-        '-e',
-        'SF_DISABLE_TELEMETRY=true',
-        '-e',
-        'SFDX_DISABLE_TELEMETRY=true',
-        containerName,
-        'bash',
-        '-lc',
-        script
-      ],
-      { input, encoding: 'utf-8', timeout: CAPTURE_TIMEOUT_MS }
-    );
+  // CLI's first-run data-collection notice; extraEnv carries the org's access token to the login.
+  const execInContainer = (script: string, extraEnv: Record<string, string> = {}) => {
+    const envArgs = Object.entries({
+      SF_DISABLE_TELEMETRY: 'true',
+      SFDX_DISABLE_TELEMETRY: 'true',
+      ...extraEnv
+    }).flatMap(([k, v]) => ['-e', `${k}=${v}`]);
+    return spawnSync('docker', ['exec', '-i', ...envArgs, containerName, 'bash', '-lc', script], {
+      encoding: 'utf-8',
+      timeout: CAPTURE_TIMEOUT_MS
+    });
+  };
 
   for (const alias of aliases) {
     log(`Authenticating extra org '${alias}' into the container`);
-    // --verbose surfaces sfdxAuthUrl (a refresh-token URL) for a scratch org. Untyped parse to match
-    // this file's other `sf --json` reads; a missing URL is a warning, not fatal (its specs will fail).
-    const raw = tryCapture('sf', ['org', 'display', '--verbose', '-o', alias, '--json']);
-    let authUrl: string | undefined;
-    if (raw) {
-      try {
-        authUrl = JSON.parse(raw)?.result?.sfdxAuthUrl;
-      } catch {
-        /* fall through to the guard below */
-      }
-    }
-    if (!authUrl) {
-      console.warn(`    WARNING: could not read sfdxAuthUrl for '${alias}' on the host — skipping.`);
+    // Auth each extra org the SAME way the image boots the default org: via its real access token +
+    // instance URL (`sf org login access-token`), NOT sfdx-url. `sf org display --verbose --json`
+    // REDACTS sfdxAuthUrl on recent CLIs (the #7718 redaction class), so a url-based login fails
+    // INVALID_SFDX_AUTH_URL. resolveOrgBootEnv reads the UN-redacted token via `sf org auth
+    // show-access-token` — exactly the source the boot env uses — routed through sfRunner (npx-sf
+    // fallback). A resolve failure is a warning, not fatal (that org's specs will then fail loudly).
+    let orgEnv: BootEnv;
+    try {
+      orgEnv = resolveOrgBootEnv(alias, { runner: sfRunner });
+    } catch (err) {
+      console.warn(
+        `    WARNING: could not resolve access token / instance URL for '${alias}' on the host — skipping. ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
       continue;
     }
-    // Feed the auth URL via a temp FILE (`--sfdx-url-file`), not `--sfdx-url-stdin`: the stdin flag's
-    // arg parsing swallowed the following `--alias` value on the image's CLI ("Unexpected argument"),
-    // whereas `--sfdx-url-file` is stable across CLI versions. Write the file (0600), log in, remove it.
-    const urlFile = `/tmp/cb-e2e-authurl-${alias}`;
-    execInContainer(`umask 077; cat > ${urlFile}`, authUrl);
+    // Token via SF_ACCESS_TOKEN env, instance URL via flag; --no-prompt skips the "access tokens are
+    // less secure" confirmation. This mirrors the container's own boot-time org login.
     const login = execInContainer(
-      `sf org login sfdx-url --sfdx-url-file ${urlFile} --alias ${alias}; rc=$?; rm -f ${urlFile}; exit $rc`
+      `sf org login access-token --instance-url ${orgEnv.instanceUrl} --alias ${alias} --no-prompt`,
+      { SF_ACCESS_TOKEN: orgEnv.accessToken }
     );
     if (login.status !== 0) {
-      console.warn(`    WARNING: 'sf org login sfdx-url' for '${alias}' failed inside the container:`);
+      console.warn(`    WARNING: 'sf org login access-token' for '${alias}' failed inside the container:`);
       if (login.stdout?.trim()) {
         console.warn(`      stdout: ${login.stdout.trim()}`);
       }
       if (login.stderr?.trim()) {
         console.warn(`      stderr: ${login.stderr.trim()}`);
       }
-      // Pin the CLI's actual flag surface so a further failure is diagnosable without another round.
-      const help = execInContainer('sf org login sfdx-url --help');
-      console.warn(`      --- sf org login sfdx-url --help ---\n${(help.stdout || help.stderr || '').trim()}`);
     }
   }
 };

--- a/scripts/codeBuilderLocalE2E.ts
+++ b/scripts/codeBuilderLocalE2E.ts
@@ -618,6 +618,30 @@ const authExtraOrgsIntoContainer = (containerName: string): void => {
     .split(',')
     .map(s => s.trim())
     .filter(Boolean);
+  if (aliases.length === 0) {
+    return;
+  }
+  // Run a bash LOGIN shell (`-lc`) inside the container so its profile is sourced and `sf` is on
+  // PATH (a plain `bash -c` is non-login and may not find it). SF_*_DISABLE_TELEMETRY suppresses the
+  // CLI's first-run data-collection notice, which otherwise prints to stderr and muddies diagnostics.
+  const execInContainer = (script: string, input?: string) =>
+    spawnSync(
+      'docker',
+      [
+        'exec',
+        '-i',
+        '-e',
+        'SF_DISABLE_TELEMETRY=true',
+        '-e',
+        'SFDX_DISABLE_TELEMETRY=true',
+        containerName,
+        'bash',
+        '-lc',
+        script
+      ],
+      { input, encoding: 'utf-8', timeout: CAPTURE_TIMEOUT_MS }
+    );
+
   for (const alias of aliases) {
     log(`Authenticating extra org '${alias}' into the container`);
     // --verbose surfaces sfdxAuthUrl (a refresh-token URL) for a scratch org. Untyped parse to match
@@ -635,13 +659,13 @@ const authExtraOrgsIntoContainer = (containerName: string): void => {
       console.warn(`    WARNING: could not read sfdxAuthUrl for '${alias}' on the host — skipping.`);
       continue;
     }
-    // `bash -lc` (LOGIN shell) so the container's profile is sourced and `sf` is on PATH — a plain
-    // `bash -c` is non-login and may not find `sf`. Capture stdout/stderr (not ignore) so a failure
-    // surfaces the real CLI error instead of a bare warning.
-    const login = spawnSync(
-      'docker',
-      ['exec', '-i', containerName, 'bash', '-lc', `sf org login sfdx-url --sfdx-url-stdin --alias ${alias}`],
-      { input: authUrl, encoding: 'utf-8', timeout: CAPTURE_TIMEOUT_MS }
+    // Feed the auth URL via a temp FILE (`--sfdx-url-file`), not `--sfdx-url-stdin`: the stdin flag's
+    // arg parsing swallowed the following `--alias` value on the image's CLI ("Unexpected argument"),
+    // whereas `--sfdx-url-file` is stable across CLI versions. Write the file (0600), log in, remove it.
+    const urlFile = `/tmp/cb-e2e-authurl-${alias}`;
+    execInContainer(`umask 077; cat > ${urlFile}`, authUrl);
+    const login = execInContainer(
+      `sf org login sfdx-url --sfdx-url-file ${urlFile} --alias ${alias}; rc=$?; rm -f ${urlFile}; exit $rc`
     );
     if (login.status !== 0) {
       console.warn(`    WARNING: 'sf org login sfdx-url' for '${alias}' failed inside the container:`);
@@ -651,6 +675,9 @@ const authExtraOrgsIntoContainer = (containerName: string): void => {
       if (login.stderr?.trim()) {
         console.warn(`      stderr: ${login.stderr.trim()}`);
       }
+      // Pin the CLI's actual flag surface so a further failure is diagnosable without another round.
+      const help = execInContainer('sf org login sfdx-url --help');
+      console.warn(`      --- sf org login sfdx-url --help ---\n${(help.stdout || help.stderr || '').trim()}`);
     }
   }
 };

--- a/scripts/codeBuilderLocalE2E.ts
+++ b/scripts/codeBuilderLocalE2E.ts
@@ -622,16 +622,17 @@ const authExtraOrgsIntoContainer = (containerName: string): void => {
   if (aliases.length === 0) {
     return;
   }
-  // Run a bash LOGIN shell (`-lc`) inside the container so its profile is sourced and `sf` is on
-  // PATH (a plain `bash -c` is non-login and may not find it). SF_*_DISABLE_TELEMETRY suppresses the
-  // CLI's first-run data-collection notice; extraEnv carries the org's access token to the login.
+  // Exec as the `codebuilder` user (NOT the default root): the workbench/extension run as codebuilder
+  // and read its ~/.sf, so a login done as root (in /root/.sf) is invisible to the org picker. A bash
+  // LOGIN shell (`-lc`) sources codebuilder's profile so `sf` is on PATH and HOME=/home/codebuilder.
+  // SF_*_DISABLE_TELEMETRY suppresses the CLI first-run notice; extraEnv carries the org access token.
   const execInContainer = (script: string, extraEnv: Record<string, string> = {}) => {
     const envArgs = Object.entries({
       SF_DISABLE_TELEMETRY: 'true',
       SFDX_DISABLE_TELEMETRY: 'true',
       ...extraEnv
     }).flatMap(([k, v]) => ['-e', `${k}=${v}`]);
-    return spawnSync('docker', ['exec', '-i', ...envArgs, containerName, 'bash', '-lc', script], {
+    return spawnSync('docker', ['exec', '-i', '-u', 'codebuilder', ...envArgs, containerName, 'bash', '-lc', script], {
       encoding: 'utf-8',
       timeout: CAPTURE_TIMEOUT_MS
     });

--- a/scripts/codeBuilderLocalE2E.ts
+++ b/scripts/codeBuilderLocalE2E.ts
@@ -603,6 +603,49 @@ const setUpInfra = async (): Promise<BootEnv> => {
   return resolveOrgBootEnv(ORG_ALIAS, { runner: sfRunner });
 };
 
+/*
+ * Auth additional pre-created orgs INTO the running container (beyond the boot org). The image's boot
+ * script authenticates only one org (SF_ACCESS_TOKEN/INSTANCE_URL); multi-org specs (org picker/switch,
+ * non-tracking, Dreamhouse) need more. `CB_EXTRA_ORG_ALIASES` (comma-separated host aliases the CI
+ * workflow pre-created) drives this: for each we read its sfdx auth URL on the host and run
+ * `sf org login sfdx-url` INSIDE the container so the alias resolves there too. Called BEFORE the
+ * restart below so the re-activated extensions enumerate the full org list — the container filesystem
+ * (and thus these logins) persists across `restart`. No-op when the env var is unset (the common path).
+ * The boot org stays the default; specs that switch to an extra org save/restore the default themselves.
+ */
+const authExtraOrgsIntoContainer = (containerName: string): void => {
+  const aliases = (process.env.CB_EXTRA_ORG_ALIASES ?? '')
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+  for (const alias of aliases) {
+    log(`Authenticating extra org '${alias}' into the container`);
+    // --verbose surfaces sfdxAuthUrl (a refresh-token URL) for a scratch org. Untyped parse to match
+    // this file's other `sf --json` reads; a missing URL is a warning, not fatal (its specs will fail).
+    const raw = tryCapture('sf', ['org', 'display', '--verbose', '-o', alias, '--json']);
+    let authUrl: string | undefined;
+    if (raw) {
+      try {
+        authUrl = JSON.parse(raw)?.result?.sfdxAuthUrl;
+      } catch {
+        /* fall through to the guard below */
+      }
+    }
+    if (!authUrl) {
+      console.warn(`    WARNING: could not read sfdxAuthUrl for '${alias}' on the host — skipping.`);
+      continue;
+    }
+    const login = spawnSync(
+      'docker',
+      ['exec', '-i', containerName, 'bash', '-c', `sf org login sfdx-url --sfdx-url-stdin --alias ${alias}`],
+      { input: authUrl, stdio: ['pipe', 'ignore', 'ignore'], timeout: CAPTURE_TIMEOUT_MS }
+    );
+    if (login.status !== 0) {
+      console.warn(`    WARNING: 'sf org login sfdx-url' for '${alias}' failed inside the container.`);
+    }
+  }
+};
+
 /* --- stand up + swap + gate (all via the toolkit) -------------------------- */
 const main = async (): Promise<number> => {
   // The three slow, independent operations — VSIX build/download, image pull, and org create/reuse —
@@ -648,6 +691,10 @@ const main = async (): Promise<number> => {
   // Point code-server at the mounted fixture + disable workspace trust (one toolkit exec does both).
   log('Seeding workspace (point code-server at the mounted fixture, disable workspace trust)');
   seedWorkspace(handle);
+
+  // Auth any extra pre-created orgs into the container now — BEFORE the restart below, so the
+  // re-activated extensions enumerate them (no-op unless CB_EXTRA_ORG_ALIASES is set).
+  authExtraOrgsIntoContainer(handle.name);
 
   // Swap the built VSIXes into the override dirs and capture the manifest the gate checks against.
   log('Swapping in built extensions');

--- a/scripts/codeBuilderLocalE2E.ts
+++ b/scripts/codeBuilderLocalE2E.ts
@@ -671,6 +671,13 @@ const authExtraOrgsIntoContainer = (containerName: string): void => {
         console.warn(`      stderr: ${login.stderr.trim()}`);
       }
     }
+    // Diagnostic (spike): confirm the exec's user/HOME match the workbench and whether the
+    // container's own `sf` lists the org — distinguishes an sf-side auth problem from the extension
+    // caching/filtering externally-added auths. Kept terse; remove once multi-org is proven.
+    const diag = execInContainer(
+      'printf "user=%s home=%s\\n" "$(whoami)" "$HOME"; sf org list --json 2>&1 | head -c 1400'
+    );
+    console.log(`    [diag] ${alias}: ${(diag.stdout || diag.stderr || '').trim()}`);
   }
 };
 


### PR DESCRIPTION
## What & why

Follow-up to the container parity work (#8102): extend Code Builder container coverage to specs that
were previously **org-blocked** — they need a non-tracking org, a second org to pick/switch between,
or Dreamhouse custom metadata a bare scratch org lacks. Adds a **multi-org capability** to the
container harness and ports **13 previously-unportable specs** (plus 2 more as documented `test.fixme`).

**Full CB e2e matrix is green 15/15.**

## The capability

The container boots ONE org (token injection). This authenticates ADDITIONAL pre-created orgs into the
running container so specs can switch between them:

- **Workflow** (`codeBuilderE2E.yml`): per-package, provisions a `--no-track-source` scratch org
  (`nonTrackingTestOrg`) and/or a Dreamhouse org (`orgBrowserDreamhouseTestOrg` — clone + deploy +
  permset), and passes their aliases via `CB_EXTRA_ORG_ALIASES`.
- **Orchestrator** (`authExtraOrgsIntoContainer`): resolves each org's access token + instance URL on
  the host (un-redacted, via `resolveOrgBootEnv`) and runs `sf org login access-token` INSIDE the
  container **as the `codebuilder` user** (so `~/.sf` matches the workbench) **after the restart** (the
  boot re-auth would otherwise wipe it). No window reload needed — the org extension reads the org list
  fresh on each picker open.
- **Specs** switch the default via the shared `switchDefaultOrgViaPicker` helper (a re-driving poll) and
  RESTORE the boot org in a `finally`, so the shared serial session isn't contaminated.

Getting here took a short CI spike: the mechanism came down to exec'ing as `codebuilder` (not root) and
auth'ing after the restart; the diagnostic path is documented in the commits.

## Newly ported (13 active)

- **org**: `orgPicker`, `orgPickers`
- **core**: `workspaceContextOrgSwitch`
- **apex-testing**: `orgOnlyClassRetrieve`, `inWorkspaceFilter` (boot org — org-only is workspace/org *presence*, not tracking)
- **metadata**: `nonTrackingOrgDeployRetrieveManifest`, `nonTrackingOrgDeployRetrieveOperations`, `refreshSObjectDefinitions`, `sourceTrackingStatusBar` (boot org, sidesteps the switch-reactivity limitation)
- **org-browser**: `orgBrowserCustomObject`, `orgBrowserCustomTab`, `orgBrowserFolderedReport`, `orgBrowserTextFilterDreamhouse`

## Documented `test.fixme` (2)

metadata `nonTrackingOrgTrackingCommandsHidden` / `nonTrackingOrgTrackingUIHidden`: the source-tracking
status bar re-evaluates only on a `~/.sf/config.json` file event, which code-server doesn't deliver
cross-extension-host for a runtime org switch — so the tracking UI doesn't hide after switching without
a window reload the web container can't do. Switch+restore bodies preserved dormant.

## Still not ported (updated ledger)

Destructive org lifecycle (web login / delete / logout / list-clean) and second-user specs remain
desktop-only — they mutate/destroy auth on the shared serial session. See
[`docs/codeBuilderContainerParity.md`](https://github.com/forcedotcom/salesforcedx-vscode/blob/jh/W-23898526-cb-e2e-multiorg/docs/codeBuilderContainerParity.md)
("Multi-org container support" + "Not ported").

## Testing

Per-package `test:compile` + eslint pass; the full 15-package `codeBuilderE2E` matrix is green against
the real image with the extra orgs provisioned + auth'd into the container.

## Stacked PR

Based on #8102 (`jh/W-23898526-cb-e2e-parity`). GitHub retargets this to `develop` once #8102 merges.

@W-23898526@
