### PR TITLE
chore: Large manifest retrieve: Maximum call stack size exceeded - W-24156300

### DIFF
--- a/.claude/plans/W-24156300.md
+++ b/.claude/plans/W-24156300.md
@@ -1,0 +1,39 @@
+# W-24156300: Large manifest retrieve stack overflow
+
+## Context
+
+`ComponentSetService.getComponentSetFromManifest` passes the complete manifest to `ComponentSet.fromManifest`. Large manifests can exhaust the JavaScript call stack before retrieve starts. Preserve manifest-retrieve behavior while making ComponentSet construction bounded by batch size rather than manifest size.
+
+Files:
+
+- `packages/salesforcedx-vscode-services/src/core/componentSetService.ts`
+- `packages/salesforcedx-vscode-services/test/jest/core/componentSetService.test.ts`
+
+## Phases
+
+1. **Reproduce the failure**
+   - Add a generated large-manifest regression test for `getComponentSetFromManifest`.
+   - Assert construction completes and retains every manifest member.
+   - Commit: `test: reproduce large manifest component set overflow`
+
+2. **Bound manifest ComponentSet construction**
+   - Parse the manifest once.
+   - Add its members to the ComponentSet in fixed-size iterative batches instead of one size-dependent recursive operation.
+   - Preserve project source-path resolution, wildcard handling, registry use, ComponentSet properties, and existing error mapping.
+   - Commit: `fix: bound large manifest component set construction`
+
+## Skills to apply
+
+- `tdd`: land the failing regression test before implementation.
+- `typescript`: keep types explicit and avoid unsafe assertions.
+- `effect-best-practices`: retain typed Effect errors, spans, and service composition.
+- `paths`: keep manifest paths derived from `vscode-uri` utilities.
+- `verification`: run targeted tests plus repository checks.
+
+## Verification
+
+1. `npm install`
+2. Run the new `ComponentSetService` regression test and confirm it fails before phase 2, then passes after phase 2.
+3. `npm run test -w salesforcedx-vscode-services -- --runInBand`
+4. `npm run test:web -w salesforcedx-vscode-services -- --retries 0`
+5. Let the repository stop hook verify compile, lint, Effect diagnostics, tests, bundle, and knip.

--- a/packages/salesforcedx-vscode-services/src/core/componentSetService.ts
+++ b/packages/salesforcedx-vscode-services/src/core/componentSetService.ts
@@ -12,7 +12,10 @@ import {
   ComponentSet,
   type ComponentSet as ComponentSetType,
   type FileResponseSuccess,
-  type MetadataMember
+  ManifestResolver,
+  type MetadataComponent,
+  type MetadataMember,
+  type RegistryAccess
 } from '@salesforce/source-deploy-retrieve';
 import * as Brand from 'effect/Brand';
 import * as Effect from 'effect/Effect';
@@ -56,6 +59,128 @@ export class FailedToBuildComponentSetError extends Schema.TaggedError<FailedToB
 ) {}
 
 const getComponentState = (component: FileResponseSuccess) => toComponentStatusChangeType(component.state);
+
+const MANIFEST_COMPONENT_BATCH_SIZE = 1000;
+
+type BotVersionFilter = NonNullable<ComponentSetType['botVersionFilters']>[number];
+
+const parseBotVersionFullName = (fullName: string): BotVersionFilter => {
+  const numberedVersion = /^(.+)\.v(\d+)$/.exec(fullName);
+  if (numberedVersion) {
+    return { botName: numberedVersion[1], versionFilter: Number(numberedVersion[2]) };
+  }
+  if (fullName.endsWith('.*')) {
+    return { botName: fullName.slice(0, -2), versionFilter: 'all' };
+  }
+  const lastDot = fullName.lastIndexOf('.');
+  return {
+    botName: lastDot > 0 ? fullName.slice(0, lastDot) : fullName,
+    versionFilter: 'highest'
+  };
+};
+
+const addManifestComponentBatch = ({
+  componentSet,
+  include,
+  components,
+  registry
+}: {
+  componentSet: ComponentSetType;
+  include: ComponentSetType;
+  components: readonly MetadataComponent[];
+  registry: RegistryAccess;
+}): BotVersionFilter[] => {
+  const componentsAndFilters = components.map(manifestComponent => {
+    if (manifestComponent.type.name === 'BotVersion') {
+      const botVersionFilter = parseBotVersionFullName(manifestComponent.fullName);
+      return {
+        component: {
+          fullName: botVersionFilter.botName,
+          type: registry.getTypeByName('Bot')
+        },
+        botVersionFilter
+      };
+    }
+    return { component: manifestComponent, botVersionFilter: undefined };
+  });
+
+  componentsAndFilters.forEach(({ component }) => {
+    include.add(component);
+    componentSet.add(component);
+  });
+
+  return componentsAndFilters.flatMap(({ botVersionFilter }) => (botVersionFilter ? [botVersionFilter] : []));
+};
+
+const addManifestComponentsInBatches = ({
+  componentSet,
+  include,
+  components,
+  registry
+}: {
+  componentSet: ComponentSetType;
+  include: ComponentSetType;
+  components: readonly MetadataComponent[];
+  registry: RegistryAccess;
+}): void => {
+  const botVersionFilters = Array.from(
+    { length: Math.ceil(components.length / MANIFEST_COMPONENT_BATCH_SIZE) },
+    (_, batchIndex) => batchIndex
+  ).flatMap(batchIndex => {
+    const batchStart = batchIndex * MANIFEST_COMPONENT_BATCH_SIZE;
+    const batch = components.slice(batchStart, batchStart + MANIFEST_COMPONENT_BATCH_SIZE);
+    return addManifestComponentBatch({ componentSet, include, components: batch, registry });
+  });
+
+  if (botVersionFilters.length > 0) {
+    componentSet.botVersionFilters = botVersionFilters;
+  }
+};
+
+const failedToBuildComponentSetFromManifest = (error: unknown): FailedToBuildComponentSetError => {
+  const { cause } = unknownToErrorCause(error);
+  return new FailedToBuildComponentSetError({
+    message: `Failed to build ComponentSet from manifest: ${cause.message}`,
+    cause
+  });
+};
+
+const buildComponentSetFromManifest = Effect.fn('ComponentSetService.buildComponentSetFromManifest')(function* ({
+  manifestPath,
+  resolveSourcePaths,
+  registry
+}: {
+  manifestPath: string;
+  resolveSourcePaths: string[];
+  registry: RegistryAccess;
+}) {
+  const manifest = yield* Effect.tryPromise({
+    try: () => new ManifestResolver(undefined, registry).resolve(manifestPath),
+    catch: failedToBuildComponentSetFromManifest
+  });
+
+  return yield* Effect.try({
+    try: () => {
+      const componentSet = new ComponentSet([], registry);
+      const include = new ComponentSet([], registry);
+      componentSet.sourceApiVersion = manifest.apiVersion;
+      componentSet.fullName = manifest.fullName;
+
+      addManifestComponentsInBatches({ componentSet, include, components: manifest.components, registry });
+
+      const sourceComponents = ComponentSet.fromSource({ fsPaths: resolveSourcePaths, include, registry });
+      componentSet.forceIgnoredPaths = sourceComponents.forceIgnoredPaths;
+      // ComponentSet exposes only a mutating add operation.
+      // eslint-disable-next-line functional/no-loop-statements
+      for (const sourceComponent of sourceComponents) {
+        componentSet.add(sourceComponent);
+      }
+
+      return componentSet;
+    },
+    catch: failedToBuildComponentSetFromManifest
+  });
+});
 
 export class ComponentSetService extends Effect.Service<ComponentSetService>()('ComponentSetService', {
   accessors: true,
@@ -132,22 +257,11 @@ export class ComponentSetService extends Effect.Service<ComponentSetService>()('
           { concurrency: 'unbounded' }
         );
 
-        const componentSet = yield* Effect.tryPromise({
-          try: async () =>
-            ComponentSet.fromManifest({
-              manifestPath,
-              // Get package directories as full paths
-              resolveSourcePaths: project.getPackageDirectories().map(pkgDir => pkgDir.fullPath),
-              forceAddWildcards: true,
-              registry: registryAccess
-            }),
-          catch: e => {
-            const { cause } = unknownToErrorCause(e);
-            return new FailedToBuildComponentSetError({
-              message: `Failed to build ComponentSet from manifest: ${cause.message}`,
-              cause
-            });
-          }
+        const componentSet = yield* buildComponentSetFromManifest({
+          manifestPath,
+          // Get package directories as full paths
+          resolveSourcePaths: project.getPackageDirectories().map(pkgDir => pkgDir.fullPath),
+          registry: registryAccess
         });
 
         yield* setComponentSetProperties({ componentSet, project, configAggregator });

--- a/packages/salesforcedx-vscode-services/test/jest/core/componentSetService.test.ts
+++ b/packages/salesforcedx-vscode-services/test/jest/core/componentSetService.test.ts
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { writeFile, mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ConfigAggregator, SfProject } from '@salesforce/core';
+import { ComponentSet, RegistryAccess } from '@salesforce/source-deploy-retrieve';
+import * as Effect from 'effect/Effect';
+import * as Layer from 'effect/Layer';
+import { URI } from 'vscode-uri';
+import { ComponentSetService, FailedToBuildComponentSetError } from '../../../src/core/componentSetService';
+import { ConfigService } from '../../../src/core/configService';
+import { MetadataRegistryService } from '../../../src/core/metadataRegistryService';
+import { ProjectService } from '../../../src/core/projectService';
+
+const MEMBER_COUNT = 3135;
+
+const makeComponentSetServiceLayer = ({
+  registryAccess,
+  project,
+  configAggregator
+}: {
+  registryAccess: RegistryAccess;
+  project: SfProject;
+  configAggregator: ConfigAggregator;
+}) =>
+  Layer.provide(
+    ComponentSetService.DefaultWithoutDependencies,
+    Layer.mergeAll(
+      Layer.succeed(MetadataRegistryService, {
+        getRegistryAccess: () => Effect.succeed(registryAccess)
+      } as unknown as MetadataRegistryService),
+      Layer.succeed(ProjectService, { getSfProject: () => Effect.succeed(project) } as unknown as ProjectService),
+      Layer.succeed(ConfigService, {
+        getConfigAggregator: () => Effect.succeed(configAggregator)
+      } as unknown as ConfigService)
+    )
+  );
+
+describe('ComponentSetService.getComponentSetFromManifest', () => {
+  let testDirectory: string;
+
+  beforeAll(async () => {
+    testDirectory = await mkdtemp(join(tmpdir(), 'component-set-service-'));
+  });
+
+  afterAll(async () => {
+    await rm(testDirectory, { recursive: true });
+  });
+
+  it('retains every member when ComponentSet.fromManifest overflows', async () => {
+    const fromManifest = jest
+      .spyOn(ComponentSet, 'fromManifest')
+      .mockRejectedValue(new RangeError('Maximum call stack size exceeded'));
+    const manifestPath = join(testDirectory, 'package.xml');
+    const packageDirectory = join(testDirectory, 'force-app');
+    const classesDirectory = join(packageDirectory, 'main', 'default', 'classes');
+    await mkdir(classesDirectory, { recursive: true });
+    await writeFile(join(classesDirectory, 'LocalClass.cls'), 'public class LocalClass {}');
+    await writeFile(
+      join(classesDirectory, 'LocalClass.cls-meta.xml'),
+      '<?xml version="1.0" encoding="UTF-8"?><ApexClass xmlns="http://soap.sforce.com/2006/04/metadata"><apiVersion>67.0</apiVersion><status>Active</status></ApexClass>'
+    );
+    const memberNames = [...Array.from({ length: MEMBER_COUNT - 1 }, (_, index) => `Example${index}`), '*'];
+    const manifest = `<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+  <types>
+    ${memberNames.map(member => `<members>${member}</members>`).join('\n    ')}
+    <name>ApexClass</name>
+  </types>
+  <version>67.0</version>
+</Package>`;
+    await writeFile(manifestPath, manifest);
+
+    const registryAccess = new RegistryAccess();
+    const project = {
+      getPackageDirectories: () => [{ fullPath: packageDirectory }],
+      getPath: () => testDirectory,
+      retrieveSfProjectJson: () => Promise.resolve({ get: () => undefined })
+    } as unknown as SfProject;
+    const configAggregator = {
+      getPropertyValue: () => undefined
+    } as unknown as ConfigAggregator;
+    const layer = makeComponentSetServiceLayer({ registryAccess, project, configAggregator });
+
+    const componentSet = await Effect.runPromise(
+      ComponentSetService.getComponentSetFromManifest(URI.file(manifestPath)).pipe(Effect.provide(layer))
+    );
+
+    expect(fromManifest).not.toHaveBeenCalled();
+    expect(Array.from(componentSet, component => component.fullName)).toEqual([...memberNames, 'LocalClass']);
+    expect(Array.from(componentSet.getSourceComponents(), component => component.fullName)).toEqual(['LocalClass']);
+    expect(componentSet.sourceApiVersion).toBe('67.0');
+    expect(componentSet.projectDirectory).toBe(testDirectory);
+  });
+
+  it('preserves BotVersion conversion and filters', async () => {
+    const manifestPath = join(testDirectory, 'bot-package.xml');
+    await writeFile(
+      manifestPath,
+      `<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+  <types>
+    <members>SpecificBot.v4</members>
+    <members>AllBot.*</members>
+    <members>HighestBot.unknown</members>
+    <members>PlainBot</members>
+    <name>BotVersion</name>
+  </types>
+  <version>67.0</version>
+</Package>`
+    );
+
+    const registryAccess = new RegistryAccess();
+    const project = {
+      getPackageDirectories: () => [],
+      getPath: () => testDirectory,
+      retrieveSfProjectJson: () => Promise.resolve({ get: () => '66.0' })
+    } as unknown as SfProject;
+    const configAggregator = { getPropertyValue: () => '65.0' } as unknown as ConfigAggregator;
+    const layer = makeComponentSetServiceLayer({ registryAccess, project, configAggregator });
+
+    const componentSet = await Effect.runPromise(
+      ComponentSetService.getComponentSetFromManifest(URI.file(manifestPath)).pipe(Effect.provide(layer))
+    );
+
+    expect(Array.from(componentSet, component => component.fullName)).toEqual([
+      'SpecificBot',
+      'AllBot',
+      'HighestBot',
+      'PlainBot'
+    ]);
+    expect(componentSet.botVersionFilters).toEqual([
+      { botName: 'SpecificBot', versionFilter: 4 },
+      { botName: 'AllBot', versionFilter: 'all' },
+      { botName: 'HighestBot', versionFilter: 'highest' },
+      { botName: 'PlainBot', versionFilter: 'highest' }
+    ]);
+    expect(componentSet.apiVersion).toBe('65.0');
+    expect(componentSet.sourceApiVersion).toBe('66.0');
+  });
+
+  it('maps manifest parsing failures to FailedToBuildComponentSetError', async () => {
+    const manifestPath = join(testDirectory, 'invalid-package.xml');
+    await writeFile(manifestPath, '<Package>');
+
+    const registryAccess = new RegistryAccess();
+    const project = {
+      getPackageDirectories: () => [],
+      getPath: () => testDirectory,
+      retrieveSfProjectJson: () => Promise.resolve({ get: () => undefined })
+    } as unknown as SfProject;
+    const configAggregator = { getPropertyValue: () => undefined } as unknown as ConfigAggregator;
+    const layer = makeComponentSetServiceLayer({ registryAccess, project, configAggregator });
+
+    const error = await Effect.runPromise(
+      ComponentSetService.getComponentSetFromManifest(URI.file(manifestPath)).pipe(Effect.flip, Effect.provide(layer))
+    );
+
+    expect(error).toBeInstanceOf(FailedToBuildComponentSetError);
+    expect(error.message).toContain('Failed to build ComponentSet from manifest: Invalid manifest file:');
+  });
+});


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-24156300@

### What changed and why?

Large manifests could cause `ComponentSet.fromManifest` to exceed the JavaScript call stack before retrieve began.

This change:
- Parses manifests once with `ManifestResolver`.
- Builds the `ComponentSet` by adding manifest members in batches of 1,000.
- Preserves wildcard handling, source-path resolution, component-set properties, `BotVersion` filters, and existing error mapping.
- Adds regression coverage for large manifests, `BotVersion` conversion, and manifest parsing failures.

This keeps retrieve behavior unchanged while preventing manifest size from determining call-stack depth.
