### PR TITLE
chore: Use Effect.filterOrFail for guard-then-fail sites in salesforcedx-vscode-org - W-23506239

### DIFF
--- a/.claude/plans/W-23506239.md
+++ b/.claude/plans/W-23506239.md
@@ -1,0 +1,25 @@
+# W-23506239: Use Effect.filterOrFail for guard-then-fail sites in salesforcedx-vscode-org
+
+## Context
+
+`promptForAlias` in `packages/salesforcedx-vscode-org/src/commands/auth/authParamsGatherer.ts` currently uses `Effect.flatMap` to inspect an optional prompt result and fail with `UserCancellationError` when it is `undefined`. Replace this guard-then-fail expression with `Effect.filterOrFail` so the code directly expresses the predicate and typed failure while retaining empty-string aliases as valid input.
+
+## Phases
+
+1. **Refactor the alias cancellation guard** — `refactor(org): use filterOrFail for alias cancellation`
+   - In `packages/salesforcedx-vscode-org/src/commands/auth/authParamsGatherer.ts`, replace the `Effect.flatMap` conditional in `promptForAlias` with `Effect.filterOrFail(isNotUndefined, () => new api.services.UserCancellationError({}))`.
+   - Keep the existing default-alias and cancellation behavior unchanged; existing coverage is in `packages/salesforcedx-vscode-org/test/jest/commands/auth/authParamsGatherer.test.ts`.
+
+## Skills to apply
+
+- `effect-best-practices`: use the dedicated Effect guard combinator and preserve the typed error channel.
+- `typescript`: retain narrowing from `string | undefined` to `string` without assertions.
+- `verification`: run package checks and Effect diagnostics after the refactor.
+
+## Verification
+
+- Run `npx effect-language-service diagnostics --file packages/salesforcedx-vscode-org/src/commands/auth/authParamsGatherer.ts`.
+- Run `npm run compile -w salesforcedx-vscode-org`.
+- Run `npm run lint -w salesforcedx-vscode-org`.
+- Run `npm test -w salesforcedx-vscode-org -- --runInBand test/jest/commands/auth/authParamsGatherer.test.ts`.
+- Run `npm run test:desktop -w salesforcedx-vscode-org -- --retries 0`.

--- a/packages/salesforcedx-vscode-org/src/commands/auth/authParamsGatherer.ts
+++ b/packages/salesforcedx-vscode-org/src/commands/auth/authParamsGatherer.ts
@@ -49,7 +49,7 @@ const inputAlias = async (): Promise<string | undefined> =>
 export const promptForAlias = Effect.fn('AuthParamsGatherer.promptForAlias')(function* () {
   const api = yield* (yield* ExtensionProviderService).getServicesApi;
   const value = yield* Effect.promise(inputAlias).pipe(
-    Effect.flatMap(v => (isUndefined(v) ? new api.services.UserCancellationError({}) : Effect.succeed(v)))
+    Effect.filterOrFail(isNotUndefined, () => new api.services.UserCancellationError({}))
   );
   return value || DEFAULT_ALIAS;
 });


### PR DESCRIPTION
### What issues does this PR fix or reference?

@W-23506239@

### What changed and why?

Replaced the guard-then-fail `Effect.flatMap` in `promptForAlias` with `Effect.filterOrFail`.

This directly expresses that `undefined` means user cancellation while preserving the typed `UserCancellationError` failure. Empty-string aliases remain valid input and retain the existing default-alias behavior.

### Testing

Not run.
