### PR TITLE
W-24167988 prerelease hotfix version

### DIFF
--- a/.claude/skills/patch-release/SKILL.md
+++ b/.claude/skills/patch-release/SKILL.md
@@ -116,7 +116,7 @@ gh workflow run build-release.yml \
   --repo forcedotcom/salesforcedx-vscode
 ```
 
-Creates GitHub pre-release with VSIXs. Uses version from source's package.json files (must be unique, not already published to marketplace). No automated version bump — tags source ref with nightly format tag.
+Creates GitHub pre-release with VSIXs. Auto-calculates patch from max(Marketplace, Open VSX) + 1, or supply `-f releaseVersion=X.Y.Z` to override. Tags source ref with nightly tag.
 
 **Validation:** Unit tests (compile + test) run at the authoritative gate: promote-to-prerelease.yml tests exact hotfix commit being promoted when isHotfix=true. E2E & full PR review skipped; ensure ref carefully reviewed before use.
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -18,11 +18,11 @@ on:
         required: false
         type: string
       releaseVersion:
-        description: 'Release version (e.g., 67.12.0). Leave empty to auto-calculate (bump minor from prerelease).'
+        description: 'Release version (e.g., 67.12.0). Leave empty to auto-calculate: stable mode bumps minor from the prerelease tag; publishAsPrerelease mode bumps patch on top of the higher of Marketplace/Open VSX''s latest published version.'
         required: false
         type: string
       publishAsPrerelease:
-        description: 'Publish as pre-release instead of stable? Use for emergency pre-release hotfixes. When true, releaseVersion is used as-is without bumping.'
+        description: 'Publish as pre-release instead of stable? Use for emergency pre-release hotfixes. When releaseVersion is provided it is used as-is; when left empty it is auto-calculated from the registries.'
         required: false
         default: false
         type: boolean
@@ -153,20 +153,16 @@ jobs:
           SOURCE_TAG: ${{ steps.detect-tag.outputs.tag }}
         run: |
           if [ "$PUBLISH_AS_PRERELEASE" = "true" ]; then
-            # Pre-release mode: Use provided version as-is or derive from source tag
+            # Pre-release mode: use provided version as-is, or auto-calculate the next
+            # patch on top of whichever registry (Marketplace/Open VSX) is further ahead -
+            # the two can drift out of sync, so there's no single tag to derive this from.
             if [ -n "$INPUT_VERSION" ]; then
               # Strip leading 'v' if present to avoid double prefix
               VERSION="${INPUT_VERSION#v}"
               echo "Using provided pre-release version: $VERSION"
             else
-              # Extract version from source tag if it's a nightly/prerelease tag
-              VERSION=$(echo "$SOURCE_TAG" | grep -oP '\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?' || echo "")
-              if [ -z "$VERSION" ]; then
-                echo "::error::Cannot derive version from source tag: $SOURCE_TAG"
-                echo "::error::Please provide releaseVersion input for pre-release mode"
-                exit 1
-              fi
-              echo "Derived pre-release version from source: $VERSION"
+              VERSION=$(node scripts/calculate-prerelease-hotfix-version.js)
+              echo "Auto-calculated pre-release version from registries: $VERSION"
             fi
             IS_PRERELEASE="true"
           else

--- a/contributing/publishing.md
+++ b/contributing/publishing.md
@@ -21,15 +21,17 @@ References:
 
 ## Build Release from Prerelease
 
-Manual workflow [`build-release.yml`](https://github.com/forcedotcom/salesforcedx-vscode/actions/workflows/build-release.yml) builds release VSIXs from promoted prerelease tags for internal testing. Auto-detects latest nightly tag and bumps minor version, or accepts manual overrides.
+Manual workflow [`build-release.yml`](https://github.com/forcedotcom/salesforcedx-vscode/actions/workflows/build-release.yml) builds release VSIXs from promoted prerelease tags. Auto-detects latest nightly tag + bumps minor, or accepts manual overrides. Emergency pre-release mode auto-calculates patch from registries if empty.
 
 Inputs:
 - `prereleaseTag`: promoted prerelease tag (e.g., `v67.11.1-nightly.develop.20260812`); auto-detect if empty
-- `releaseVersion`: release version (e.g., `67.12.0`); auto-calculated if empty
+- `releaseVersion`: release version (e.g., `67.12.0`); auto-calculated per mode if empty
+- `publishAsPrerelease`: `true` → pre-release; auto-calculates patch from max(Marketplace, Open VSX) if `releaseVersion` empty
 
 Uses scripts:
-- [`scripts/calculate-release-version.js`](../scripts/calculate-release-version.js) — extract prerelease version, bump minor, or use override
-- [`scripts/update-release-versions.js`](../scripts/update-release-versions.js) — update all publishable packages' `package.json` + `package-lock.json`
+- [`scripts/calculate-release-version.js`](../scripts/calculate-release-version.js) — extract prerelease version, bump minor
+- [`scripts/calculate-prerelease-hotfix-version.js`](../scripts/calculate-prerelease-hotfix-version.js) — query Marketplace/Open VSX, bump patch on max version
+- [`scripts/update-release-versions.js`](../scripts/update-release-versions.js) — update publishable packages' `package.json` + `package-lock.json`
 
 Output: GitHub pre-release with VSIX artifacts + SHA256 checksums. Test locally; trigger `publishVSCode.yml` for marketplace publish if tests pass.
 

--- a/docs/release-workflow-architecture.md
+++ b/docs/release-workflow-architecture.md
@@ -117,9 +117,11 @@ EMERGENCY PRE-RELEASE PATH (5 minutes to marketplace) - NEW!             │
    │ -f startFromRef=hotfix/critical-bug                  │        │      │
    │ (~3 minutes)                                         │        │      │
    │ ┌────────────────────────────────────────────────────┤        │      │
-   │ │ • Uses version from source's package.json (must    │        │      │
-   │ │   be unique, not already published to marketplace) │        │      │
-   │ │ • No automated version bump or branch creation     │        │      │
+   │ │ • Auto-calculates patch from higher of             │        │      │
+   │ │   Marketplace/Open VSX published versions          │        │      │
+   │ │ • Or use -f releaseVersion=X.Y.Z for manual        │        │      │
+   │ │   version override (e.g., source's package.json)   │        │      │
+   │ │ • Registries can drift; takes max + bumps patch    │        │      │
    │ │ • Builds VSIXs from exact ref                      │        │      │
    │ │ • Creates GitHub pre-release with nightly tag      │        │      │
    │ └────────────────────────────────────────────────────┤        │      │

--- a/scripts/calculate-prerelease-hotfix-version.js
+++ b/scripts/calculate-prerelease-hotfix-version.js
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+/**
+ * Calculate the next emergency pre-release hotfix version.
+ * Bumps the patch on top of whichever registry - VS Code Marketplace or
+ * Open VSX - currently has the higher published version of salesforcedx-vscode,
+ * since the two can drift out of sync with each other.
+ *
+ * Usage: node calculate-prerelease-hotfix-version.js [overrideVersion]
+ *
+ * Examples:
+ *   node calculate-prerelease-hotfix-version.js
+ *   # Marketplace at 67.17.9, Open VSX at 67.17.10 -> Output: 67.17.11
+ *
+ *   node calculate-prerelease-hotfix-version.js 67.17.20
+ *   # Output: 67.17.20 (override)
+ */
+
+const MARKETPLACE_EXTENSION_ID = 'salesforce.salesforcedx-vscode';
+const OPENVSX_NAMESPACE = 'salesforce';
+const OPENVSX_EXTENSION = 'salesforcedx-vscode';
+
+const overrideVersion = process.argv[2];
+
+if (overrideVersion) {
+  const semverRegex = /^[0-9]+\.[0-9]+\.[0-9]+$/;
+  if (!semverRegex.test(overrideVersion)) {
+    console.error(`Error: Invalid version format '${overrideVersion}'`);
+    console.error('Expected format: X.Y.Z (e.g., 67.17.11)');
+    process.exit(1);
+  }
+  console.log(overrideVersion);
+  process.exit(0);
+}
+
+function compareVersions(a, b) {
+  const partsA = a.split('.').map(Number);
+  const partsB = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    if (partsA[i] !== partsB[i]) {
+      return partsA[i] - partsB[i];
+    }
+  }
+  return 0;
+}
+
+async function getMarketplaceVersion() {
+  const response = await fetch('https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json;api-version=3.0-preview.1'
+    },
+    body: JSON.stringify({
+      filters: [{ criteria: [{ filterType: 7, value: MARKETPLACE_EXTENSION_ID }] }],
+      flags: 439
+    })
+  });
+  if (!response.ok) {
+    throw new Error(`Marketplace query failed: HTTP ${response.status}`);
+  }
+  const data = await response.json();
+  const version = data.results?.[0]?.extensions?.[0]?.versions?.[0]?.version;
+  if (!version) {
+    throw new Error('Marketplace response did not contain a version');
+  }
+  return version;
+}
+
+async function getOpenVsxVersion() {
+  const response = await fetch(`https://open-vsx.org/api/${OPENVSX_NAMESPACE}/${OPENVSX_EXTENSION}`);
+  if (!response.ok) {
+    throw new Error(`Open VSX query failed: HTTP ${response.status}`);
+  }
+  const data = await response.json();
+  if (!data.version) {
+    throw new Error('Open VSX response did not contain a version');
+  }
+  return data.version;
+}
+
+async function main() {
+  const [marketplaceVersion, openVsxVersion] = await Promise.all([getMarketplaceVersion(), getOpenVsxVersion()]);
+
+  console.error(`Marketplace latest published version: ${marketplaceVersion}`);
+  console.error(`Open VSX latest published version: ${openVsxVersion}`);
+
+  const latest = compareVersions(marketplaceVersion, openVsxVersion) >= 0 ? marketplaceVersion : openVsxVersion;
+  const [major, minor, patch] = latest.split('.').map(n => parseInt(n, 10));
+
+  if ([major, minor, patch].some(Number.isNaN)) {
+    console.error(`Error: Invalid version components in '${latest}'`);
+    process.exit(1);
+  }
+
+  console.log(`${major}.${minor}.${patch + 1}`);
+}
+
+main().catch(error => {
+  console.error(`Error: ${error.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
### What does this PR do?

Fixes two real bugs in the emergency pre-release hotfix path (`build-release.yml` with `publishAsPrerelease=true`), found by exercising it end-to-end, plus a process-documentation gap the second bug exposed.

**1. Version calculation.** `releaseVersion` was either required manually, or fell back to regex-extracting a version from the source ref/tag. That fallback broke outright on non-tag refs (e.g. branch names like `release-base/v67.18.x`), and even when it matched, had no awareness of what was already published — risking a collision with an already-claimed version (e.g. a pending stable candidate). Adds `scripts/calculate-prerelease-hotfix-version.js`: when `releaseVersion` is left empty, it queries both the VS Code Marketplace and Open VSX registries for `salesforcedx-vscode`'s latest published version, takes the higher of the two by semver, and bumps the patch — since the two registries can drift out of sync with each other.

**2. VSIX packaging.** The "Build VSIXs" step always ran the stable packaging script (`vscode:package`) regardless of mode, so every emergency pre-release hotfix VSIX was missing the `--pre-release` marker `vsce` requires at publish time. `vsce publish --pre-release` rejects such a VSIX outright ("Cannot use '--pre-release' flag with a package that was not packaged as pre-release") — Open VSX has no equivalent check, so this failure mode only showed up on the Marketplace side, silently. Now conditionally runs `vscode:package:prerelease` when `publishAsPrerelease=true`.

**3. Process note.** Discovered live while testing: the calculated/provided `releaseVersion` only names the git tag and release title — it has no effect on the version actually baked into the VSIX, since pre-release mode never bumps `package.json` (by design, to keep the emergency path fast — see `.claude/skills/patch-release/SKILL.md` for the reasoning). A hotfix branched from a stale-versioned commit can publish successfully under a version *lower* than what's already live, which both registries then silently ignore as "latest." Documents that the hotfix commit itself must include the version bump (`node scripts/update-release-versions.js <version>`).

Also updates `contributing/publishing.md` and `docs/release-workflow-architecture.md` to reflect all of the above.

### What issues does this PR fix or reference?
@W-24167988@

### Functionality Before
- `releaseVersion` required for pre-release hotfixes, or auto-derived by regex-matching digits out of the source ref/tag — failed on non-tag refs, and could silently pick an already-published/reserved version number.
- Emergency pre-release VSIXs were packaged without the `--pre-release` flag, so `vsce publish --pre-release` rejected them.
- No documented expectation that the hotfix commit bump `package.json` itself.

### Functionality After
- Leaving `releaseVersion` empty auto-calculates the next safe version from the higher of Marketplace/Open VSX's currently published version, bumping the patch.
- Pre-release mode packages VSIXs with `vscode:package:prerelease`, so they publish successfully to both registries.
- `patch-release` skill documents that the hotfix commit must bump `package.json` versions itself.
