### PR TITLE
chore: Add port-3001 kill after failed try-run on every e2e-web job - W-24142840

### DIFF
--- a/.claude/plans/W-24142840.md
+++ b/.claude/plans/W-24142840.md
@@ -1,0 +1,32 @@
+# W-24142840
+
+## Context
+
+Every `e2e-web` job must kill the process using port 3001 when its `try-run` step fails. This prevents that failed attempt from leaving the web-test port occupied before the job continues.
+
+## Phases
+
+### 1. Add failed-try-run port cleanup
+
+- Add a port-3001 kill step immediately after `try-run`, conditioned on `steps.try-run.outcome == 'failure'`, in each `e2e-web` job in:
+  - `.github/workflows/apexLogE2E.yml`
+  - `.github/workflows/apexTestingE2E.yml`
+  - `.github/workflows/lwcPlaywrightE2E.yml`
+  - `.github/workflows/metadataE2E.yml`
+  - `.github/workflows/orgBrowserE2E.yml`
+  - `.github/workflows/playwrightVscodeExtE2E.yml`
+  - `.github/workflows/servicesE2E.yml`
+  - `.github/workflows/soqlE2E.yml`
+  - `.github/workflows/visualforceE2E.yml`
+- Commit message: `fix: kill port 3001 after failed e2e-web try-runs`
+
+## Skills to apply
+
+- `implement`: make the scoped workflow edits.
+- `concise`: keep step names and YAML changes terse.
+
+## Verification
+
+- Parse all 9 edited workflow files as valid YAML.
+- Confirm every `e2e-web` job has exactly one port-3001 kill step directly after `try-run` with the failure condition.
+- Review the diff to confirm no non-`e2e-web` jobs or unrelated files changed.

--- a/.github/workflows/apexLogE2E.yml
+++ b/.github/workflows/apexLogE2E.yml
@@ -74,6 +74,10 @@ jobs:
         run: |
           npm run test:web -w salesforcedx-vscode-apex-log
 
+      - name: Kill process on port 3001
+        if: steps.try-run.outcome == 'failure'
+        run: lsof -ti :3001 | xargs --no-run-if-empty kill -9
+
       # Only run expensive setup when try-run failed (cache miss). On cache hit we never reach these steps.
       - name: Install Salesforce CLI
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/apexTestingE2E.yml
+++ b/.github/workflows/apexTestingE2E.yml
@@ -81,6 +81,10 @@ jobs:
         run: |
           npm run test:web -w salesforcedx-vscode-apex-testing
 
+      - name: Kill process on port 3001
+        if: steps.try-run.outcome == 'failure'
+        run: lsof -ti :3001 | xargs --no-run-if-empty kill -9
+
       # Only run expensive setup when try-run failed (cache miss). On cache hit we never reach these steps.
       - name: Install Salesforce CLI
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/lwcPlaywrightE2E.yml
+++ b/.github/workflows/lwcPlaywrightE2E.yml
@@ -69,6 +69,10 @@ jobs:
         run: |
           npm run test:web -w salesforcedx-vscode-lwc
 
+      - name: Kill process on port 3001
+        if: steps.try-run.outcome == 'failure'
+        run: lsof -ti :3001 | xargs --no-run-if-empty kill -9
+
       - uses: ./.github/actions/cache-vscode-web
         if: steps.try-run.outcome == 'failure'
         with:

--- a/.github/workflows/metadataE2E.yml
+++ b/.github/workflows/metadataE2E.yml
@@ -78,6 +78,10 @@ jobs:
         run: |
           npm run test:web -w salesforcedx-vscode-metadata
 
+      - name: Kill process on port 3001
+        if: steps.try-run.outcome == 'failure'
+        run: lsof -ti :3001 | xargs --no-run-if-empty kill -9
+
       # Only run expensive setup when try-run failed (cache miss). On cache hit we never reach these steps.
       - name: Install Salesforce CLI
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/orgBrowserE2E.yml
+++ b/.github/workflows/orgBrowserE2E.yml
@@ -74,6 +74,10 @@ jobs:
         run: |
           npm run test:web -w salesforcedx-vscode-org-browser
 
+      - name: Kill process on port 3001
+        if: steps.try-run.outcome == 'failure'
+        run: lsof -ti :3001 | xargs --no-run-if-empty kill -9
+
       # Only run expensive setup when try-run failed (cache miss). On cache hit we never reach these steps.
       - uses: ./.github/actions/cache-vscode-web
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/playwrightVscodeExtE2E.yml
+++ b/.github/workflows/playwrightVscodeExtE2E.yml
@@ -67,6 +67,10 @@ jobs:
         run: |
           npm run test:web -w @salesforce/playwright-vscode-ext
 
+      - name: Kill process on port 3001
+        if: steps.try-run.outcome == 'failure'
+        run: lsof -ti :3001 | xargs --no-run-if-empty kill -9
+
       - uses: ./.github/actions/cache-vscode-web
         if: steps.try-run.outcome == 'failure'
         with:

--- a/.github/workflows/servicesE2E.yml
+++ b/.github/workflows/servicesE2E.yml
@@ -73,6 +73,10 @@ jobs:
         run: |
           npm run test:web -w salesforcedx-vscode-services
 
+      - name: Kill process on port 3001
+        if: steps.try-run.outcome == 'failure'
+        run: lsof -ti :3001 | xargs --no-run-if-empty kill -9
+
       # Only run expensive setup when try-run failed (cache miss). On cache hit we never reach these steps.
       - name: Install Salesforce CLI
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/soqlE2E.yml
+++ b/.github/workflows/soqlE2E.yml
@@ -74,6 +74,10 @@ jobs:
         run: |
           npm run test:web -w salesforcedx-vscode-soql
 
+      - name: Kill process on port 3001
+        if: steps.try-run.outcome == 'failure'
+        run: lsof -ti :3001 | xargs --no-run-if-empty kill -9
+
       # Only run expensive setup when try-run failed (cache miss). On cache hit we never reach these steps.
       - name: Install Salesforce CLI
         if: steps.try-run.outcome == 'failure'

--- a/.github/workflows/visualforceE2E.yml
+++ b/.github/workflows/visualforceE2E.yml
@@ -71,6 +71,10 @@ jobs:
         run: |
           npm run test:web -w salesforcedx-vscode-visualforce
 
+      - name: Kill process on port 3001
+        if: steps.try-run.outcome == 'failure'
+        run: lsof -ti :3001 | xargs --no-run-if-empty kill -9
+
       - uses: ./.github/actions/cache-vscode-web
         if: steps.try-run.outcome == 'failure'
         with:


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-24142840@

### What changed and why?
Added a failure-gated port-3001 cleanup step immediately after `try-run` in every `e2e-web` job across these workflows:

- `.github/workflows/apexLogE2E.yml`
- `.github/workflows/apexTestingE2E.yml`
- `.github/workflows/lwcPlaywrightE2E.yml`
- `.github/workflows/metadataE2E.yml`
- `.github/workflows/orgBrowserE2E.yml`
- `.github/workflows/playwrightVscodeExtE2E.yml`
- `.github/workflows/servicesE2E.yml`
- `.github/workflows/soqlE2E.yml`
- `.github/workflows/visualforceE2E.yml`

When `try-run` fails, the step terminates the process listening on port 3001. This prevents a timed-out web server from blocking subsequent Playwright runs and retries. No non-`e2e-web` jobs or unrelated files are changed.
