### PR TITLE
chore: Use Effect.filterOrFail for bundle-kind guard in salesforcedx-vscode-lightning - W-23506242

### DIFF
--- a/.claude/plans/W-23506242.md
+++ b/.claude/plans/W-23506242.md
@@ -1,0 +1,25 @@
+# W-23506242
+
+## Context
+
+- GUS subject: Use `Effect.filterOrFail` for bundle-kind guard in `salesforcedx-vscode-lightning`.
+- `packages/salesforcedx-vscode-lightning/src/commands/renameAura.ts` currently guards the Aura bundle kind with an imperative `if` and `return yield*`.
+- Match the existing Effect pipeline in `packages/salesforcedx-vscode-lwc/src/commands/renameLwc.ts`; preserve the current `NotInBundleError`, source URI, and message.
+
+## Phases
+
+1. Replace the Aura bundle-kind `if` in `packages/salesforcedx-vscode-lightning/src/commands/renameAura.ts` with `yield* Effect.succeed(getBundleKind(bundleUri)).pipe(Effect.filterOrFail(...))`.
+   - Commit: `refactor(lightning): use Effect.filterOrFail for bundle kind`
+
+## Skills to apply
+
+- `effect-best-practices`: follow Effect failure-channel idioms.
+- `typescript`: preserve repository TypeScript style and type narrowing.
+- `verification`: verify the single source change after implementation.
+
+## Verification
+
+1. Run the Effect review required by the verification skill for Effect-related changes.
+2. From the repository root, run `npm run compile -w salesforcedx-vscode-lightning`.
+3. From the repository root, run `npm run lint -w salesforcedx-vscode-lightning`.
+4. From the repository root, run `npm test -w salesforcedx-vscode-lightning`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -41004,7 +41004,7 @@
     },
     "packages/salesforcedx-vscode-services-types": {
       "name": "@salesforce/vscode-services",
-      "version": "67.17.10",
+      "version": "67.17.11",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.43",

--- a/packages/salesforcedx-vscode-lightning/src/commands/renameAura.ts
+++ b/packages/salesforcedx-vscode-lightning/src/commands/renameAura.ts
@@ -52,12 +52,16 @@ export const renameAuraCommand = Effect.fn('renameAuraCommand')(function* (
       ),
     onSome: Effect.succeed
   });
-  if (getBundleKind(bundleUri) !== 'aura') {
-    return yield* new NotInBundleError({
-      sourceUri: resolvedSource.toString(),
-      message: 'Source path is not within an aura bundle'
-    });
-  }
+  yield* Effect.succeed(getBundleKind(bundleUri)).pipe(
+    Effect.filterOrFail(
+      kind => kind === 'aura',
+      () =>
+        new NotInBundleError({
+          sourceUri: resolvedSource.toString(),
+          message: 'Source path is not within an aura bundle'
+        })
+    )
+  );
 
   const oldName = Utils.basename(bundleUri);
 


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-23506242@

### What changed and why?
Replaced the imperative Aura bundle-kind guard in `renameAuraCommand` with `Effect.filterOrFail`, matching the existing LWC rename implementation.

The change preserves the existing `NotInBundleError`, source URI, and error message while using the Effect failure channel consistently.
