### PR TITLE
chore: 7 Adopt Predicate.isNull/isNotNull in effect packages - W-23358838

### DIFF
--- a/.claude/plans/W-23358838.md
+++ b/.claude/plans/W-23358838.md
@@ -1,0 +1,60 @@
+# W-23358838 — Adopt Predicate.isNull/isNotNull in effect packages
+
+## Context
+
+Replace direct `null` equality checks in packages already depending on `effect` with `Predicate.isNull` and `Predicate.isNotNull`. This standardizes null predicates without changing behavior or adding dependencies.
+
+Files identified by the scoped search:
+
+- `packages/drivable-vscode/src/sessionService.ts`
+- `packages/playwright-vscode-ext/src/codeBuilder/digest.ts`
+- `packages/playwright-vscode-ext/src/codeBuilder/runner.ts`
+- `packages/playwright-vscode-ext/src/fixtures/createDesktopTest.ts`
+- `packages/playwright-vscode-ext/src/pages/contextMenu.ts`
+- `packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts`
+- `packages/salesforcedx-apex-replay-debugger/src/core/heapDumpService.ts`
+- `packages/salesforcedx-apex-replay-debugger/src/core/logContext.ts`
+- `packages/salesforcedx-apex-replay-debugger/src/states/frameStateUtil.ts`
+- `packages/salesforcedx-apex-replay-debugger/src/states/variableAssignmentState.ts`
+- `packages/salesforcedx-apex/src/narrowing/narrowing.ts`
+- `packages/salesforcedx-apex/src/reporters/markdownTextReporter.ts`
+- `packages/salesforcedx-apex/src/tests/asyncTests.ts`
+- `packages/salesforcedx-apex/src/tests/utils.ts`
+- `packages/salesforcedx-lightning-lsp-common/src/types/packageJson.ts`
+- `packages/salesforcedx-lightning-lsp-common/src/utils.ts`
+- `packages/salesforcedx-lightning-lsp-common/src/workspaceReadFileHandler.ts`
+- `packages/salesforcedx-lwc-language-server/src/baseIndexer.ts`
+- `packages/salesforcedx-lwc-language-server/src/componentIndexer.ts`
+- `packages/salesforcedx-lwc-language-server/src/context/lwcContext.ts`
+- `packages/salesforcedx-lwc-language-server/src/javascript/typeMapping.ts`
+- `packages/salesforcedx-lwc-language-server/src/tag.ts`
+- `packages/salesforcedx-lwc-language-server/src/typing.ts`
+- `packages/salesforcedx-lwc-language-server/test/lwcServerNode.test.ts`
+- `packages/salesforcedx-vscode-apex-log/src/schemas/traceFlagsSchema.ts`
+- `packages/salesforcedx-vscode-apex-oas/src/oas/externalServiceRegistrationManager.ts`
+- `packages/salesforcedx-vscode-apex/test/jest/languageServerOrphanHandler.test.ts`
+- `packages/salesforcedx-vscode-core/src/metadataSupport/metadataHoverProvider.ts`
+- `packages/salesforcedx-vscode-core/test/jest/metadataSupport/metadataHoverProvider.test.ts`
+- `packages/salesforcedx-vscode-org-browser/test/playwright/pages/orgBrowserPage.ts`
+- `packages/salesforcedx-vscode-org/test/jest/commands/auth/orgLogoutAll.test.ts`
+- `packages/salesforcedx-vscode-services/scripts/o11yDebugServer.ts`
+- `packages/salesforcedx-vscode-services/src/core/artifactIdentity.ts`
+- `packages/salesforcedx-vscode-services/src/core/transmogrifierService.ts`
+- `packages/salesforcedx-vscode-services/test/jest/core/templateService.test.ts`
+
+## Phases
+
+1. Replace each direct `=== null`/`!== null` check with the matching Effect predicate; add or extend `effect/Predicate` imports; preserve surrounding conditions, narrowing, and return values.
+   - Commit: `refactor: adopt Effect null predicates`
+
+## Skills to apply
+
+- `typescript`: imports, predicate-based narrowing, repository TypeScript conventions.
+- `verification`: focused tests plus repository static checks after edits.
+
+## Verification
+
+- Confirm changed Effect packages contain no remaining direct `=== null` or `!== null` checks.
+- Run formatting, lint, and TypeScript checks covering every changed package.
+- Run focused tests for changed test files and production modules with existing tests.
+- Review the diff to confirm predicate-only changes and no dependency or behavior changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -40111,6 +40111,7 @@
       "dependencies": {
         "@salesforce/core": "^9.1.9",
         "@salesforce/kit": "^4.0.0",
+        "effect": "^3.21.2",
         "fast-glob": "^3.3.2",
         "faye": "1.4.1",
         "istanbul-lib-coverage": "^3.2.2",
@@ -40125,7 +40126,6 @@
         "@types/istanbul-lib-report": "^3.0.3",
         "@types/istanbul-reports": "^3.0.4",
         "@types/sinon": "^17.0.3",
-        "effect": "^3.21.2",
         "prettier": "3.8.3",
         "sinon": "^17.0.1"
       },
@@ -40168,6 +40168,7 @@
         "@salesforce/salesforcedx-utils": "*",
         "@salesforce/vscode-i18n": "*",
         "@vscode/debugadapter": "1.68.0",
+        "effect": "^3.21.2",
         "vscode-uri": "^3.1.0"
       },
       "devDependencies": {

--- a/packages/drivable-vscode/src/sessionService.ts
+++ b/packages/drivable-vscode/src/sessionService.ts
@@ -17,6 +17,7 @@ import * as ExecutionStrategy from 'effect/ExecutionStrategy';
 import * as Exit from 'effect/Exit';
 import * as Match from 'effect/Match';
 import * as Option from 'effect/Option';
+import { isNull } from 'effect/Predicate';
 import * as Queue from 'effect/Queue';
 import * as Ref from 'effect/Ref';
 import * as Schema from 'effect/Schema';
@@ -235,7 +236,7 @@ const closeSessionScope = (scope: Scope.CloseableScope, exit: Exit.Exit<unknown,
 const closeElectron = Effect.fn('SessionService.closeElectron')(function* (app: ElectronApplication) {
   const child = app.process();
   const kill = Effect.suspend(() =>
-    typeof child.pid === 'number' && child.exitCode === null
+    typeof child.pid === 'number' && isNull(child.exitCode)
       ? Effect.try({
           try: () => process.kill(process.platform === 'win32' ? child.pid! : -child.pid!, 'SIGKILL'),
           catch: cause =>

--- a/packages/playwright-vscode-ext/src/codeBuilder/digest.ts
+++ b/packages/playwright-vscode-ext/src/codeBuilder/digest.ts
@@ -20,6 +20,7 @@
  * misses a bundle-only change; the bundle digest catches it.
  */
 
+import { isNull } from 'effect/Predicate';
 import { createHash } from 'node:crypto';
 import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
 import { join, resolve, sep } from 'node:path';
@@ -155,6 +156,6 @@ export const computeExtensionDigest = (dir: string, rawPkgJson?: string): Extens
   const pkgJsonDigest = sha256(canonicalPackageJson(raw));
   const { main } = JSON.parse(raw) as { main?: string };
   const entry = resolveEntrypointFromMain(root, main);
-  const bundleDigest = entry === null ? null : sha256(readFileSync(entry));
+  const bundleDigest = isNull(entry) ? null : sha256(readFileSync(entry));
   return { pkgJsonDigest, bundleDigest };
 };

--- a/packages/playwright-vscode-ext/src/fixtures/createDesktopTest.ts
+++ b/packages/playwright-vscode-ext/src/fixtures/createDesktopTest.ts
@@ -9,6 +9,7 @@
 import type { WorkerFixtures, TestFixtures } from './desktopFixtureTypes';
 import { test as base, _electron as electron, type ElectronApplication, type Page } from '@playwright/test';
 import { downloadAndUnzipVSCode, resolveCliPathFromVSCodeExecutablePath } from '@vscode/test-electron';
+import { isNotNull, isNull } from 'effect/Predicate';
 import { spawnSync, type ChildProcess } from 'node:child_process';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
@@ -108,7 +109,7 @@ const forceKillProcessGroup = (proc: ChildProcess): void => {
 /** Resolve once `proc` exits (via the given event) or after `timeoutMs`, whichever comes first. */
 const awaitProcExit = (proc: ChildProcess, { event, timeoutMs }: { event: 'close' | 'exit'; timeoutMs: number }): Promise<void> =>
   new Promise<void>(resolve => {
-    if (proc.exitCode !== null) {
+    if (isNotNull(proc.exitCode)) {
       resolve();
       return;
     }
@@ -375,7 +376,7 @@ export const createDesktopTest = (options: CreateDesktopTestOptions) => {
             ]);
           } catch {}
           // Force-kill if close didn't work (Windows timeout fallback)
-          if (proc?.exitCode === null && process.platform === 'win32') {
+          if (isNull(proc?.exitCode) && process.platform === 'win32') {
             try {
               process.kill(proc.pid!, 'SIGKILL');
             } catch {}

--- a/packages/playwright-vscode-ext/src/pages/contextMenu.ts
+++ b/packages/playwright-vscode-ext/src/pages/contextMenu.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Page, Locator } from '@playwright/test';
+import { isNotNull } from 'effect/Predicate';
 import { EDITOR_WITH_URI, CONTEXT_MENU } from '../utils/locators';
 import { focusOnFilesExplorer } from './nativeCommands';
 
@@ -27,7 +28,7 @@ const openEditorContextMenu = async (page: Page, fileName?: string): Promise<Loc
     const count = await allEditors.count();
     const dataUris = (
       await Promise.all(Array.from({ length: count }, (_, i) => allEditors.nth(i).getAttribute('data-uri')))
-    ).filter((uri): uri is string => uri !== null);
+    ).filter((uri): uri is string => isNotNull(uri));
     throw new Error(
       `No editor found with fileName containing "${fileName}". Available data-uris: ${dataUris.join(', ')}`,
       { cause }

--- a/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
+++ b/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
@@ -29,6 +29,7 @@ import {
 } from '@vscode/debugadapter';
 import { DebugProtocol } from '@vscode/debugprotocol';
 import * as Arr from 'effect/Array';
+import { isNull } from 'effect/Predicate';
 import * as os from 'node:os';
 import { basename } from 'node:path';
 import { ExceptionBreakpointInfo } from '../breakpoints/exceptionBreakpoint';
@@ -169,7 +170,7 @@ export class ApexVariable extends Variable {
       return value.nameForMessages;
     }
 
-    if (value.value === undefined || value.value === null) {
+    if (value.value === undefined || isNull(value.value)) {
       // We want to explicitly display null for null values (no type info for strings).
       return 'null';
     }

--- a/packages/salesforcedx-apex-replay-debugger/package.json
+++ b/packages/salesforcedx-apex-replay-debugger/package.json
@@ -17,6 +17,7 @@
     "@salesforce/salesforcedx-utils": "*",
     "@salesforce/vscode-i18n": "*",
     "@vscode/debugadapter": "1.68.0",
+    "effect": "^3.21.2",
     "vscode-uri": "^3.1.0"
   },
   "devDependencies": {

--- a/packages/salesforcedx-apex-replay-debugger/src/core/heapDumpService.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/core/heapDumpService.ts
@@ -6,6 +6,7 @@
  */
 
 import { StackFrame } from '@vscode/debugadapter';
+import { isNotNull, isNull, isUndefined } from 'effect/Predicate';
 import { ApexVariableContainer } from '../adapter/variableContainer';
 import {
   ApexExecutionOverlayResultCommandSuccess,
@@ -38,7 +39,7 @@ const isAddress = (value: any): boolean => typeof value === 'string' && value.st
 
 const createStringFromExtentValue = (value: any): string =>
   // can't toString undefined or null
-  value === undefined || value === null ? String(value) : value.toString();
+  isUndefined(value) || isNull(value) ? String(value) : value.toString();
 
 const PRIMITIVE_TYPES = new Set([
   LC_APEX_PRIMITIVE_BLOB,
@@ -70,7 +71,7 @@ const getKeyTypeForMap = (typeName: string, collectionType: string): string => {
 const isTriggerExtent = (outerExtent: HeapDumpExtents): boolean =>
   (outerExtent.typeName.toLowerCase() === LC_APEX_PRIMITIVE_BOOLEAN || isCollectionType(outerExtent.typeName)) &&
   outerExtent.count > 0 &&
-  outerExtent.extent[0].symbols !== null &&
+  isNotNull(outerExtent.extent[0].symbols) &&
   outerExtent.extent[0].symbols.length > 0 &&
   outerExtent.extent[0].symbols[0].startsWith(EXTENT_TRIGGER_PREFIX);
 
@@ -438,7 +439,7 @@ export class HeapDumpService {
     // and we can't reset set the value now.
     if (visitedMap.has(refVariable.ref)) {
       const visitedVar = visitedMap.get(refVariable.ref)!;
-      if (visitedVar !== null) {
+      if (isNotNull(visitedVar)) {
         if (visitedVar.name !== varName) {
           const updatedNameVarContainer = this.copyReferenceContainer(visitedVar, varName, false);
           updateAfterVarCreation.push(updatedNameVarContainer);

--- a/packages/salesforcedx-apex-replay-debugger/src/core/logContext.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/core/logContext.ts
@@ -6,6 +6,7 @@
  */
 
 import { StackFrame } from '@vscode/debugadapter';
+import { isNotNull } from 'effect/Predicate';
 import { ApexDebugStackFrameInfo } from '../adapter/apexDebugStackFrameInfo';
 import { ApexReplayDebug } from '../adapter/apexReplayDebug';
 import { HeapDumpResult, LaunchRequestArguments } from '../adapter/types';
@@ -107,11 +108,13 @@ export class LogContext {
     return (
       this.logLines &&
       this.logLines.length > 0 &&
-      this.logLines[0].match(
-        // Matches logs with APEX_CODE,FINEST and VISUALFORCE at FINER or FINEST level.
-        // The optional semicolons (;?) handle cases where Visualforce is the last category.
-        /(\d{2}.*APEX_CODE,FINEST;.*VISUALFORCE,FINER;?.*|\d{2}.*APEX_CODE,FINEST;.*VISUALFORCE,FINEST;?.*)/
-      ) !== null
+      isNotNull(
+        this.logLines[0].match(
+          // Matches logs with APEX_CODE,FINEST and VISUALFORCE at FINER or FINEST level.
+          // The optional semicolons (;?) handle cases where Visualforce is the last category.
+          /(\d{2}.*APEX_CODE,FINEST;.*VISUALFORCE,FINER;?.*|\d{2}.*APEX_CODE,FINEST;.*VISUALFORCE,FINEST;?.*)/
+        )
+      )
     );
   }
 

--- a/packages/salesforcedx-apex-replay-debugger/src/states/frameStateUtil.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/states/frameStateUtil.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { isNotNull } from 'effect/Predicate';
 import {
   EVENT_CODE_UNIT_FINISHED,
   EVENT_CODE_UNIT_STARTED,
@@ -95,6 +96,6 @@ export class FrameStateUtil {
   public static isExtraneousVFGetterOrSetterLogLine(logLine: string): boolean {
     const getMatch = ' get\\((.*)\\)';
     const setMatch = ' set\\((.*)\\)';
-    return logLine.match(getMatch) !== null || logLine.match(setMatch) !== null;
+    return isNotNull(logLine.match(getMatch)) || isNotNull(logLine.match(setMatch));
   }
 }

--- a/packages/salesforcedx-apex-replay-debugger/src/states/variableAssignmentState.ts
+++ b/packages/salesforcedx-apex-replay-debugger/src/states/variableAssignmentState.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { isNotNull } from 'effect/Predicate';
 import { ApexVariableContainer } from '../adapter/variableContainer';
 import { LogContext } from '../core/logContext';
 import { DebugLogState } from './debugLogState';
@@ -146,7 +147,7 @@ export class VariableAssignmentState implements DebugLogState {
       if (refContainer) {
         const tmpContainer = this.copyReferenceContainer(refContainer, key, logContext);
         container.variables.set(key, tmpContainer);
-      } else if (rawValue !== null && typeof rawValue === 'object') {
+      } else if (isNotNull(rawValue) && typeof rawValue === 'object') {
         // Nested object/array (parent SObject rel, multi-level hierarchy, or child subquery
         // records). Build an expandable child container and recurse. type='' is acceptable:
         // VARIABLE_ASSIGNMENT JSON carries no nested SObject type metadata (only field

--- a/packages/salesforcedx-apex/package.json
+++ b/packages/salesforcedx-apex/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@salesforce/core": "^9.1.9",
     "@salesforce/kit": "^4.0.0",
+    "effect": "^3.21.2",
     "fast-glob": "^3.3.2",
     "faye": "1.4.1",
     "istanbul-lib-coverage": "^3.2.2",
@@ -30,7 +31,6 @@
     "@types/istanbul-lib-report": "^3.0.3",
     "@types/istanbul-reports": "^3.0.4",
     "@types/sinon": "^17.0.3",
-    "effect": "^3.21.2",
     "prettier": "3.8.3",
     "sinon": "^17.0.1"
   },

--- a/packages/salesforcedx-apex/src/narrowing/narrowing.ts
+++ b/packages/salesforcedx-apex/src/narrowing/narrowing.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { isNullable } from 'effect/Predicate';
 import { CLASS_ID_PREFIX, TEST_RUN_ID_PREFIX } from '../tests/constants';
 import { TestResult, TestRunIdResult } from '../tests/types';
 
@@ -11,7 +12,7 @@ export const isTestResult = (result: TestResult | TestRunIdResult): result is Te
   'summary' in result && 'tests' in result && result.summary !== undefined && result.tests !== undefined;
 
 export const isEmpty = (value: string | number): boolean =>
-  value === null || value === undefined || (typeof value === 'string' && value.length === 0);
+  isNullable(value) || (typeof value === 'string' && value.length === 0);
 
 export const isValidTestRunID = (testRunId: string): boolean =>
   isValidSalesforceId(testRunId) && testRunId.startsWith(TEST_RUN_ID_PREFIX);

--- a/packages/salesforcedx-apex/src/reporters/markdownTextReporter.ts
+++ b/packages/salesforcedx-apex/src/reporters/markdownTextReporter.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { isNotNull } from 'effect/Predicate';
 import { TestResult, ApexTestResultData } from '../tests/types';
 
 /** @internal Used by the co-repo Apex Testing extension; not part of the supported npm API. */
@@ -154,7 +155,7 @@ export const getSeverityScore = (
   // Subtract coverage (lower = worse, but only if it's a problem)
   if (codeCoverage && hasLowCoverage) {
     const coverage = getCoveragePercentage(test.perClassCoverage?.[0]?.percentage);
-    if (coverage !== null) {
+    if (isNotNull(coverage)) {
       score += (100 - coverage) * 100; // Lower coverage = higher score
     }
   }

--- a/packages/salesforcedx-apex/src/tests/asyncTests.ts
+++ b/packages/salesforcedx-apex/src/tests/asyncTests.ts
@@ -7,6 +7,7 @@
 
 import { AuthInfo, Connection, Logger, LoggerLevel, PollingClient } from '@salesforce/core';
 import { Duration } from '@salesforce/kit';
+import { isNotNull, isNull } from 'effect/Predicate';
 import { JsonStreamStringify } from 'json-stream-stringify';
 import { createWriteStream } from 'node:fs';
 import * as fs from 'node:fs/promises';
@@ -608,7 +609,7 @@ export class AsyncTests {
       const testRunApexIdResults = await this.connection.tooling.query<ApexTestQueueItemRecord>(
         `SELECT ApexClassId FROM ApexTestQueueItem WHERE Id = '${testRunId}'`
       );
-      return testRunApexIdResults.records.some(record => record.ApexClassId === null);
+      return testRunApexIdResults.records.some(record => isNull(record.ApexClassId));
     } catch {
       return false;
     }
@@ -661,8 +662,8 @@ export class AsyncTests {
       return { apexTestIds: [], flowTestIds: [] };
     }
     return {
-      apexTestIds: records.filter(r => r.ApexClassId !== null).map(r => r.Id),
-      flowTestIds: records.filter(r => r.ApexClassId === null).map(r => r.Id)
+      apexTestIds: records.filter(r => isNotNull(r.ApexClassId)).map(r => r.Id),
+      flowTestIds: records.filter(r => isNull(r.ApexClassId)).map(r => r.Id)
     };
   }
 

--- a/packages/salesforcedx-apex/src/tests/utils.ts
+++ b/packages/salesforcedx-apex/src/tests/utils.ts
@@ -8,6 +8,7 @@
 import type { CodeCoverage } from './codeCoverage';
 import type { QueryResult, Record as JsforceRecord } from '@jsforce/jsforce-node';
 import { Connection, Logger } from '@salesforce/core';
+import { isNotNull } from 'effect/Predicate';
 import { Progress } from '../common';
 import { nls } from '../i18n';
 import {
@@ -104,7 +105,7 @@ export const queryAll = async <R extends JsforceRecord>(
 };
 
 export const getJsonIndent = (): number | undefined => {
-  if (jsonIndent !== null) {
+  if (isNotNull(jsonIndent)) {
     return jsonIndent;
   }
 
@@ -128,7 +129,7 @@ export const getJsonIndent = (): number | undefined => {
 };
 
 export const getBufferSize = (): number => {
-  if (bufferSize !== null) {
+  if (isNotNull(bufferSize)) {
     return bufferSize;
   }
 

--- a/packages/salesforcedx-lwc-language-server/src/componentIndexer.ts
+++ b/packages/salesforcedx-lwc-language-server/src/componentIndexer.ts
@@ -16,6 +16,7 @@ import {
   NormalizedPath
 } from '@salesforce/salesforcedx-lightning-lsp-common';
 import { snakeCase, camelCase } from 'change-case';
+import { isNotNull } from 'effect/Predicate';
 import * as path from 'node:path';
 import { Connection, DocumentUri } from 'vscode-languageserver';
 import { URI, Utils } from 'vscode-uri';
@@ -403,7 +404,7 @@ export default class ComponentIndexer {
       return tag;
     });
     (await Promise.all(promises))
-      .filter((tag): tag is Tag => tag !== null)
+      .filter((tag): tag is Tag => isNotNull(tag))
       .forEach(tag => this.tags.set(getTagName(tag), tag));
 
     (await this.getStaleTags()).forEach(tag => this.tags.delete(getTagName(tag)));

--- a/packages/salesforcedx-lwc-language-server/src/context/lwcContext.ts
+++ b/packages/salesforcedx-lwc-language-server/src/context/lwcContext.ts
@@ -21,6 +21,7 @@ import {
   type NormalizedPath
 } from '@salesforce/salesforcedx-lightning-lsp-common';
 import * as Arr from 'effect/Array';
+import { isNotNull } from 'effect/Predicate';
 import * as ejs from 'ejs';
 import * as path from 'node:path';
 import { TextDocument } from 'vscode-languageserver-textdocument';
@@ -65,7 +66,7 @@ export class LWCWorkspaceContext extends BaseWorkspaceContext {
                   const i = parts.lastIndexOf('lwc');
                   return i === -1 ? null : normalizePath(parts.slice(0, i + 1).join('/'));
                 })
-                .filter((d): d is NormalizedPath => d !== null)
+                .filter((d): d is NormalizedPath => isNotNull(d))
             );
             roots.lwc.push(...lwcDirs);
 
@@ -77,7 +78,7 @@ export class LWCWorkspaceContext extends BaseWorkspaceContext {
                   const i = parts.lastIndexOf('aura');
                   return i === -1 ? null : normalizePath(parts.slice(0, i + 1).join('/'));
                 })
-                .filter((d): d is NormalizedPath => d !== null)
+                .filter((d): d is NormalizedPath => isNotNull(d))
             );
             roots.aura.push(...auraDirs);
           }

--- a/packages/salesforcedx-lwc-language-server/src/javascript/typeMapping.ts
+++ b/packages/salesforcedx-lwc-language-server/src/javascript/typeMapping.ts
@@ -19,6 +19,7 @@ import {
   ClassMember as InternalClassMember,
   Location as InternalLocation
 } from '@salesforce/salesforcedx-lightning-lsp-common';
+import { isNotNull } from 'effect/Predicate';
 import {
   Metadata as InternalMetadata,
   ModuleExports as InternalModuleExports,
@@ -275,10 +276,10 @@ const getMemberMethod = (methodObj: ClassMethod): InternalClassMember | null => 
 const getMembers = (classObj: Class): InternalClassMember[] => {
   const properties: InternalClassMember[] = classObj.properties
     .map(getMemberProperty)
-    .filter((member): member is InternalClassMember => member !== null);
+    .filter((member): member is InternalClassMember => isNotNull(member));
   const methods: InternalClassMember[] = classObj.methods
     .map(getMemberMethod)
-    .filter((member): member is InternalClassMember => member !== null);
+    .filter((member): member is InternalClassMember => isNotNull(member));
 
   // In the original metadata, the properties & methods were intermixed in the order
   // that they appeared in the component code. Since the new metadata exposes this information
@@ -515,7 +516,7 @@ const getDecorators = (classObj: Class): InternalDecorator[] => {
         }
       : null;
 
-  return [api, wire, track].filter((decorator): decorator is InternalDecorator => decorator !== null);
+  return [api, wire, track].filter((decorator): decorator is InternalDecorator => isNotNull(decorator));
 };
 
 const getExports = (lwcExports: LwcExport[]): InternalModuleExports[] =>

--- a/packages/salesforcedx-lwc-language-server/src/tag.ts
+++ b/packages/salesforcedx-lwc-language-server/src/tag.ts
@@ -280,7 +280,7 @@ export const getClassMemberLocation = (
 // Utility function to get tag description
 export const getTagDescription = (tag: Tag): string => {
   const docs: string[] = [getTagDocumentation(tag), getAttributeDocs(tag) ?? '', getMethodDocs(tag) ?? ''];
-  return docs.filter(item => item !== null && item !== '').join('\n');
+  return docs.filter(item => item !== '').join('\n');
 };
 
 // Utility function to get tag documentation

--- a/packages/salesforcedx-lwc-language-server/test/lwcServerNode.test.ts
+++ b/packages/salesforcedx-lwc-language-server/test/lwcServerNode.test.ts
@@ -120,6 +120,7 @@ import {
   SFDX_WORKSPACE_STRUCTURE,
   sfdxFileSystemAccessor
 } from '@salesforce/salesforcedx-lightning-lsp-common/testUtils';
+import { isNotNull } from 'effect/Predicate';
 import * as path from 'node:path';
 import { getLanguageService } from 'vscode-html-languageservice';
 import {
@@ -638,7 +639,7 @@ describe('lwcServerNode', () => {
         // Note: hover might be null if test_component isn't found or doesn't have the expected structure
         // This test expects info and icon-name from test_component, but it might not be indexed correctly
         // For now, we'll skip the assertion if hover is null (known issue with test_component)
-        if (hover !== null) {
+        if (isNotNull(hover)) {
           const contents = hover.contents as MarkupContent;
           expect(contents.value).toContain('**info**');
           expect(contents.value).toContain('**icon-name**');

--- a/packages/salesforcedx-vscode-core/src/metadataSupport/metadataHoverProvider.ts
+++ b/packages/salesforcedx-vscode-core/src/metadataSupport/metadataHoverProvider.ts
@@ -4,7 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { isNotUndefined } from 'effect/Predicate';
+import { isNotNull, isNotUndefined } from 'effect/Predicate';
 import * as vscode from 'vscode';
 import { MetadataDocumentationService } from './metadataDocumentationService';
 
@@ -28,7 +28,7 @@ export const isMetadataFile = (
   const xmlElementRegex = /<(\/?)([\w:]+)(\s|>|\/)/g;
   let match;
 
-  while ((match = xmlElementRegex.exec(documentText)) !== null) {
+  while (isNotNull((match = xmlElementRegex.exec(documentText)))) {
     const elementName = match[2];
     // Remove namespace prefix if present
     const cleanElementName = elementName.includes(':') ? elementName.split(':')[1] : elementName;
@@ -55,7 +55,7 @@ export const extractMetadataType = (
   const xmlElementRegex = /<(\/?)([\w:]+)(\s|>|\/)/g;
   let match;
 
-  while ((match = xmlElementRegex.exec(lineText)) !== null) {
+  while (isNotNull((match = xmlElementRegex.exec(lineText)))) {
     const [fullMatch, , elementName] = match;
     const matchStart = match.index;
     const matchEnd = match.index + fullMatch.length;
@@ -76,7 +76,7 @@ export const extractMetadataType = (
   const multiLineElementRegex = /<(\/?)([\w:]+)$/g;
   let multiLineMatch;
 
-  while ((multiLineMatch = multiLineElementRegex.exec(lineText)) !== null) {
+  while (isNotNull((multiLineMatch = multiLineElementRegex.exec(lineText)))) {
     const [fullMatch, , elementName] = multiLineMatch;
     const matchStart = multiLineMatch.index;
     const matchEnd = multiLineMatch.index + fullMatch.length;
@@ -140,7 +140,7 @@ export const findParentMetadataTypeWithLayers = (
     const selfClosingTagRegex = /<([\w:]+)(?:\s[^>]*)?\/>/g;
     const selfClosingTags = new Set<number>();
     let match;
-    while ((match = selfClosingTagRegex.exec(line)) !== null) {
+    while (isNotNull((match = selfClosingTagRegex.exec(line)))) {
       selfClosingTags.add(match.index);
     }
 
@@ -148,7 +148,7 @@ export const findParentMetadataTypeWithLayers = (
     const openingTagRegex = /<([\w:]+)(?:\s[^>]*)?>/g;
     const incompleteOpeningTagRegex = /<([\w:]+)(?:\s[^>]*)?$/;
 
-    while ((match = openingTagRegex.exec(line)) !== null) {
+    while (isNotNull((match = openingTagRegex.exec(line)))) {
       // Skip if this is a self-closing tag
       if (!selfClosingTags.has(match.index)) {
         const elementName = match[1];
@@ -166,7 +166,7 @@ export const findParentMetadataTypeWithLayers = (
 
     // Find closing tags
     const closingTagRegex = /<\/([\w:]+)>/g;
-    while ((match = closingTagRegex.exec(line)) !== null) {
+    while (isNotNull((match = closingTagRegex.exec(line)))) {
       const elementName = match[1];
       const cleanElementName = elementName.includes(':') ? elementName.split(':')[1] : elementName;
       // Remove the matching opening tag from the stack
@@ -221,7 +221,7 @@ export const extractFieldInfo = (
   const xmlElementRegex = /<(\/?)([\w:]+)(\s|>|\/)/g;
   let match;
 
-  while ((match = xmlElementRegex.exec(line.text)) !== null) {
+  while (isNotNull((match = xmlElementRegex.exec(line.text)))) {
     const [fullMatch, , elementName] = match;
     const matchStart = match.index;
     const matchEnd = match.index + fullMatch.length;
@@ -252,7 +252,7 @@ export const extractFieldInfo = (
   const multiLineElementRegex = /<(\/?)([\w:]+)$/g;
   let multiLineMatch;
 
-  while ((multiLineMatch = multiLineElementRegex.exec(line.text)) !== null) {
+  while (isNotNull((multiLineMatch = multiLineElementRegex.exec(line.text)))) {
     const [fullMatch, , elementName] = multiLineMatch;
     const matchStart = multiLineMatch.index;
     const matchEnd = multiLineMatch.index + fullMatch.length;

--- a/packages/salesforcedx-vscode-core/test/jest/metadataSupport/metadataHoverProvider.test.ts
+++ b/packages/salesforcedx-vscode-core/test/jest/metadataSupport/metadataHoverProvider.test.ts
@@ -6,6 +6,7 @@
  */
 
 import * as vscode from 'vscode';
+import { isNotNull } from 'effect/Predicate';
 import { MetadataDocumentationService } from '../../../src/metadataSupport/metadataDocumentationService';
 import {
   MetadataHoverProvider,
@@ -60,7 +61,7 @@ const createMockDocument = (fileName: string, content: string) =>
       const xmlElementRegex = /<(\/?)([\w:]+)(\s|>|\/)/g;
       let match;
 
-      while ((match = xmlElementRegex.exec(line)) !== null) {
+      while (isNotNull((match = xmlElementRegex.exec(line)))) {
         const [fullMatch, , elementName] = match;
         const matchStart = match.index;
         const matchEnd = match.index + fullMatch.length;

--- a/packages/salesforcedx-vscode-org-browser/test/playwright/pages/orgBrowserPage.ts
+++ b/packages/salesforcedx-vscode-org-browser/test/playwright/pages/orgBrowserPage.ts
@@ -4,6 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import { isNull } from 'effect/Predicate';
 import { Page, Locator, expect } from '@playwright/test';
 import {
   activeQuickInputTextField,
@@ -77,7 +78,7 @@ export class OrgBrowserPage {
     const firstRootItem = this.sidebar.getByRole('treeitem', { level: 1 }).first();
     if ((await firstRootItem.count()) === 0) return 0;
     const setSize = await firstRootItem.getAttribute('aria-setsize');
-    return setSize === null ? 0 : Number(setSize);
+    return isNull(setSize) ? 0 : Number(setSize);
   }
 
   /** Poll {@link getRootTypeCount} until it reaches `expected` (the tree re-fetches asynchronously after a filter toggle). */

--- a/packages/salesforcedx-vscode-org/test/jest/commands/auth/orgLogoutAll.test.ts
+++ b/packages/salesforcedx-vscode-org/test/jest/commands/auth/orgLogoutAll.test.ts
@@ -7,6 +7,7 @@
 
 import { AuthRemover } from '@salesforce/core';
 import { ExtensionProviderService } from '@salesforce/effect-ext-utils';
+import { isNotNull } from 'effect/Predicate';
 import * as Effect from 'effect/Effect';
 import * as Exit from 'effect/Exit';
 import * as Schema from 'effect/Schema';
@@ -21,7 +22,7 @@ class UserCancellationError extends Schema.TaggedError<UserCancellationError>()(
 jest.mock('../../../../src/orgPicker/orgList', () => ({
   buildOrgQuickPickItems: (auths: Array<{ username: string }>) =>
     auths.map(a => ({ label: a.username, orgUsername: a.username })),
-  isOrgItem: (item: unknown): boolean => typeof item === 'object' && item !== null && 'orgUsername' in item
+  isOrgItem: (item: unknown): boolean => typeof item === 'object' && isNotNull(item) && 'orgUsername' in item
 }));
 
 const mockGetFreshAuthorizations = jest.fn<Effect.Effect<unknown, never, never>, []>();

--- a/packages/salesforcedx-vscode-services/scripts/o11yDebugServer.ts
+++ b/packages/salesforcedx-vscode-services/scripts/o11yDebugServer.ts
@@ -7,7 +7,7 @@
 
 import * as Effect from 'effect/Effect';
 import * as Encoding from 'effect/Encoding';
-import { isError } from 'effect/Predicate';
+import { isError, isNull } from 'effect/Predicate';
 import * as http from 'node:http';
 
 const PORT = 3002;
@@ -45,7 +45,7 @@ const extractJsonObjects = (str: string): string[] => {
   const findMatches = (startIdx: number): number[] => {
     pattern.lastIndex = startIdx;
     const match = pattern.exec(str);
-    if (match === null || match.index >= str.length) return allMatchIndices;
+    if (isNull(match) || match.index >= str.length) return allMatchIndices;
     allMatchIndices.push(match.index);
     return findMatches(match.index + 1);
   };

--- a/packages/salesforcedx-vscode-services/src/core/artifactIdentity.ts
+++ b/packages/salesforcedx-vscode-services/src/core/artifactIdentity.ts
@@ -5,6 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import { isNull } from 'effect/Predicate';
 import * as Schema from 'effect/Schema';
 
 export const ArtifactTargetKindSchema = Schema.Literal('metadata-component', 'sobject');
@@ -42,7 +43,7 @@ export type ArtifactIdentity = typeof ArtifactIdentitySchema.Type;
 export const normalizeArtifactIdentityPart = (value: string): string => value.toLowerCase();
 
 export const normalizeArtifactNamespace = (namespace: ArtifactNamespace): ArtifactNamespace =>
-  namespace === null ? null : normalizeArtifactIdentityPart(namespace);
+  isNull(namespace) ? null : normalizeArtifactIdentityPart(namespace);
 
 export const normalizeArtifactIdentity = (identity: ArtifactIdentity): ArtifactIdentity => ({
   ...identity,

--- a/packages/salesforcedx-vscode-services/src/core/transmogrifierService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/transmogrifierService.ts
@@ -8,6 +8,7 @@
 import type { SObjectArtifactIdentity } from './artifactIdentity';
 import type { Connection } from '@salesforce/core';
 import * as Effect from 'effect/Effect';
+import { isNull } from 'effect/Predicate';
 import * as S from 'effect/Schema';
 import type { URI } from 'vscode-uri';
 import { SObjectSemanticModelSchema, type SObjectSemanticField, type SObjectSemanticModel } from './artifactProjection';
@@ -252,17 +253,17 @@ const mapRestFieldToSemanticField = (field: SObjectField): SObjectSemanticField 
   type: field.type,
   custom: field.custom,
   defaultValue: field.defaultValue,
-  ...(field.inlineHelpText === null ? {} : { inlineHelpText: field.inlineHelpText }),
+  ...(isNull(field.inlineHelpText) ? {} : { inlineHelpText: field.inlineHelpText }),
   ...(field.length === undefined ? {} : { length: field.length }),
   ...(field.precision === undefined ? {} : { precision: field.precision }),
   ...(field.scale === undefined ? {} : { scale: field.scale }),
   referenceTo: field.referenceTo.toSorted(),
-  ...(field.relationshipName === null ? {} : { relationshipName: field.relationshipName }),
+  ...(isNull(field.relationshipName) ? {} : { relationshipName: field.relationshipName }),
   picklistValues: field.picklistValues
     .map(value => ({
       value: value.value,
       active: value.active,
-      ...(value.label === null ? {} : { label: value.label })
+      ...(isNull(value.label) ? {} : { label: value.label })
     }))
     .toSorted((left, right) => left.value.localeCompare(right.value)),
   runtimeCapabilities: {
@@ -291,7 +292,7 @@ const mapRestDescribeToSemanticModel = (
         .map(relationship => ({
           childSObject: relationship.childSObject,
           field: relationship.field,
-          ...(relationship.relationshipName === null ? {} : { relationshipName: relationship.relationshipName })
+          ...(isNull(relationship.relationshipName) ? {} : { relationshipName: relationship.relationshipName })
         }))
         .toSorted((left, right) =>
           left.childSObject === right.childSObject

--- a/packages/salesforcedx-vscode-services/test/jest/core/templateService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/templateService.test.ts
@@ -8,6 +8,7 @@
 import { OrgConfigProperties } from '@salesforce/core';
 import type { ConfigAggregator } from '@salesforce/core/configAggregator';
 import * as SfTemplates from '@salesforce/templates';
+import { isNull } from 'effect/Predicate';
 import * as Effect from 'effect/Effect';
 import * as Layer from 'effect/Layer';
 import * as Stream from 'effect/Stream';
@@ -82,7 +83,7 @@ const createMockProjectService = (): Layer.Layer<ProjectService> => {
       isSalesforceProject: () => Effect.succeed(true),
       getSfProject: () => Effect.succeed(mockSfProject),
       getProjectNamespace: () => Effect.succeed(null),
-      isArtifactNamespaceWorkspaceEligible: namespace => Effect.succeed(namespace === null),
+      isArtifactNamespaceWorkspaceEligible: namespace => Effect.succeed(isNull(namespace)),
       projectConfigChanges: Stream.empty,
       isInPackageDirectories: () => Effect.succeed(true),
       ensureInPackageDirectories: () => Effect.void,


### PR DESCRIPTION
### What issues does this PR fix or reference?

@W-23358838@

### What changed and why?

- Replaced direct `null` equality checks with `isNull`/`isNotNull` from `effect/Predicate` across the affected Effect-using packages.
- Updated filters, type guards, regex loops, debugger logic, test helpers, and service mappings while preserving existing behavior and narrowing.
- Removed one redundant null check in the LWC tag description filter.
- Moved or added `effect` as a runtime dependency where production code now imports `effect/Predicate`, and updated `package-lock.json`.

This standardizes null handling across the codebase without changing functional behavior.
