### PR TITLE
chore: Fix circular dependency in salesforcedx-apex-debugger and add check:circular-deps - W-23566389

### DIFF
--- a/.claude/plans/W-23566389.md
+++ b/.claude/plans/W-23566389.md
@@ -1,0 +1,32 @@
+# W-23566389
+
+## Context
+
+`packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts` imports debugger message and workspace-setting contracts from `src/index.ts`, while `src/index.ts` exports `SetExceptionBreakpointsArguments` from `apexDebug.ts`. Remove this circular import so module initialization no longer depends on the public entry point. Add the package's missing circular-dependency check to prevent recurrence.
+
+## Phases
+
+### 1. Remove the cycle and enforce the dependency check
+
+Commit: `fix: remove apex debugger circular dependency`
+
+- Move `VscodeDebuggerMessageType` and `VscodeDebuggerMessage` from `packages/salesforcedx-apex-debugger/src/index.ts` to `packages/salesforcedx-apex-debugger/src/vscodeDebuggerMessage.ts`.
+- Move `WorkspaceSettings` from `packages/salesforcedx-apex-debugger/src/index.ts` to `packages/salesforcedx-apex-debugger/src/workspaceSettings.ts`.
+- Update `packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts` to import those contracts from their defining files instead of `src/index.ts`.
+- Re-export the contracts explicitly from `packages/salesforcedx-apex-debugger/src/index.ts`, preserving the package API.
+- Update `packages/salesforcedx-apex-debugger/package.json`: add the Wireit-backed `check:circular-deps` script, track `.circular-deps.json`, remove it during `clean`, and make `lint` depend on the check.
+
+## Skills to apply
+
+- `typescript`: direct imports, explicit exports, camelCase filenames.
+- `packageJson`: preserve package script conventions.
+- `wireit`: explicit inputs, output, and lint dependency.
+- `verification`: targeted checks after implementation.
+
+## Verification
+
+- Run `npm install` from the repository root.
+- Run `WIREIT_CACHE=none npm run check:circular-deps -w salesforcedx-apex-debugger`; confirm zero cycles.
+- Run `WIREIT_CACHE=none npm run compile -w salesforcedx-apex-debugger`.
+- Run `WIREIT_CACHE=none npm run lint -w salesforcedx-apex-debugger`.
+- Run `WIREIT_CACHE=none npm test -w salesforcedx-apex-debugger`.

--- a/packages/salesforcedx-apex-debugger/package.json
+++ b/packages/salesforcedx-apex-debugger/package.json
@@ -35,7 +35,8 @@
     "bundle:debugger": "wireit",
     "compile": "wireit",
     "lint": "wireit",
-    "clean": "shx rm -rf node_modules out dist coverage .nyc_output .wireit .eslintcache",
+    "check:circular-deps": "wireit",
+    "clean": "shx rm -rf node_modules out dist coverage .nyc_output .wireit .eslintcache .circular-deps.json",
     "test": "wireit",
     "test:compile": "wireit"
   },
@@ -100,6 +101,7 @@
       "command": "eslint --color --cache --cache-location .eslintcache .",
       "dependencies": [
         "../eslint-local-rules:compile",
+        "check:circular-deps",
         "compile"
       ],
       "files": [
@@ -110,6 +112,18 @@
         "package.nls.json"
       ],
       "output": []
+    },
+    "check:circular-deps": {
+      "command": "dpdm --no-warning --no-tree --exit-code circular:1 --output .circular-deps.json src/index.ts",
+      "dependencies": [
+        "compile"
+      ],
+      "files": [
+        "src/**/*.ts"
+      ],
+      "output": [
+        ".circular-deps.json"
+      ]
     }
   }
 }

--- a/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
+++ b/packages/salesforcedx-apex-debugger/src/adapter/apexDebug.ts
@@ -75,9 +75,10 @@ import {
   StreamingService
 } from '../core';
 import { extractJsonObject } from '../extractJsonObject';
-import { VscodeDebuggerMessage, VscodeDebuggerMessageType, WorkspaceSettings } from '../index';
 import { nls } from '../messages';
 import { RequestService } from '../requestService/requestService';
+import { VscodeDebuggerMessage, VscodeDebuggerMessageType } from '../vscodeDebuggerMessage';
+import { WorkspaceSettings } from '../workspaceSettings';
 
 // Below import has to be required for bundling
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/packages/salesforcedx-apex-debugger/src/index.ts
+++ b/packages/salesforcedx-apex-debugger/src/index.ts
@@ -21,23 +21,9 @@ export {
   SF_CONFIG_ISV_DEBUGGER_URL
 } from './constants';
 export type { SetExceptionBreakpointsArguments } from './adapter/apexDebug';
-export enum VscodeDebuggerMessageType {
-  Info,
-  Warning,
-  Error
-}
-
-export type VscodeDebuggerMessage = {
-  type: VscodeDebuggerMessageType;
-  message: string;
-};
-
-export type WorkspaceSettings = {
-  proxyUrl: string;
-  proxyStrictSSL: boolean;
-  proxyAuth: string;
-  connectionTimeoutMs: number;
-};
+export { VscodeDebuggerMessageType } from './vscodeDebuggerMessage';
+export type { VscodeDebuggerMessage } from './vscodeDebuggerMessage';
+export type { WorkspaceSettings } from './workspaceSettings';
 
 // Define the metric payload sent to the debugger extension.
 type Metric = {

--- a/packages/salesforcedx-apex-debugger/src/vscodeDebuggerMessage.ts
+++ b/packages/salesforcedx-apex-debugger/src/vscodeDebuggerMessage.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+export enum VscodeDebuggerMessageType {
+  Info,
+  Warning,
+  Error
+}
+
+export type VscodeDebuggerMessage = {
+  type: VscodeDebuggerMessageType;
+  message: string;
+};

--- a/packages/salesforcedx-apex-debugger/src/workspaceSettings.ts
+++ b/packages/salesforcedx-apex-debugger/src/workspaceSettings.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+export type WorkspaceSettings = {
+  proxyUrl: string;
+  proxyStrictSSL: boolean;
+  proxyAuth: string;
+  connectionTimeoutMs: number;
+};


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-23566389@

### What changed and why?

- Moved debugger message and workspace settings contracts into dedicated modules.
- Updated `apexDebug.ts` to import those contracts directly, removing its circular dependency on `index.ts`.
- Preserved the public API by re-exporting the contracts from `index.ts`.
- Added a Wireit-backed `check:circular-deps` script using `dpdm`.
- Made `lint` depend on the circular-dependency check and removed its generated output during `clean`.

This prevents module initialization issues and helps prevent the circular dependency from recurring.

### Verification

Not run in this session.
