### PR TITLE
chore: Close tracked-base-branch bypasses: switch, branch, -B, clustered -b - W-24101261

### DIFF
--- a/.claude/plans/W-24101261.md
+++ b/.claude/plans/W-24101261.md
@@ -1,0 +1,27 @@
+# W-24101261: Close tracked-base-branch bypasses
+
+## Context
+
+The tracked-base-branch safeguard blocks some branch creation from `origin/develop` and `origin/main` without `--no-track`, but its command classification misses `git switch`, `git branch`, `git checkout -B`, and checkout options that cluster `-b` with other short options. These forms can create a local branch that tracks a shared remote base branch.
+
+Extend the existing parsed-command policy in `scripts/ai-safeguards.mjs`; keep the Claude hook and OpenCode plugin on that single policy implementation.
+
+## Phases
+
+1. **Recognize every named branch-creation form**
+   - Update `scripts/ai-safeguards.mjs` to classify the named `switch`, `branch`, checkout `-B`, and clustered checkout `-b` forms as branch creation when their parsed arguments name `origin/develop` or `origin/main` and omit `--no-track`.
+   - Extend `test/ai-safeguards.test.mjs` with deny cases for each named bypass against both tracked base branches, plus matching `--no-track` allow cases and unrelated-command allow cases.
+   - Commit: `fix: close tracked base branch bypasses - W-24101261`
+
+## Skills to apply
+
+- `concise`: direct policy names, denial text, and test cases.
+- `verification`: targeted safeguard tests followed by repository checks.
+
+## Verification
+
+1. Run `npm install` in this worktree.
+2. Run `npm run test:ai-safeguards`.
+3. Confirm focused coverage denies `switch`, `branch`, checkout `-B`, and clustered checkout `-b` forms for both `origin/develop` and `origin/main` without `--no-track`.
+4. Confirm the corresponding `--no-track` and unrelated-command cases remain allowed.
+5. Run `npm run compile`, `npm run lint`, `npm test`, `npm run vscode:bundle`, and `npm run check:knip`.

--- a/scripts/ai-safeguards.mjs
+++ b/scripts/ai-safeguards.mjs
@@ -238,15 +238,75 @@ const missingDependenciesDenial = ({ command, cwd, run = defaultRun }) => {
   return result.reason;
 };
 
+const argumentsBeforeDoubleDash = arguments_ => {
+  const doubleDash = arguments_.indexOf('--');
+  return doubleDash < 0 ? arguments_ : arguments_.slice(0, doubleDash);
+};
+
+const hasShortOption = (arguments_, options) =>
+  argumentsBeforeDoubleDash(arguments_).some(
+    argument =>
+      argument.startsWith('-') &&
+      !argument.startsWith('--') &&
+      [...argument.slice(1)].some(option => options.includes(option))
+  );
+
+const hasLongOption = (arguments_, option) =>
+  argumentsBeforeDoubleDash(arguments_).some(argument => argument === option || argument.startsWith(`${option}=`));
+
+const effectiveTracking = arguments_ =>
+  argumentsBeforeDoubleDash(arguments_).reduce((tracking, argument) => {
+    if (argument === '--no-track') return false;
+    return argument === '--track' || argument.startsWith('--track=') || hasShortOption([argument], 't')
+      ? true
+      : tracking;
+  }, undefined);
+
+const branchDoesNotCreate = arguments_ =>
+  hasShortOption(arguments_, 'alrvdDmMcCu') ||
+  [
+    '--all',
+    '--remotes',
+    '--delete',
+    '--move',
+    '--copy',
+    '--list',
+    '--show-current',
+    '--edit-description',
+    '--set-upstream-to',
+    '--unset-upstream',
+    '--contains',
+    '--no-contains',
+    '--merged',
+    '--no-merged',
+    '--points-at',
+    '--column',
+    '--sort',
+    '--format'
+  ].some(option => hasLongOption(arguments_, option));
+
 const trackedBaseBranchDenial = ({ command, cwd }) =>
   inspectCommand(command, cwd, tokens => {
     const git = gitCommand(tokens);
-    if (!git || git.arguments.includes('--no-track')) return undefined;
-    const namesRemoteBase = git.arguments.some(argument => argument === 'origin/develop' || argument === 'origin/main');
+    if (!git) return undefined;
+    const arguments_ = git.subcommand === 'checkout' ? argumentsBeforeDoubleDash(git.arguments) : git.arguments;
+    const remoteBaseIndex = arguments_.findIndex(
+      argument => argument === 'origin/develop' || argument === 'origin/main'
+    );
+    const namesBranchBeforeRemoteBase = arguments_
+      .slice(0, remoteBaseIndex)
+      .some(argument => !argument.startsWith('-'));
+    const tracking = effectiveTracking(git.arguments);
     const createsBranch =
       (git.subcommand === 'worktree' && git.arguments[0] === 'add') ||
-      (git.subcommand === 'checkout' && git.arguments.includes('-b'));
-    return namesRemoteBase && createsBranch ? TRACKED_BASE_BRANCH_REASON : undefined;
+      (git.subcommand === 'checkout' && (hasShortOption(git.arguments, 'bB') || tracking === true)) ||
+      (git.subcommand === 'switch' &&
+        (hasShortOption(git.arguments, 'cC') ||
+          hasLongOption(git.arguments, '--create') ||
+          hasLongOption(git.arguments, '--force-create') ||
+          tracking === true)) ||
+      (git.subcommand === 'branch' && !branchDoesNotCreate(git.arguments) && namesBranchBeforeRemoteBase);
+    return remoteBaseIndex >= 0 && tracking !== false && createsBranch ? TRACKED_BASE_BRANCH_REASON : undefined;
   }).reason;
 
 export const commandDenial = (input, policy = 'all') =>

--- a/test/ai-safeguards.test.mjs
+++ b/test/ai-safeguards.test.mjs
@@ -47,32 +47,64 @@ test('denies git --no-verify', () => {
 
 test('denies branches from remote bases without --no-track', () => {
   ['origin/develop', 'origin/main'].forEach(remoteBase => {
-    assert.equal(
-      commandDenial({ command: `git worktree add -b feature ../feature ${remoteBase}`, cwd: '/tmp' }),
-      TRACKED_BASE_BRANCH_REASON
-    );
-    assert.equal(
-      commandDenial({ command: `git checkout -b feature ${remoteBase}`, cwd: '/tmp' }),
-      TRACKED_BASE_BRANCH_REASON
-    );
+    [
+      `git worktree add -b feature ../feature ${remoteBase}`,
+      `git checkout -b feature ${remoteBase}`,
+      `git checkout --track ${remoteBase}`,
+      `git checkout -t ${remoteBase}`,
+      `git checkout --no-track --track ${remoteBase}`,
+      `git switch -c feature ${remoteBase}`,
+      `git switch -C feature ${remoteBase}`,
+      `git switch --create feature ${remoteBase}`,
+      `git switch --force-create feature ${remoteBase}`,
+      `git switch --track ${remoteBase}`,
+      `git switch -t ${remoteBase}`,
+      `git switch --no-track --track ${remoteBase}`,
+      `git switch --create=feature ${remoteBase}`,
+      `git switch --force-create=feature ${remoteBase}`,
+      `git branch feature ${remoteBase}`,
+      `git checkout -B feature ${remoteBase}`,
+      `git checkout -qb feature ${remoteBase}`,
+      `git checkout -qB feature ${remoteBase}`
+    ].forEach(command => assert.equal(commandDenial({ command, cwd: '/tmp' }), TRACKED_BASE_BRANCH_REASON, command));
   });
 });
 
 test('allows non-tracking and unrelated branch commands', () => {
   ['origin/develop', 'origin/main'].forEach(remoteBase => {
-    assert.equal(
-      commandDenial({ command: `git worktree add --no-track -b feature ../feature ${remoteBase}`, cwd: '/tmp' }),
-      undefined
-    );
-    assert.equal(
-      commandDenial({ command: `git checkout --no-track -b feature ${remoteBase}`, cwd: '/tmp' }),
-      undefined
-    );
+    [
+      `git worktree add --no-track -b feature ../feature ${remoteBase}`,
+      `git checkout --no-track -b feature ${remoteBase}`,
+      `git checkout --track --no-track ${remoteBase}`,
+      `git switch --no-track -c feature ${remoteBase}`,
+      `git switch --no-track -C feature ${remoteBase}`,
+      `git switch --no-track --create feature ${remoteBase}`,
+      `git switch --no-track --force-create feature ${remoteBase}`,
+      `git switch --track --no-track ${remoteBase}`,
+      `git switch --no-track --create=feature ${remoteBase}`,
+      `git switch --no-track --force-create=feature ${remoteBase}`,
+      `git branch --no-track feature ${remoteBase}`,
+      `git checkout --no-track -B feature ${remoteBase}`,
+      `git checkout --no-track -qb feature ${remoteBase}`,
+      `git checkout --no-track -qB feature ${remoteBase}`
+    ].forEach(command => assert.equal(commandDenial({ command, cwd: '/tmp' }), undefined, command));
   });
   [
     'git worktree add -b feature ../feature develop',
     'git checkout -b feature origin/release',
     'git checkout origin/develop',
+    'git switch origin/main',
+    'git branch --contains origin/develop',
+    'git branch --contains feature origin/develop',
+    'git branch --contains HEAD --contains origin/develop',
+    'git branch --merged feature origin/main',
+    'git branch --points-at feature origin/develop',
+    'git branch --list feature origin/main',
+    'git branch -l feature origin/develop',
+    'git branch -m feature origin/develop',
+    'git branch -c feature origin/main',
+    'git branch -d feature origin/develop',
+    'git checkout -- -b origin/develop',
     'echo git checkout -b feature origin/main'
   ].forEach(command => assert.equal(commandDenial({ command, cwd: '/tmp' }), undefined));
 });


### PR DESCRIPTION
### What issues does this PR fix or reference?
@W-24101261@

### What changed and why?

- Extended the shared parsed-command safeguard to detect tracked-base-branch creation through:
  - `git switch`
  - `git branch`
  - `git checkout -B`
  - clustered checkout options containing `-b` or `-B`
- Preserved `--no-track` exceptions and avoided false positives for unrelated branch commands.
- Added coverage for `origin/develop` and `origin/main`, including allowed and denied cases.
- Keeps the Claude hook and OpenCode plugin on the same policy implementation.
