### PR TITLE
chore: 1.3 Delete leftover org TelemetryService module - W-24163047

### DIFF
--- a/.claude/plans/W-24163047.md
+++ b/.claude/plans/W-24163047.md
@@ -1,0 +1,28 @@
+# W-24163047 — Delete leftover org TelemetryService module
+
+## Context
+
+- GUS subject: `1.3 Delete leftover org TelemetryService module [repo:forcedotcom/salesforcedx-vscode] [ai-auto]`.
+- Current checkout contains no org-owned `TelemetryService` module and no live `TelemetryService` reference under `packages/salesforcedx-vscode-org`.
+- The remaining org-package reference is a historical telemetry comment in `packages/salesforcedx-vscode-org/src/commands/orgCreate.ts`.
+- Remove that stale reference; runtime behavior remains unchanged.
+
+## Phases
+
+### Phase 1 — Remove the leftover org TelemetryService reference
+
+- Delete the historical `telemetryService.sendException` comment from `packages/salesforcedx-vscode-org/src/commands/orgCreate.ts`.
+- Keep the failure-path implementation unchanged.
+- Commit: `chore(org): remove leftover TelemetryService reference - W-24163047`
+
+## Skills to apply
+
+- `concise` — keep the deletion and commit focused.
+- `verification` — verify scope and repository checks.
+
+## Verification
+
+- Confirm `TelemetryService`, `telemetryService`, `getTelemetryService`, and `setTelemetryService` have no matches under `packages/salesforcedx-vscode-org`.
+- Run `npm run compile`.
+- Run `npm run lint`.
+- Inspect the diff: only the stale comment is removed; no runtime code changes.

--- a/packages/salesforcedx-vscode-org/src/commands/orgCreate.ts
+++ b/packages/salesforcedx-vscode-org/src/commands/orgCreate.ts
@@ -184,10 +184,6 @@ export const orgCreateCommand = Effect.fn('orgCreateCommand')(function* () {
   });
 
   // failure branch: sf prints `{ status, message }` — surface the message to the channel (no aggregator refresh).
-  // NOTE: the old executor sent telemetryService.sendException('org_create', message) here and
-  // 'org_create_scratch' on parse errors. Both are intentionally dropped: migrated Effect org commands
-  // (orgOpen, orgDeleteDefaultCommand) emit no failure-exception telemetry; OrgCreateParseError flows to
-  // ErrorHandlerService for user-facing rendering instead.
   const handleFailure = Effect.fn('orgCreateCommand.handleFailure')(function* ({ message }: OrgCreateFailure) {
     const channel = yield* api.services.ChannelService;
     yield* channel.appendToChannel(message);


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-24163047@

### What changed and why?
Removed the stale historical `telemetryService.sendException` comment from `packages/salesforcedx-vscode-org/src/commands/orgCreate.ts`.

No runtime behavior changes: the existing failure handling remains unchanged. This removes the final leftover reference to the deleted org telemetry module.
