### PR TITLE
chore: Bump actions/cache from v4 to v6 in cache-vscode-web/cache-vscode-desktop actions - W-23596027

### DIFF
--- a/.claude/plans/W-23596027.md
+++ b/.claude/plans/W-23596027.md
@@ -1,0 +1,28 @@
+# Context
+
+Upgrade `actions/cache` from v4 to v6 in the repository's VS Code cache composite actions. This keeps both restore and save steps on the requested major version without changing cache paths, keys, conditions, or fallback-cache behavior.
+
+Files:
+
+- `.github/actions/cache-vscode-web/action.yml`
+- `.github/actions/cache-vscode-desktop/action.yml`
+
+# Phases
+
+## 1. Upgrade VS Code cache actions
+
+- Change `actions/cache/restore@v4` to `actions/cache/restore@v6` in both files.
+- Change `actions/cache/save@v4` to `actions/cache/save@v6` in both files.
+- Preserve all existing inputs, cache configuration, shell logic, and conditions.
+- Commit message: `chore: bump actions/cache from v4 to v6`
+
+# Skills to apply
+
+- `concise`: keep the dependency-only change and documentation minimal.
+- `verification`: validate changed GitHub Actions metadata with the repository check.
+
+# Verification
+
+- Run `npm run check:actions` from the repository root.
+- Confirm both action files contain only `actions/cache/restore@v6` and `actions/cache/save@v6` references.
+- Review the diff to confirm no cache behavior changed beyond the action major version.

--- a/.github/actions/cache-vscode-desktop/action.yml
+++ b/.github/actions/cache-vscode-desktop/action.yml
@@ -7,7 +7,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@v6
       id: restore
       with:
         path: .vscode-test/vscode-*
@@ -24,7 +24,7 @@ runs:
             echo "Fallback: using on-disk version $onDisk instead of pinned ${{ inputs.vscode-version }}"
           fi
         fi
-    - uses: actions/cache/save@v4
+    - uses: actions/cache/save@v6
       if: always() && steps.restore.outputs.cache-hit != 'true'
       with:
         path: .vscode-test/vscode-*

--- a/.github/actions/cache-vscode-web/action.yml
+++ b/.github/actions/cache-vscode-web/action.yml
@@ -7,7 +7,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/cache/restore@v4
+    - uses: actions/cache/restore@v6
       id: restore
       with:
         path: .vscode-test-web
@@ -17,7 +17,7 @@ runs:
       run: |
         dir=$(ls .vscode-test-web 2>/dev/null | grep -E '^vscode-web-stable-' | head -1)
         [ -n "$dir" ] && echo "PLAYWRIGHT_WEB_VSCODE_COMMIT=${dir#vscode-web-stable-}" >> "$GITHUB_ENV"
-    - uses: actions/cache/save@v4
+    - uses: actions/cache/save@v6
       if: always() && steps.restore.outputs.cache-hit != 'true'
       with:
         path: .vscode-test-web


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-23596027@

### What changed and why?

Updated the VS Code web and desktop cache composite actions to use `actions/cache/restore@v6` and `actions/cache/save@v6` instead of v4.

Cache paths, keys, fallback behavior, conditions, and shell logic remain unchanged. `npm run check:actions` passes.
